### PR TITLE
Ensure reports only occur if a PO was created

### DIFF
--- a/src/getFCP.ts
+++ b/src/getFCP.ts
@@ -25,7 +25,9 @@ export const getFCP = (onReport: ReportHandler) => {
   const metric = initMetric('FCP');
   const firstHidden = getFirstHidden();
 
-  const po = observe('paint', (entry: PerformanceEntry) => {
+  let report: ReturnType<typeof bindReporter>;
+
+  const entryHandler = (entry: PerformanceEntry) => {
     if (entry.name === 'first-contentful-paint') {
       // Only report if the page wasn't hidden prior to the first paint.
       if (entry.startTime < firstHidden.timeStamp) {
@@ -35,7 +37,10 @@ export const getFCP = (onReport: ReportHandler) => {
         report();
       }
     }
-  });
+  };
 
-  const report = bindReporter(onReport, metric, po);
+  const po = observe('paint', entryHandler);
+  if (po) {
+    report = bindReporter(onReport, metric, po);
+  }
 };

--- a/src/getFID.ts
+++ b/src/getFID.ts
@@ -60,14 +60,12 @@ export const getFID = (onReport: ReportHandler) => {
   const po = observe('first-input', entryHandler as PerformanceEntryHandler);
   const report = bindReporter(onReport, metric, po);
 
-  onHidden(() => {
-    if (po) {
+  if (po) {
+    onHidden(() => {
       po.takeRecords().map(entryHandler as PerformanceEntryHandler);
       po.disconnect();
-    }
-  }, true);
-
-  if (!po) {
+    }, true);
+  } else {
     if (window.perfMetrics && window.perfMetrics.onFirstInputDelay) {
       window.perfMetrics.onFirstInputDelay((value: number, event: Event) => {
         // Only report if the page wasn't hidden prior to the first input.

--- a/test/e2e/getCLS-test.js
+++ b/test/e2e/getCLS-test.js
@@ -73,6 +73,27 @@ describe('getCLS()', async function() {
     assert.strictEqual(cls.isFinal, true);
   });
 
+  it('does not report if the browser does not support CLS', async function() {
+    if (browserSupportsCLS) this.skip();
+
+    await browser.url('/test/cls');
+
+    // Wait until all images are loaded and rendered, then change to hidden.
+    await imagesPainted();
+    await stubVisibilityChange('hidden');
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    await browser.url('about:blank');
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    const beacons = await getBeacons();
+    assert.strictEqual(beacons.length, 0);
+  });
+
   it('reports no new values on visibility hidden after shifts (reportAllChanges === true)', async function() {
     if (!browserSupportsCLS) this.skip();
 

--- a/test/e2e/getFCP-test.js
+++ b/test/e2e/getFCP-test.js
@@ -46,6 +46,18 @@ describe('getFCP()', async function() {
     assert.strictEqual(fcp.isFinal, true);
   });
 
+  it('does not report if the browser does not support FCP', async function() {
+    if (browserSupportsFCP) this.skip();
+
+    await browser.url('/test/fcp');
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    const beacons = await getBeacons();
+    assert.strictEqual(beacons.length, 0);
+  });
+
   it('does not report if the document was hidden at page load time', async function() {
     if (!browserSupportsFCP) this.skip();
 

--- a/test/e2e/getFID-test.js
+++ b/test/e2e/getFID-test.js
@@ -50,6 +50,22 @@ describe('getFID()', async function() {
     assert.strictEqual(fid.isFinal, true);
   });
 
+  it('does not report if the browser does not support FID and the polyfill is not used', async function() {
+    if (browserSupportsFID) this.skip();
+
+    await browser.url('/test/fid');
+
+    // Click on the <h1>.
+    const h1 = await $('h1');
+    await h1.click();
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    const beacons = await getBeacons();
+    assert.strictEqual(beacons.length, 0);
+  });
+
   it('falls back to the polyfill in non-supporting browsers', async function() {
     // Ignore Safari until this bug is fixed:
     // https://bugs.webkit.org/show_bug.cgi?id=211101

--- a/test/e2e/getLCP-test.js
+++ b/test/e2e/getLCP-test.js
@@ -129,6 +129,32 @@ describe('getLCP()', async function() {
     assertFullReportsAreCorrect(await getBeacons());
   });
 
+  it('does not report if the browser does not support LCP', async function() {
+    if (browserSupportsLCP) this.skip();
+
+    await browser.url('/test/lcp');
+
+    // Wait until all images are loaded and fully rendered.
+    await imagesPainted();
+
+    // Click on the h1.
+    const h1 = await $('h1');
+    await h1.click();
+
+    // Scroll down
+    const footer = await $('footer');
+    await footer.scrollIntoView();
+
+    // Load a new page to trigger the hidden state.
+    await browser.url('about:blank');
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    const beacons = await getBeacons();
+    assert.strictEqual(beacons.length, 0);
+  });
+
   it('does not report if the document was hidden at page load time', async function() {
     if (!browserSupportsLCP) this.skip();
 


### PR DESCRIPTION
Fixes #57 

This PR updates all metric functions (e.g. `getCLS()`) to ensure that their callback does not run if the browser does not support the metric (i.e. cannnot create a `PerformanceObserver` and observe the required entry type needed for the metric). It also adds tests to check that nothing is reported in browsers that don't support the metric.