### PR TITLE
Update sendToAnalytics() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The `sendToAnalytics()` function uses the [`navigator.sendBeacon()`](https://dev
 import {getCLS, getFID, getLCP} from 'web-vitals';
 
 function sendToAnalytics(metric) {
-  const body = JSON.stringify(metric);
+  const body = JSON.stringify({[metric.name]: metric.value});
   // Use `navigator.sendBeacon()` if available, falling back to `fetch()`.
   (navigator.sendBeacon && navigator.sendBeacon('/analytics', body)) ||
       fetch('/analytics', {body, method: 'POST', keepalive: true});


### PR DESCRIPTION
Fixes #77 

This PR simplifies the `sendToAnalytics()` function to just send the metric name and value as a JSON object, rather than stringifying the entire metric object (which includes the various performance entries). The issue is, in some cases performance entries cannot be JSON stringified. 