### PR TITLE
Remove the unload listener

### DIFF
--- a/src/lib/onHidden.ts
+++ b/src/lib/onHidden.ts
@@ -30,10 +30,10 @@ const onPageHide = (event: PageTransitionEvent) => {
 const addListeners = () => {
   addEventListener('pagehide', onPageHide);
 
-  // Unload is needed to fix this bug:
+  // `beforeunload` is needed to fix this bug:
   // https://bugs.chromium.org/p/chromium/issues/detail?id=987409
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  addEventListener('unload', () => {});
+  addEventListener('beforeunload', () => {});
 }
 
 export const onHidden = (cb: OnHiddenCallback, once = false) => {


### PR DESCRIPTION
This PR fixes #67 by switching from `unload` to `beforeunload`. Both events work to address [this Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=987409), but the `beforeunload` event won't fail the new [`no-unload-listeners`](https://github.com/GoogleChrome/lighthouse/pull/11085) Lighthouse audit.