### PR TITLE
Replace addEventListener with window.addEventListener

### DIFF
--- a/src/getTTFB.ts
+++ b/src/getTTFB.ts
@@ -72,7 +72,7 @@ const afterLoad = (callback: () => void) => {
     setTimeout(callback, 0);
   } else {
     // Use `pageshow` so the callback runs after `loadEventEnd`.
-    addEventListener('pageshow', callback);
+    window.addEventListener('pageshow', callback);
   }
 }
 

--- a/src/lib/onHidden.ts
+++ b/src/lib/onHidden.ts
@@ -28,12 +28,12 @@ const onPageHide = (event: PageTransitionEvent) => {
 };
 
 const addListeners = () => {
-  addEventListener('pagehide', onPageHide);
+  window.addEventListener('pagehide', onPageHide);
 
   // Unload is needed to fix this bug:
   // https://bugs.chromium.org/p/chromium/issues/detail?id=987409
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  addEventListener('unload', () => {});
+  window.addEventListener('unload', () => {});
 }
 
 export const onHidden = (cb: OnHiddenCallback, once = false) => {
@@ -42,7 +42,7 @@ export const onHidden = (cb: OnHiddenCallback, once = false) => {
     listenersAdded = true;
   }
 
-  addEventListener('visibilitychange', ({timeStamp}) => {
+  window.addEventListener('visibilitychange', ({timeStamp}) => {
     if (document.visibilityState === 'hidden') {
       cb({timeStamp, isUnloading});
     }

--- a/src/lib/whenInput.ts
+++ b/src/lib/whenInput.ts
@@ -20,7 +20,7 @@ export const whenInput = () => {
   if (!inputPromise) {
     inputPromise = new Promise((r) => {
       return ['scroll', 'keydown', 'pointerdown'].map((type) => {
-        addEventListener(type, r, {
+        window.addEventListener(type, r, {
           once: true,
           passive: true,
           capture: true,

--- a/test/utils/imagesPainted.js
+++ b/test/utils/imagesPainted.js
@@ -26,7 +26,7 @@ function imagesPainted() {
       if (document.readyState === 'complete') {
         resolve();
       } else {
-        addEventListener('load', resolve);
+        window.addEventListener('load', resolve);
       }
     });
 


### PR DESCRIPTION
Avoid a compilation error with the Closure compiler.