### PR TITLE
Remove the isFinal flag from the Metric interface

### DIFF
--- a/src/getCLS.ts
+++ b/src/getCLS.ts
@@ -43,14 +43,10 @@ export const getCLS = (onReport: ReportHandler, reportAllChanges = false) => {
 
   const po = observe('layout-shift', entryHandler as PerformanceEntryHandler);
   if (po) {
-    report = bindReporter(onReport, metric, po, reportAllChanges);
+    report = bindReporter(onReport, metric, reportAllChanges);
 
-    onHidden(({isUnloading}) => {
+    onHidden(() => {
       po.takeRecords().map(entryHandler as PerformanceEntryHandler);
-
-      if (isUnloading) {
-        metric.isFinal = true;
-      }
       report();
     });
   }

--- a/src/getFCP.ts
+++ b/src/getFCP.ts
@@ -15,6 +15,7 @@
  */
 
 import {bindReporter} from './lib/bindReporter.js';
+import {finalMetrics} from './lib/finalMetrics.js';
 import {getFirstHidden} from './lib/getFirstHidden.js';
 import {initMetric} from './lib/initMetric.js';
 import {observe} from './lib/observe.js';
@@ -29,11 +30,15 @@ export const getFCP = (onReport: ReportHandler) => {
 
   const entryHandler = (entry: PerformanceEntry) => {
     if (entry.name === 'first-contentful-paint') {
+      if (po) {
+        po.disconnect();
+      }
+
       // Only report if the page wasn't hidden prior to the first paint.
       if (entry.startTime < firstHidden.timeStamp) {
         metric.value = entry.startTime;
-        metric.isFinal = true;
         metric.entries.push(entry);
+        finalMetrics.add(metric);
         report();
       }
     }
@@ -41,6 +46,6 @@ export const getFCP = (onReport: ReportHandler) => {
 
   const po = observe('paint', entryHandler);
   if (po) {
-    report = bindReporter(onReport, metric, po);
+    report = bindReporter(onReport, metric);
   }
 };

--- a/src/getFID.ts
+++ b/src/getFID.ts
@@ -15,6 +15,7 @@
  */
 
 import {bindReporter} from './lib/bindReporter.js';
+import {finalMetrics} from './lib/finalMetrics.js';
 import {getFirstHidden} from './lib/getFirstHidden.js';
 import {initMetric} from './lib/initMetric.js';
 import {observe, PerformanceEntryHandler} from './lib/observe.js';
@@ -52,13 +53,13 @@ export const getFID = (onReport: ReportHandler) => {
     if (entry.startTime < firstHidden.timeStamp) {
       metric.value = entry.processingStart - entry.startTime;
       metric.entries.push(entry);
-      metric.isFinal = true;
+      finalMetrics.add(metric);
       report();
     }
   };
 
   const po = observe('first-input', entryHandler as PerformanceEntryHandler);
-  const report = bindReporter(onReport, metric, po);
+  const report = bindReporter(onReport, metric);
 
   if (po) {
     onHidden(() => {
@@ -71,7 +72,6 @@ export const getFID = (onReport: ReportHandler) => {
         // Only report if the page wasn't hidden prior to the first input.
         if (event.timeStamp < firstHidden.timeStamp) {
           metric.value = value;
-          metric.isFinal = true;
           metric.entries = [{
             entryType: 'first-input',
             name: event.type,
@@ -80,6 +80,7 @@ export const getFID = (onReport: ReportHandler) => {
             startTime: event.timeStamp,
             processingStart: event.timeStamp + value,
           } as PerformanceEventTiming];
+          finalMetrics.add(metric);
           report();
         }
       });

--- a/src/getTTFB.ts
+++ b/src/getTTFB.ts
@@ -107,7 +107,6 @@ export const getTTFB = (onReport: ReportHandler) => {
           (navigationEntry as PerformanceNavigationTiming).responseStart;
 
       metric.entries = [navigationEntry];
-      metric.isFinal = true;
 
       onReport(metric);
     } catch (error) {

--- a/src/lib/bindReporter.ts
+++ b/src/lib/bindReporter.ts
@@ -14,23 +14,20 @@
  * limitations under the License.
  */
 
+import {finalMetrics} from './finalMetrics.js';
 import {Metric, ReportHandler} from '../types.js';
 
 
 export const bindReporter = (
   callback: ReportHandler,
   metric: Metric,
-  po: PerformanceObserver | undefined,
   observeAllUpdates?: boolean,
 ) => {
   let prevValue: number;
   return () => {
-    if (po && metric.isFinal) {
-      po.disconnect();
-    }
     if (metric.value >= 0) {
       if (observeAllUpdates ||
-          metric.isFinal ||
+          finalMetrics.has(metric) ||
           document.visibilityState === 'hidden') {
         metric.delta = metric.value - (prevValue || 0);
 
@@ -38,9 +35,9 @@ export const bindReporter = (
         // final, or if no previous value exists (which can happen in the case
         // of the document becoming hidden when the metric value is 0).
         // See: https://github.com/GoogleChrome/web-vitals/issues/14
-        if (metric.delta || metric.isFinal || prevValue === undefined) {
-          callback(metric);
+        if (metric.delta || prevValue === undefined) {
           prevValue = metric.value;
+          callback(metric);
         }
       }
     }

--- a/src/lib/finalMetrics.ts
+++ b/src/lib/finalMetrics.ts
@@ -15,15 +15,6 @@
  */
 
 import {Metric} from '../types.js';
-import {generateUniqueID} from './generateUniqueID.js';
 
 
-export const initMetric = (name: Metric['name'], value = -1): Metric => {
-  return {
-    name,
-    value,
-    delta: 0,
-    entries: [],
-    id: generateUniqueID()
-  };
-};
+export const finalMetrics: WeakSet<Metric> = new WeakSet();

--- a/src/lib/onHidden.ts
+++ b/src/lib/onHidden.ts
@@ -16,35 +16,27 @@
 
 
 export interface OnHiddenCallback {
-  // TODO(philipwalton): add `isPersisted` if needed for bfcache.
-  ({timeStamp, isUnloading}: {timeStamp: number; isUnloading: boolean}): void;
+  (event: Event): void;
 }
 
-let isUnloading = false;
-let listenersAdded = false;
-
-const onPageHide = (event: PageTransitionEvent) => {
-  isUnloading = !event.persisted;
-};
-
-const addListeners = () => {
-  addEventListener('pagehide', onPageHide);
-
-  // `beforeunload` is needed to fix this bug:
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=987409
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  addEventListener('beforeunload', () => {});
-}
+let beforeUnloadFixAdded = false;
 
 export const onHidden = (cb: OnHiddenCallback, once = false) => {
-  if (!listenersAdded) {
-    addListeners();
-    listenersAdded = true;
+  // Adding a `beforeunload` listener is needed to fix this bug:
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=987409
+  if (!beforeUnloadFixAdded) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    addEventListener('beforeunload', () => {});
+    beforeUnloadFixAdded = true;
   }
 
-  addEventListener('visibilitychange', ({timeStamp}) => {
+  const onVisibilityChange = (event: Event) => {
     if (document.visibilityState === 'hidden') {
-      cb({timeStamp, isUnloading});
+      cb(event);
+      if (once) {
+        removeEventListener('visibilitychange', onVisibilityChange, true);
+      }
     }
-  }, {capture: true, once});
+  }
+  addEventListener('visibilitychange', onVisibilityChange, true);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,10 +31,6 @@ export interface Metric {
   // together and calculate a total.
   id: string;
 
-  // `false` if the value of the metric may change in the future,
-  // for the current page.
-  isFinal: boolean;
-
   // Any performance entries used in the metric value calculation.
   // Note, entries will be added to the array as the value changes.
   entries: PerformanceEntry[];

--- a/test/e2e/getFCP-test.js
+++ b/test/e2e/getFCP-test.js
@@ -43,7 +43,6 @@ describe('getFCP()', async function() {
     assert.strictEqual(fcp.name, 'FCP');
     assert.strictEqual(fcp.value, fcp.delta);
     assert.strictEqual(fcp.entries.length, 1);
-    assert.strictEqual(fcp.isFinal, true);
   });
 
   it('does not report if the browser does not support FCP', async function() {

--- a/test/e2e/getFID-test.js
+++ b/test/e2e/getFID-test.js
@@ -47,7 +47,6 @@ describe('getFID()', async function() {
     assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.entries[0].name, 'mousedown');
-    assert.strictEqual(fid.isFinal, true);
   });
 
   it('does not report if the browser does not support FID and the polyfill is not used', async function() {
@@ -85,7 +84,6 @@ describe('getFID()', async function() {
     assert(fid.id.match(/\d+-\d+/));
     assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
-    assert.strictEqual(fid.isFinal, true);
     assert.strictEqual(fid.entries[0].name, 'mousedown');
     if (browserSupportsFID) {
       assert('duration' in fid.entries[0]);

--- a/test/e2e/getLCP-test.js
+++ b/test/e2e/getLCP-test.js
@@ -61,7 +61,7 @@ describe('getLCP()', async function() {
     // Load a new page to trigger the hidden state.
     await browser.url('about:blank');
 
-    await beaconCountIs(3);
+    await beaconCountIs(2);
     assertFullReportsAreCorrect(await getBeacons());
   });
 
@@ -93,7 +93,7 @@ describe('getLCP()', async function() {
     const h1 = await $('h1');
     await h1.click();
 
-    await beaconCountIs(3);
+    await beaconCountIs(2);
     assertFullReportsAreCorrect(await getBeacons());
   });
 
@@ -191,7 +191,6 @@ describe('getLCP()', async function() {
     assert.strictEqual(lcp1.value, lcp1.delta);
     assert.strictEqual(lcp1.entries.length, 1);
     assert.strictEqual(lcp1.entries[0].element, 'h1');
-    assert.strictEqual(lcp1.isFinal, true);
   });
 
   it('stops reporting after the document changes to hidden (reportAllChanges === true)', async function() {
@@ -200,7 +199,15 @@ describe('getLCP()', async function() {
     await browser.url('/test/lcp?reportAllChanges=1&imgDelay=0&imgHidden=1');
 
     await beaconCountIs(1);
+    const [lcp] = await getBeacons();
 
+    assert(lcp.value > 0);
+    assert.strictEqual(lcp.name, 'LCP');
+    assert.strictEqual(lcp.value, lcp.delta);
+    assert.strictEqual(lcp.entries.length, 1);
+    assert.strictEqual(lcp.entries[0].element, 'h1');
+
+    await clearBeacons();
     await stubVisibilityChange('hidden');
     await stubVisibilityChange('visible');
 
@@ -208,25 +215,11 @@ describe('getLCP()', async function() {
       document.querySelector('img').hidden = false;
     });
 
-    // Since we're dispatching a visibilitychange event,
-    // we don't need to do anything else to trigger the metric reporting.
-    await beaconCountIs(2);
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
 
-    const [lcp1, lcp2] = await getBeacons();
-
-    assert(lcp1.value > 0);
-    assert.strictEqual(lcp1.name, 'LCP');
-    assert.strictEqual(lcp1.value, lcp1.delta);
-    assert.strictEqual(lcp1.entries.length, 1);
-    assert.strictEqual(lcp1.entries[0].element, 'h1');
-    assert.strictEqual(lcp1.isFinal, false);
-
-    assert.strictEqual(lcp2.value, lcp1.value);
-    assert.strictEqual(lcp2.name, 'LCP');
-    assert.strictEqual(lcp2.delta, 0);
-    assert.strictEqual(lcp2.entries.length, 1);
-    assert.strictEqual(lcp2.entries[0].element, 'h1');
-    assert.strictEqual(lcp2.isFinal, true);
+    const beacons = await getBeacons();
+    assert.strictEqual(beacons.length, 0);
   });
 });
 
@@ -238,30 +231,20 @@ const assertStandardReportsAreCorrect = (beacons) => {
   assert.strictEqual(lcp.name, 'LCP');
   assert.strictEqual(lcp.value, lcp.delta);
   assert.strictEqual(lcp.entries.length, 2);
-  assert.strictEqual(lcp.isFinal, true);
 };
 
 const assertFullReportsAreCorrect = (beacons) => {
-  const [lcp1, lcp2, lcp3] = beacons;
+  const [lcp1, lcp2] = beacons;
 
   assert(lcp1.value < 500); // Less than the image load delay.
   assert(lcp1.id.match(/\d+-\d+/));
   assert.strictEqual(lcp1.name, 'LCP');
   assert.strictEqual(lcp1.value, lcp1.delta);
   assert.strictEqual(lcp1.entries.length, 1);
-  assert.strictEqual(lcp1.isFinal, false);
 
   assert(lcp2.value > 500); // Greater than the image load delay.
   assert.strictEqual(lcp2.value, lcp1.value + lcp2.delta);
   assert.strictEqual(lcp2.name, 'LCP');
   assert.strictEqual(lcp2.id, lcp1.id);
   assert.strictEqual(lcp2.entries.length, 2);
-  assert.strictEqual(lcp2.isFinal, false);
-
-  assert.strictEqual(lcp3.value, lcp2.value);
-  assert.strictEqual(lcp3.name, 'LCP');
-  assert.strictEqual(lcp3.id, lcp2.id);
-  assert.strictEqual(lcp3.delta, 0);
-  assert.strictEqual(lcp3.entries.length, 2);
-  assert.strictEqual(lcp3.isFinal, true);
 };

--- a/test/e2e/getTTFB-test.js
+++ b/test/e2e/getTTFB-test.js
@@ -76,7 +76,6 @@ describe('getTTFB()', async function() {
     assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.entries.length, 1);
-    assert.strictEqual(ttfb.isFinal, true);
 
     assertValidEntry(ttfb.entries[0]);
   });
@@ -95,7 +94,6 @@ describe('getTTFB()', async function() {
     assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.entries.length, 1);
-    assert.strictEqual(ttfb.isFinal, true);
 
     assertValidEntry(ttfb.entries[0]);
   });


### PR DESCRIPTION
This PR fixes #82 by removing the `isFinal` flag from the `Metric` interface.

The primary implication of this change is now when calling any of the metric functions with the `reportAllChanges` argument set to `true`, the callback will _only_ be invoked if the metric value changes—i.e. the callback won't be invoked when the page is backgrounded or unloading, nor (in the case of `getLCP()`) will the callback be invoked after user input.

Prior to this change a callback could be invoked without its value changing, but the `isFinal` flag would flip from `false` to `true`.

cc: @addyosmani as this will affect the Web Vitals Extension.


