### PR TITLE
Updating Module to CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "web-vitals",
   "version": "0.2.1",
   "description": "Easily measure performance metrics in JavaScript",
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/web-vitals.es5.umd.min.js",
   "module": "dist/web-vitals.es5.min.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Was trying to run `npm run test` which invokes the test server however it was failing due to:

```shell
07:06:42 ~/P/web-vitals master origin/master ✓
~ npm run test

> web-vitals@0.2.1 test /Users/stephenyu/Personal/web-vitals
> npm-run-all build -p -r test:*


> web-vitals@0.2.1 build /Users/stephenyu/Personal/web-vitals
> run-s clean build:ts build:js


> web-vitals@0.2.1 clean /Users/stephenyu/Personal/web-vitals
> rm -rf dist tsconfig.tsbuildinfo


> web-vitals@0.2.1 build:ts /Users/stephenyu/Personal/web-vitals
> tsc -b


> web-vitals@0.2.1 build:js /Users/stephenyu/Personal/web-vitals
> rollup -c

loaded rollup.config.js with warnings
(!) Unused external imports
default imported from external module 'fs-extra' but never used

dist/index.js → ./dist/web-vitals.es5.min.js...
created ./dist/web-vitals.es5.min.js in 808ms

dist/index.js → ./dist/web-vitals.es5.umd.min.js...
created ./dist/web-vitals.es5.umd.min.js in 480ms

> web-vitals@0.2.1 test:e2e /Users/stephenyu/Personal/web-vitals
> wdio wdio.conf.js


> web-vitals@0.2.1 test:server /Users/stephenyu/Personal/web-vitals
> node test/server.js

internal/modules/cjs/loader.js:1174
      throw new ERR_REQUIRE_ESM(filename, parentPath, packageJsonPath);
      ^

Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /Users/stephenyu/Personal/web-vitals/test/server.js
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1174:13)
    at Module.load (internal/modules/cjs/loader.js:1002:32)
    at Function.Module._load (internal/modules/cjs/loader.js:901:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
    at internal/main/run_main_module.js:18:47 {
  code: 'ERR_REQUIRE_ESM'
}
```

This is due to the `require` statements within `server.js`.

This PR simply changes the `package.json` type declaration to `commonjs` which seems to have done the trick