### PR TITLE
Add a name property to the Metric interface

### DIFF
--- a/src/getCLS.ts
+++ b/src/getCLS.ts
@@ -28,7 +28,7 @@ interface LayoutShift extends PerformanceEntry {
 }
 
 export const getCLS = (onReport: ReportHandler, reportAllChanges = false) => {
-  const metric = initMetric(0);
+  const metric = initMetric('CLS', 0);
 
   const entryHandler = (entry: LayoutShift) => {
     // Only count layout shifts without recent user input.

--- a/src/getFCP.ts
+++ b/src/getFCP.ts
@@ -22,7 +22,7 @@ import {ReportHandler} from './types.js';
 
 
 export const getFCP = (onReport: ReportHandler) => {
-  const metric = initMetric();
+  const metric = initMetric('FCP');
 
   const po = observe('paint', (entry: PerformanceEntry) => {
     if (entry.name === 'first-contentful-paint') {

--- a/src/getFID.ts
+++ b/src/getFID.ts
@@ -44,7 +44,7 @@ interface PerformanceEventTiming extends PerformanceEntry {
 }
 
 export const getFID = (onReport: ReportHandler) => {
-  const metric = initMetric();
+  const metric = initMetric('FID');
 
   const entryHandler = (entry: PerformanceEventTiming) => {
     // Only report if the page wasn't hidden prior to the first input.

--- a/src/getLCP.ts
+++ b/src/getLCP.ts
@@ -24,7 +24,7 @@ import {ReportHandler} from './types.js';
 
 
 export const getLCP = (onReport: ReportHandler, reportAllChanges = false) => {
-  const metric = initMetric();
+  const metric = initMetric('LCP');
 
   const entryHandler = (entry: PerformanceEntry) => {
     // The startTime attribute returns the value of the renderTime if it is not 0,

--- a/src/getTTFB.ts
+++ b/src/getTTFB.ts
@@ -95,7 +95,7 @@ const getNavigationEntryFromPerformanceTiming = () => {
 };
 
 export const getTTFB = (onReport: ReportHandler) => {
-  const metric = initMetric();
+  const metric = initMetric('TTFB');
 
   afterLoad(() => {
     try {

--- a/src/lib/initMetric.ts
+++ b/src/lib/initMetric.ts
@@ -18,8 +18,9 @@ import {Metric} from '../types.js';
 import {generateUniqueID} from './generateUniqueID.js';
 
 
-export const initMetric = (value = -1): Metric => {
+export const initMetric = (name: Metric['name'], value = -1): Metric => {
   return {
+    name,
     value,
     delta: 0,
     entries: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,9 @@
  */
 
 export interface Metric {
+  // The name of the metric (in acronym form).
+  name: 'CLS' | 'FCP' | 'FID' | 'LCP' | 'TTFB';
+
   // The current value of the metric.
   value: number;
 

--- a/test/e2e/getCLS-test.js
+++ b/test/e2e/getCLS-test.js
@@ -45,6 +45,7 @@ describe('getCLS()', async function() {
     const [cls] = await getBeacons();
     assert(cls.value >= 0);
     assert(cls.id.match(/\d+-\d+/));
+    assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, cls.delta);
     assert.strictEqual(cls.entries.length, 2);
     assert.strictEqual(cls.isFinal, false);
@@ -66,6 +67,7 @@ describe('getCLS()', async function() {
     const [cls] = await getBeacons();
     assert(cls.value >= 0);
     assert(cls.id.match(/\d+-\d+/));
+    assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, cls.delta);
     assert.strictEqual(cls.entries.length, 2);
     assert.strictEqual(cls.isFinal, true);
@@ -83,11 +85,13 @@ describe('getCLS()', async function() {
 
     assert(cls1.value >= 0);
     assert(cls1.id.match(/\d+-\d+/));
+    assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.isFinal, false);
     assert.strictEqual(cls1.entries.length, 1);
 
     assert(cls2.value >= cls1.value);
+    assert.strictEqual(cls2.name, 'CLS');
     assert.strictEqual(cls2.id, cls1.id);
     assert.strictEqual(cls2.value, cls1.value + cls2.delta);
     assert.strictEqual(cls2.isFinal, false);
@@ -120,6 +124,7 @@ describe('getCLS()', async function() {
     assert.strictEqual(cls1.entries.length, 1);
 
     assert(cls2.value >= cls1.value);
+    assert.strictEqual(cls2.name, 'CLS');
     assert.strictEqual(cls2.id, cls1.id);
     assert.strictEqual(cls2.value, cls1.value + cls2.delta);
     assert.strictEqual(cls2.isFinal, false);
@@ -132,6 +137,7 @@ describe('getCLS()', async function() {
 
     const [cls3] = await getBeacons();
     assert(cls3.value >= 0);
+    assert.strictEqual(cls3.name, 'CLS');
     assert.strictEqual(cls3.id, cls2.id);
     assert.strictEqual(cls3.delta, 0);
     assert.strictEqual(cls3.isFinal, true);
@@ -154,6 +160,7 @@ describe('getCLS()', async function() {
     assert(cls1.value >= 0);
     assert(cls1.delta >= 0);
     assert(cls1.id.match(/\d+-\d+/));
+    assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.isFinal, false);
     assert.strictEqual(cls1.entries.length, 2);
@@ -173,6 +180,7 @@ describe('getCLS()', async function() {
 
     const [cls2] = await getBeacons();
     assert(cls2.value >= cls1.value);
+    assert.strictEqual(cls2.name, 'CLS');
     assert.strictEqual(cls2.id, cls1.id);
     assert.strictEqual(cls2.value, cls1.value + cls2.delta);
     assert.strictEqual(cls2.isFinal, false);
@@ -185,6 +193,7 @@ describe('getCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls3] = await getBeacons();
+    assert.strictEqual(cls3.name, 'CLS');
     assert.strictEqual(cls3.value, cls2.value);
     assert.strictEqual(cls3.id, cls2.id);
     assert(cls3.delta === 0);
@@ -202,11 +211,13 @@ describe('getCLS()', async function() {
 
     assert(cls1.value > 0);
     assert(cls1.id.match(/\d+-\d+/));
+    assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.isFinal, false);
     assert.strictEqual(cls1.entries.length, 1);
 
     assert(cls2.value > cls1.value);
+    assert.strictEqual(cls2.name, 'CLS');
     assert.strictEqual(cls2.id, cls1.id);
     assert.strictEqual(cls2.value, cls1.value + cls2.delta);
     assert.strictEqual(cls2.isFinal, false);
@@ -225,6 +236,7 @@ describe('getCLS()', async function() {
     const [cls3] = await getBeacons();
 
     assert(cls3.value > cls2.value);
+    assert.strictEqual(cls3.name, 'CLS');
     assert.strictEqual(cls3.id, cls2.id);
     assert.strictEqual(cls3.value, cls2.value + cls3.delta);
     assert.strictEqual(cls3.isFinal, false);
@@ -237,6 +249,7 @@ describe('getCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls4] = await getBeacons();
+    assert.strictEqual(cls4.name, 'CLS');
     assert.strictEqual(cls4.value, cls3.value);
     assert.strictEqual(cls4.id, cls3.id);
     assert(cls4.delta === 0);
@@ -255,6 +268,7 @@ describe('getCLS()', async function() {
 
     const [cls] = await getBeacons();
     assert(cls.id.match(/\d+-\d+/));
+    assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
     assert.strictEqual(cls.isFinal, false);
@@ -272,6 +286,7 @@ describe('getCLS()', async function() {
 
     const [cls] = await getBeacons();
     assert(cls.id.match(/\d+-\d+/));
+    assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
     assert.strictEqual(cls.isFinal, false);
@@ -289,6 +304,7 @@ describe('getCLS()', async function() {
 
     const [cls] = await getBeacons();
     assert(cls.id.match(/\d+-\d+/));
+    assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
     assert.strictEqual(cls.isFinal, true);
@@ -306,6 +322,7 @@ describe('getCLS()', async function() {
 
     const [cls] = await getBeacons();
     assert(cls.id.match(/\d+-\d+/));
+    assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
     assert.strictEqual(cls.isFinal, true);

--- a/test/e2e/getFCP-test.js
+++ b/test/e2e/getFCP-test.js
@@ -40,6 +40,7 @@ describe('getFCP()', async function() {
     const [fcp] = await getBeacons();
     assert(fcp.value >= 0);
     assert(fcp.id.match(/\d+-\d+/));
+    assert.strictEqual(fcp.name, 'FCP');
     assert.strictEqual(fcp.value, fcp.delta);
     assert.strictEqual(fcp.entries.length, 1);
     assert.strictEqual(fcp.isFinal, true);

--- a/test/e2e/getFID-test.js
+++ b/test/e2e/getFID-test.js
@@ -44,6 +44,7 @@ describe('getFID()', async function() {
     const [fid] = await getBeacons();
     assert(fid.value >= 0);
     assert(fid.id.match(/\d+-\d+/));
+    assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.entries[0].name, 'mousedown');
     assert.strictEqual(fid.isFinal, true);
@@ -66,6 +67,7 @@ describe('getFID()', async function() {
 
     assert(fid.value >= 0);
     assert(fid.id.match(/\d+-\d+/));
+    assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.isFinal, true);
     assert.strictEqual(fid.entries[0].name, 'mousedown');

--- a/test/e2e/getLCP-test.js
+++ b/test/e2e/getLCP-test.js
@@ -193,6 +193,7 @@ describe('getLCP()', async function() {
     const [lcp1] = await getBeacons();
 
     assert(lcp1.value > 0);
+    assert.strictEqual(lcp1.name, 'LCP');
     assert.strictEqual(lcp1.value, lcp1.delta);
     assert.strictEqual(lcp1.entries.length, 1);
     assert.strictEqual(lcp1.entries[0].element, 'h1');
@@ -220,12 +221,14 @@ describe('getLCP()', async function() {
     const [lcp1, lcp2] = await getBeacons();
 
     assert(lcp1.value > 0);
+    assert.strictEqual(lcp1.name, 'LCP');
     assert.strictEqual(lcp1.value, lcp1.delta);
     assert.strictEqual(lcp1.entries.length, 1);
     assert.strictEqual(lcp1.entries[0].element, 'h1');
     assert.strictEqual(lcp1.isFinal, false);
 
     assert.strictEqual(lcp2.value, lcp1.value);
+    assert.strictEqual(lcp2.name, 'LCP');
     assert.strictEqual(lcp2.delta, 0);
     assert.strictEqual(lcp2.entries.length, 1);
     assert.strictEqual(lcp2.entries[0].element, 'h1');
@@ -238,6 +241,7 @@ const assertStandardReportsAreCorrect = (beacons) => {
 
   assert(lcp.value > 500); // Greater than the image load delay.
   assert(lcp.id.match(/\d+-\d+/));
+  assert.strictEqual(lcp.name, 'LCP');
   assert.strictEqual(lcp.value, lcp.delta);
   assert.strictEqual(lcp.entries.length, 2);
   assert.strictEqual(lcp.isFinal, true);
@@ -248,17 +252,20 @@ const assertFullReportsAreCorrect = (beacons) => {
 
   assert(lcp1.value < 500); // Less than the image load delay.
   assert(lcp1.id.match(/\d+-\d+/));
+  assert.strictEqual(lcp1.name, 'LCP');
   assert.strictEqual(lcp1.value, lcp1.delta);
   assert.strictEqual(lcp1.entries.length, 1);
   assert.strictEqual(lcp1.isFinal, false);
 
   assert(lcp2.value > 500); // Greater than the image load delay.
   assert.strictEqual(lcp2.value, lcp1.value + lcp2.delta);
+  assert.strictEqual(lcp2.name, 'LCP');
   assert.strictEqual(lcp2.id, lcp1.id);
   assert.strictEqual(lcp2.entries.length, 2);
   assert.strictEqual(lcp2.isFinal, false);
 
   assert.strictEqual(lcp3.value, lcp2.value);
+  assert.strictEqual(lcp3.name, 'LCP');
   assert.strictEqual(lcp3.id, lcp2.id);
   assert.strictEqual(lcp3.delta, 0);
   assert.strictEqual(lcp3.entries.length, 2);

--- a/test/e2e/getTTFB-test.js
+++ b/test/e2e/getTTFB-test.js
@@ -73,6 +73,7 @@ describe('getTTFB()', async function() {
     assert(ttfb.value >= ttfb.entries[0].requestStart);
     assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
     assert(ttfb.id.match(/\d+-\d+/));
+    assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.entries.length, 1);
     assert.strictEqual(ttfb.isFinal, true);
@@ -91,6 +92,7 @@ describe('getTTFB()', async function() {
     assert(ttfb.value >= ttfb.entries[0].requestStart);
     assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
     assert(ttfb.id.match(/\d+-\d+/));
+    assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.entries.length, 1);
     assert.strictEqual(ttfb.isFinal, true);

--- a/test/views/lcp.njk
+++ b/test/views/lcp.njk
@@ -38,15 +38,12 @@
 
       // Elements can't be serialized, so we convert first.
       lcp = {
-        value: lcp.value,
-        delta: lcp.delta,
-        id: lcp.id,
+        ...lcp,
         entries: lcp.entries.map((e) => ({
           element: e.element.nodeName.toLowerCase(),
           size: e.size,
           startTime: e.startTime,
         })),
-        isFinal: lcp.isFinal,
       };
 
       // Test sending the metric to an analytics endpoint.


### PR DESCRIPTION
This PR adds a `name` property to the `Metric` interface, which will make it easier to re-use the same reporting function with each of these methods, and disambiguate the metric on the back end (or in an analytics tool).