### PR TITLE
Add TTFB

### DIFF
--- a/src/getTTFB.ts
+++ b/src/getTTFB.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {initMetric} from './lib/initMetric.js';
+import {ReportHandler} from './types.js';
+
+
+interface NavigationEntryShim {
+  // From `PerformanceNavigationTimingEntry`.
+  entryType: string;
+  startTime: number;
+
+  // From `performance.timing`.
+  connectEnd?: number;
+  connectStart?: number;
+  domComplete?: number;
+  domContentLoadedEventEnd?: number;
+  domContentLoadedEventStart?: number;
+  domInteractive?: number;
+  domainLookupEnd?: number;
+  domainLookupStart?: number;
+  fetchStart?: number;
+  loadEventEnd?: number;
+  loadEventStart?: number;
+  redirectEnd?: number;
+  redirectStart?: number;
+  requestStart?: number;
+  responseEnd?: number;
+  responseStart?: number;
+  secureConnectionStart?: number;
+  unloadEventEnd?: number;
+  unloadEventStart?: number;
+};
+
+type PerformanceTimingKeys =
+    'connectEnd' |
+    'connectStart' |
+    'domComplete' |
+    'domContentLoadedEventEnd' |
+    'domContentLoadedEventStart' |
+    'domInteractive' |
+    'domainLookupEnd' |
+    'domainLookupStart' |
+    'fetchStart' |
+    'loadEventEnd' |
+    'loadEventStart' |
+    'redirectEnd' |
+    'redirectStart' |
+    'requestStart' |
+    'responseEnd' |
+    'responseStart' |
+    'secureConnectionStart' |
+    'unloadEventEnd' |
+    'unloadEventStart';
+
+const afterLoad = (callback: () => void) => {
+  if (document.readyState === 'complete') {
+    callback();
+  } else {
+    // Use `pageshow` so the callback runs after `loadEventEnd`.
+    addEventListener('pageshow', callback);
+  }
+}
+
+const getNavigationEntryFromPerformanceTiming = () => {
+  // Really annoying that TypeScript errors when using `PerformanceTiming`.
+  const timing = performance.timing;
+
+  const navigationEntry: NavigationEntryShim = {
+    entryType: 'navigation',
+    startTime: 0,
+  };
+
+  for (const key in timing) {
+    if (key !== 'navigationStart' && key !== 'toJSON') {
+      navigationEntry[key as PerformanceTimingKeys] = Math.max(
+          timing[key as PerformanceTimingKeys] - timing.navigationStart, 0);
+    }
+  }
+  return navigationEntry as PerformanceNavigationTiming;
+};
+
+export const getTTFB = (onReport: ReportHandler) => {
+  const metric = initMetric();
+
+  afterLoad(() => {
+    try {
+      // Use the NavigationTiming L2 entry if available.
+      const navigationEntry = performance.getEntriesByType('navigation')[0] ||
+          getNavigationEntryFromPerformanceTiming();
+
+      metric.value = metric.delta =
+          (navigationEntry as PerformanceNavigationTiming).responseStart;
+
+      metric.entries = [navigationEntry];
+      metric.isFinal = true;
+
+      onReport(metric);
+    } catch (error) {
+      // Do nothing.
+    }
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,4 @@ export {getCLS} from './getCLS.js';
 export {getFCP} from './getFCP.js';
 export {getFID} from './getFID.js';
 export {getLCP} from './getLCP.js';
+export {getTTFB} from './getTTFB.js';

--- a/test/e2e/getTTFB-test.js
+++ b/test/e2e/getTTFB-test.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('assert');
+const {beaconCountIs, clearBeacons, getBeacons} = require('../utils/beacons.js');
+
+
+/**
+ * Accepts a PerformanceNavigationTimingEntry (or shim) and asserts that it
+ * has all the expected properties.
+ * @param {Object} entry
+ */
+function assertValidEntry(entry) {
+  const timingProps = [
+    'connectEnd',
+    'connectStart',
+    'domComplete',
+    'domContentLoadedEventEnd',
+    'domContentLoadedEventStart',
+    'domInteractive',
+    'domainLookupEnd',
+    'domainLookupStart',
+    'fetchStart',
+    'loadEventEnd',
+    'loadEventStart',
+    'redirectEnd',
+    'redirectStart',
+    'requestStart',
+    'responseEnd',
+    'responseStart',
+    'secureConnectionStart',
+    'startTime',
+    'unloadEventEnd',
+    'unloadEventStart',
+  ];
+
+  assert.strictEqual(entry.entryType, 'navigation');
+  for (const timingProp of timingProps) {
+    if (!(entry[timingProp] >= 0)) {
+      console.log(timingProp, entry[timingProp]);
+    }
+
+    assert(entry[timingProp] >= 0);
+  }
+}
+
+describe('getTTFB()', async function() {
+  beforeEach(async function() {
+    await clearBeacons();
+  });
+
+  it('reports the correct value when run during page load', async function() {
+    await browser.url('/test/ttfb');
+
+    await beaconCountIs(1);
+
+    const [{ttfb}] = await getBeacons();
+
+    assert(ttfb.value >= 0);
+    assert(ttfb.value >= ttfb.entries[0].requestStart);
+    assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
+    assert.strictEqual(ttfb.value, ttfb.delta);
+    assert.strictEqual(ttfb.entries.length, 1);
+    assert.strictEqual(ttfb.isFinal, true);
+
+    assertValidEntry(ttfb.entries[0]);
+  });
+
+  it('reports the correct value when run after page load', async function() {
+    await browser.url('/test/ttfb-after-load');
+
+    await beaconCountIs(1);
+
+    const [{ttfb}] = await getBeacons();
+
+    assert(ttfb.value >= 0);
+    assert(ttfb.value >= ttfb.entries[0].requestStart);
+    assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
+    assert.strictEqual(ttfb.value, ttfb.delta);
+    assert.strictEqual(ttfb.entries.length, 1);
+    assert.strictEqual(ttfb.isFinal, true);
+
+    assertValidEntry(ttfb.entries[0]);
+  });
+});

--- a/test/views/ttfb-after-load.njk
+++ b/test/views/ttfb-after-load.njk
@@ -1,0 +1,41 @@
+<!--
+ Copyright 2020 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+{% extends 'layout.njk' %}
+
+{% block content %}
+  <h1>TTFB Test</h1>
+  <p>
+    <img src="/test/img/square.png">
+  </p>
+
+  <p>Text below the image</p>
+
+  <script type="module">
+    import {getTTFB} from '/dist/web-vitals.js';
+
+    // Invoke `getTTFB()` after the load event fires.
+    addEventListener('load', () => {
+      setTimeout(() => {
+        getTTFB((ttfb) => {
+          // Log for easier manual testing.
+          console.log(ttfb);
+
+          // Test sending the metric to an analytics endpoint.
+          navigator.sendBeacon(`/collect`, JSON.stringify({ttfb}));
+        }, self.__reportAllChanges);
+      }, 200);
+    });
+  </script>
+{% endblock %}

--- a/test/views/ttfb.njk
+++ b/test/views/ttfb.njk
@@ -1,0 +1,36 @@
+<!--
+ Copyright 2020 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+{% extends 'layout.njk' %}
+
+{% block content %}
+  <h1>TTFB Test</h1>
+  <p>
+    <img src="/test/img/square.png">
+  </p>
+
+  <p>Text below the image</p>
+
+  <script type="module">
+    import {getTTFB} from '/dist/web-vitals.js';
+
+    getTTFB((ttfb) => {
+      // Log for easier manual testing.
+      console.log(ttfb);
+
+      // Test sending the metric to an analytics endpoint.
+      navigator.sendBeacon(`/collect`, JSON.stringify({ttfb}));
+    }, self.__reportAllChanges);
+  </script>
+{% endblock %}


### PR DESCRIPTION
This PR add a `getTTFB()` function to track the [Time to First Byte (TTFB)](https://web.dev/time-to-first-byte/) metric.

The TTFB value is calculated using the `responseStart` property of the [Navigation Timing API](https://w3c.github.io/navigation-timing/). Browsers that don't support the Navigation Timing API will seamlessly fall back to using the `performance.timing` interface instead (with each of the values exposed there converted from epoch time to `DOMHighResTimeStamp`).

This means `getTTFB()` will work in Chrome, Firefox, Safari, and Internet Explorer.

cc: @addyosmani 