### PR TITLE
docs: added comment to explain "startTime" in LCP

### DIFF
--- a/src/getLCP.ts
+++ b/src/getLCP.ts
@@ -27,6 +27,8 @@ export const getLCP = (onReport: ReportHandler, reportAllChanges = false) => {
   const metric = initMetric();
 
   const entryHandler = (entry: PerformanceEntry) => {
+    // The startTime attribute returns the value of the renderTime if it is not 0,
+    // and the value of the loadTime otherwise.
     const value = entry.startTime;
 
     // If the page was hidden prior to paint time of the entry,


### PR DESCRIPTION
I was reading the code related to LCP, and I noticed you used `startTime` instead of the code suggested in https://web.dev/lcp/#measure-lcp-in-javascript.

I did more digging and then I arrived at this part of the spec https://wicg.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface where is explained how `startTime`.

That's dope!!! I just learned something new to adjust to Perfume.js.

If you don't mind I added a couple of line of comments for future devs, that might be wondering why it is used
```ts
const value = entry.startTime;
```
instead of
```ts
const value = entry.renderTime || entry.loadTime;
```