### PR TITLE
Polyfill the PerformanceEventTiming entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,6 @@ interface Metric {
   // Any performance entries used in the metric value calculation.
   // Note, entries will be added to the array as the value changes.
   entries: PerformanceEntry[];
-
-  // Only present if the reported value came from the FID polyfill.
-  event?: Event;
 }
 ```
 
@@ -316,20 +313,9 @@ The `getFID()` function will work in all browsers if the page has included the [
 
 Browsers that support the native [Event Timing API](https://wicg.github.io/event-timing/) will use that and report the metric value from the `first-input` performance entry.
 
-Browsers that **do not** support the native Event Timing API will report the value reported by the polyfill, including the `Event` object of the first input.
+Browsers that **do not** support the native Event Timing API will use the value reported by the polyfill, and the `entries` array will contain a plain-object version of the native [`PerformanceEventTiming`](https://wicg.github.io/event-timing/#sec-performance-event-timing) object.
 
-For example:
-
-```js
-import {getFID} from 'web-vitals';
-
-getFID((metric) => {
-  // When using the polyfill, the `event` property will be present.
-  // The  `entries` property will also be present, but it will be empty.
-  console.log(metric.event); // Event
-  console.log(metric.entries);  // []
-});
-```
+_**Note:** the `duration` and `processingEnd` properties of the `PerformanceEventTiming` will not be present, as they're not exposed by the polyfill._
 
 ## Development
 

--- a/src/getFID.ts
+++ b/src/getFID.ts
@@ -38,7 +38,9 @@ declare global {
 
 // https://wicg.github.io/event-timing/#sec-performance-event-timing
 interface PerformanceEventTiming extends PerformanceEntry {
-  processingStart: number;
+  processingStart: DOMHighResTimeStamp;
+  cancelable?: boolean;
+  target?: Element;
 }
 
 export const getFID = (onReport: ReportHandler) => {
@@ -70,8 +72,15 @@ export const getFID = (onReport: ReportHandler) => {
         // Only report if the page wasn't hidden prior to the first input.
         if (event.timeStamp < getFirstHiddenTime()) {
           metric.value = value;
-          metric.event = event;
           metric.isFinal = true;
+          metric.entries = [{
+            entryType: 'first-input',
+            name: event.type,
+            target: event.target,
+            cancelable: event.cancelable,
+            startTime: event.timeStamp,
+            processingStart: event.timeStamp + value,
+          } as PerformanceEventTiming];
           report();
         }
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,9 +35,6 @@ export interface Metric {
   // Any performance entries used in the metric value calculation.
   // Note, entries will be added to the array as the value changes.
   entries: PerformanceEntry[];
-
-  // Only present if the reported value came from the FID polyfill.
-  event?: Event;
 }
 
 export interface ReportHandler {

--- a/test/e2e/getFID-test.js
+++ b/test/e2e/getFID-test.js
@@ -68,10 +68,11 @@ describe('getFID()', async function() {
     assert(fid.id.match(/\d+-\d+/));
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.isFinal, true);
+    assert.strictEqual(fid.entries[0].name, 'mousedown');
     if (browserSupportsFID) {
-      assert.strictEqual(fid.entries[0].name, 'mousedown');
+      assert('duration' in fid.entries[0]);
     } else {
-      assert.strictEqual(fid.event.type, 'mousedown');
+      assert(!('duration' in fid.entries[0]));
     }
   });
 

--- a/test/views/fid.njk
+++ b/test/views/fid.njk
@@ -36,11 +36,6 @@
       // Log for easier manual testing.
       console.log(fid);
 
-      // Event objects can't be serialized, so we objectify them first.
-      if (fid.event) {
-        fid.event = {type: fid.event.type};
-      }
-
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(fid));
     }, self.__reportAllChanges);


### PR DESCRIPTION
The PR updates how the `getFID()` function exposes the FID polyfill. Rather than passing the `event` on the metric object (and reporting with an empty `entries` array), it now will create a plain-object version of the native `PerformanceEventTiming`, omitting properties that it are not available (e.g. `duration` and `processingEnd`).

This change increases the size of the library a bit (~50 bytes), but now consumers of the `getFID()` function should be able to have the same reporting code work in both the polyfill and non-polyfill cases (which should mean less application code is needed).