### PR TITLE
refactor: added requestStart to the TTFB formula

### DIFF
--- a/src/getTTFB.ts
+++ b/src/getTTFB.ts
@@ -102,8 +102,10 @@ export const getTTFB = (onReport: ReportHandler) => {
       const navigationEntry = performance.getEntriesByType('navigation')[0] ||
           getNavigationEntryFromPerformanceTiming();
 
+      // TTFB as the time from when the browser issues the network request,
+      // untill when the first byte of the response arrives.
       metric.value = metric.delta =
-          (navigationEntry as PerformanceNavigationTiming).responseStart;
+          (navigationEntry as PerformanceNavigationTiming).responseStart - (navigationEntry as PerformanceNavigationTiming).requestStart;
 
       metric.entries = [navigationEntry];
       metric.isFinal = true;


### PR DESCRIPTION
Super excited to see Time to First Byte joining the WebVitals family 🌲🚀🌕

I was wondering why TTFB is based only as `navigationEntry.responseStart` instead of being the combination of `navigationEntry.responseStart - navigationEntry.requestStart`. Doing this subtraction will imply not including browser set up, redirects, or tcp and ssl negotiation in the final result.

I originally learn about this way of calculating TTFB by the [Assessing Loading Performance in Real Life with Navigation and Resource Timing](https://developers.google.com/web/fundamentals/performance/navigation-and-resource-timing) article.

I made a tiny PR with this change in case you and the team believe `navigationEntry.responseStart - navigationEntry.requestStart` could work better to guide developer with this tool.

Thank you @philipwalton  🙌