### PR TITLE
Add support for reporting metrics on bfcache restore

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,7 @@
         "max-len": [2, {
           "ignorePattern": "^\\s*import|= require\\(|^\\s*it\\(|^\\s*describe\\(",
           "ignoreUrls": true
-        }]
+        }],
       }
     },
     {
@@ -47,6 +47,7 @@
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/camelcase": "off",
         "node/no-missing-import": "off",
         "node/no-unsupported-features/es-syntax": "off",

--- a/external-polyfill.js
+++ b/external-polyfill.js
@@ -1,0 +1,2 @@
+// Creates the `web-vitals/external-polyfill` import in node-based bundlers.
+export * from './dist/web-vitals.external-polyfill.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2291,6 +2291,35 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/plugin-replace": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.4.tgz",
+      "integrity": "sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
@@ -2343,6 +2372,12 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/cucumber/-/cucumber-6.0.1.tgz",
       "integrity": "sha512-+GZV6xfN0MeN9shDCdny8GbC8N0+U6uca8cjyaJndcwmrUhwS6qOU2vmYn0d71EOwJF568/v3SxJ8VKxuZNYRw==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "@types/fs-extra": {
@@ -2449,9 +2484,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
       "dev": true
     },
     "@types/parse-json": {
@@ -5725,9 +5760,9 @@
       "dev": true
     },
     "jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+      "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -6113,6 +6148,15 @@
         "yallist": "^2.1.2"
       }
     },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -6377,6 +6421,15 @@
           "dev": true,
           "requires": {
             "picomatch": "^2.2.1"
+          }
+        },
+        "serialize-javascript": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+          "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
           }
         },
         "string-width": {
@@ -7452,15 +7505,6 @@
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
-        },
-        "serialize-javascript": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-          "dev": true,
-          "requires": {
-            "randombytes": "^2.1.0"
-          }
         }
       }
     },
@@ -7661,9 +7705,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -7768,6 +7812,12 @@
           "dev": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -8041,9 +8091,9 @@
       }
     },
     "terser": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.8.tgz",
-      "integrity": "sha512-zVotuHoIfnYjtlurOouTazciEfL7V38QMAOhGqpXDEg6yT13cF4+fEP9b0rrCEQTn+tT46uxgFsTZzhygk+CzQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.3.tgz",
+      "integrity": "sha512-vRQDIlD+2Pg8YMwVK9kMM3yGylG95EIwzBai1Bw7Ot4OBfn3VP1TZn3EWx4ep2jERN/AmnVaTiGuelZSN7ds/A==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:ts": "tsc -b",
     "build:js": "rollup -c",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "dev": "run-p watch serve",
+    "dev": "run-p watch test:server",
     "lint": "eslint \"*.js\" \"src/**/*.ts\" \"test/**/*.js\"",
     "lint:fix": "eslint --fix \"*.js\" \"src/**/*.ts\" \"test/**/*.js\"",
     "postversion": "git push --follow-tags",
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",
+    "@rollup/plugin-replace": "^2.3.4",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
     "@wdio/cli": "^6.7.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,18 +13,11 @@
  limitations under the License.
 */
 
+import replace from '@rollup/plugin-replace';
 import {terser} from 'rollup-plugin-terser';
 import babel from 'rollup-plugin-babel';
 
-
-const baseOpts = {
-  input: 'dist/index.js',
-  watch: {
-    clearScreen: false,
-  },
-};
-
-const configurePlugins = ({module}) => {
+const configurePlugins = ({module, externalPolyfill = false}) => {
   return [
     babel({
       presets: [['@babel/preset-env', {
@@ -38,25 +31,57 @@ const configurePlugins = ({module}) => {
       mangle: true,
       compress: true,
     }),
+    replace({
+      'self.__WEB_VITALS_EXTERNAL_POLYFILL__': externalPolyfill,
+    })
   ]
 }
 
-export default [
+const configs = [
   {
-    ...baseOpts,
+    input: 'dist/modules/index.js',
     output: {
       format: 'esm',
-      file: './dist/web-vitals.es5.min.js',
+      file: './dist/web-vitals.full.js',
     },
-    plugins: configurePlugins({module: true}),
+    plugins: configurePlugins({module: true, externalPolyfill: false}),
   },
   {
-    ...baseOpts,
+    input: 'dist/modules/index.js',
     output: {
       format: 'umd',
-      file: './dist/web-vitals.es5.umd.min.js',
+      file: `./dist/web-vitals.full.umd.js`,
       name: 'webVitals',
+    },
+    plugins: configurePlugins({module: false, externalPolyfill: false}),
+  },
+  {
+    input: 'dist/modules/index.js',
+    output: {
+      format: 'esm',
+      file: './dist/web-vitals.external-polyfill.js',
+    },
+    plugins: configurePlugins({module: true, externalPolyfill: true}),
+  },
+  {
+    input: 'dist/modules/index.js',
+    output: {
+      format: 'umd',
+      file: `./dist/web-vitals.external-polyfill.umd.js`,
+      name: 'webVitals',
+    },
+    plugins: configurePlugins({module: false, externalPolyfill: true}),
+  },
+  {
+    input: 'dist/modules/polyfill.js',
+    output: {
+      format: 'iife',
+      file: './dist/polyfill.js',
+      name: 'webVitals',
+      strict: false,
     },
     plugins: configurePlugins({module: false}),
   },
 ];
+
+export default configs;

--- a/src/getCLS.ts
+++ b/src/getCLS.ts
@@ -17,6 +17,7 @@
 import {initMetric} from './lib/initMetric.js';
 import {observe, PerformanceEntryHandler} from './lib/observe.js';
 import {onHidden} from './lib/onHidden.js';
+import {onBFCacheRestore} from './lib/onBFCacheRestore.js';
 import {bindReporter} from './lib/bindReporter.js';
 import {ReportHandler} from './types.js';
 
@@ -28,8 +29,7 @@ interface LayoutShift extends PerformanceEntry {
 }
 
 export const getCLS = (onReport: ReportHandler, reportAllChanges = false) => {
-  const metric = initMetric('CLS', 0);
-
+  let metric = initMetric('CLS', 0);
   let report: ReturnType<typeof bindReporter>;
 
   const entryHandler = (entry: LayoutShift) => {
@@ -48,6 +48,11 @@ export const getCLS = (onReport: ReportHandler, reportAllChanges = false) => {
     onHidden(() => {
       po.takeRecords().map(entryHandler as PerformanceEntryHandler);
       report();
+    });
+
+    onBFCacheRestore(() => {
+      metric = initMetric('CLS', 0);
+      report = bindReporter(onReport, metric, reportAllChanges);
     });
   }
 };

--- a/src/lib/getFirstHidden.ts
+++ b/src/lib/getFirstHidden.ts
@@ -14,23 +14,49 @@
  * limitations under the License.
  */
 
+import {onBFCacheRestore} from './onBFCacheRestore.js';
 import {onHidden} from './onHidden.js';
 
+let firstHiddenTime = -1;
 
-let firstHiddenTime: number
+const initHiddenTime = () => {
+  return document.visibilityState === 'hidden' ? 0 : Infinity;
+}
+
+const trackChanges = () => {
+  // Update the time if/when the document becomes hidden.
+  onHidden(({timeStamp}) => {
+    firstHiddenTime = timeStamp
+  }, true);
+};
 
 export const getFirstHidden = () => {
-  if (firstHiddenTime === undefined) {
+  if (firstHiddenTime < 0) {
     // If the document is hidden when this code runs, assume it was hidden
     // since navigation start. This isn't a perfect heuristic, but it's the
     // best we can do until an API is available to support querying past
     // visibilityState.
-    firstHiddenTime = document.visibilityState === 'hidden' ? 0 : Infinity;
+    if (self.__WEB_VITALS_EXTERNAL_POLYFILL__) {
+      firstHiddenTime = self.webVitals.firstHiddenTime;
+      if (firstHiddenTime === Infinity) {
+        trackChanges();
+      }
+    } else {
+      firstHiddenTime = initHiddenTime();
+      trackChanges();
+    }
 
-    // Update the time if/when the document becomes hidden.
-    onHidden(({timeStamp}) => firstHiddenTime = timeStamp, true);
+    // Reset the time on bfcache restores.
+    onBFCacheRestore(() => {
+      // Schedule a task in order to track the `visibilityState` once it's
+      // had an opportunity to change to visible in all browsers.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=1133363
+      setTimeout(() => {
+        firstHiddenTime = initHiddenTime();
+        trackChanges();
+      }, 0);
+    });
   }
-
   return {
     get timeStamp() {
       return firstHiddenTime;

--- a/src/lib/onBFCacheRestore.ts
+++ b/src/lib/onBFCacheRestore.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
-/**
- * Performantly generate a unique, 30-char string by combining a version
- * number, the current timestamp with a 13-digit number integer.
- * @return {string}
- */
-export const generateUniqueID = () => {
-  return `v1-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
+interface onBFCacheRestoreCallback {
+  (event: PageTransitionEvent): void;
+}
+
+export const onBFCacheRestore = (cb: onBFCacheRestoreCallback) => {
+  addEventListener('pageshow', (event) => {
+    if (event.persisted) {
+      cb(event);
+    }
+  }, true);
 };

--- a/src/lib/onHidden.ts
+++ b/src/lib/onHidden.ts
@@ -24,7 +24,11 @@ let beforeUnloadFixAdded = false;
 export const onHidden = (cb: OnHiddenCallback, once = false) => {
   // Adding a `beforeunload` listener is needed to fix this bug:
   // https://bugs.chromium.org/p/chromium/issues/detail?id=987409
-  if (!beforeUnloadFixAdded) {
+  if (!beforeUnloadFixAdded &&
+      // Avoid adding this in Firefox as it'll break bfcache:
+      // https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
+      // @ts-ignore
+      typeof InstallTrigger === 'undefined') {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     addEventListener('beforeunload', () => {});
     beforeUnloadFixAdded = true;

--- a/src/lib/polyfills/firstHiddenTimePolyfill.ts
+++ b/src/lib/polyfills/firstHiddenTimePolyfill.ts
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-/**
- * Performantly generate a unique, 30-char string by combining a version
- * number, the current timestamp with a 13-digit number integer.
- * @return {string}
- */
-export const generateUniqueID = () => {
-  return `v1-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
-};
+export let firstHiddenTime =
+    document.visibilityState === 'hidden' ? 0 : Infinity;
+
+const onVisibilityChange = (event: Event) => {
+  if (document.visibilityState === 'hidden') {
+    firstHiddenTime = event.timeStamp;
+    removeEventListener('visibilitychange', onVisibilityChange, true);
+  }
+}
+
+// Note: do not add event listeners unconditionally (outside of polyfills).
+addEventListener('visibilitychange', onVisibilityChange, true);

--- a/src/lib/polyfills/firstInputPolyfill.ts
+++ b/src/lib/polyfills/firstInputPolyfill.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {PerformanceEventTiming} from '../../types.js';
+
+
+type addOrRemoveEventListener =
+    typeof addEventListener | typeof removeEventListener;
+
+interface FirstInputCallback {
+  (entry: PerformanceEventTiming): void;
+}
+
+let firstInputEvent: Event|null;
+let firstInputDelay: number;
+let firstInputTimeStamp: Date;
+let callbacks: FirstInputCallback[]
+
+const listenerOpts: AddEventListenerOptions = {passive: true, capture: true};
+const startTimeStamp: Date = new Date();
+
+/**
+ * Accepts a callback to be invoked once the first input delay and event
+ * are known.
+ * @param {!Function} callback
+ */
+export const firstInputPolyfill = (onFirstInput: FirstInputCallback) => {
+  callbacks.push(onFirstInput);
+  reportFirstInputDelayIfRecordedAndValid();
+}
+
+export const resetFirstInputPolyfill = () => {
+  callbacks = [];
+  firstInputDelay = -1;
+  firstInputEvent = null;
+  eachEventType(addEventListener);
+}
+
+/**
+ * Records the first input delay and event, so subsequent events can be
+ * ignored. All added event listeners are then removed.
+ */
+const recordFirstInputDelay = (delay: number, event: Event) => {
+  if (!firstInputEvent) {
+    firstInputEvent = event;
+    firstInputDelay = delay;
+    firstInputTimeStamp = new Date;
+
+    eachEventType(removeEventListener);
+    reportFirstInputDelayIfRecordedAndValid();
+  }
+}
+
+/**
+ * Reports the first input delay and event (if they're recorded and valid)
+ * by running the array of callback functions.
+ */
+const reportFirstInputDelayIfRecordedAndValid = () => {
+  // In some cases the recorded delay is clearly wrong, e.g. it's negative
+  // or it's larger than the delta between now and initialization.
+  // - https://github.com/GoogleChromeLabs/first-input-delay/issues/4
+  // - https://github.com/GoogleChromeLabs/first-input-delay/issues/6
+  // - https://github.com/GoogleChromeLabs/first-input-delay/issues/7
+  if (firstInputDelay >= 0 &&
+      // @ts-ignore (subtracting two dates always returns a number)
+      firstInputDelay < firstInputTimeStamp - startTimeStamp) {
+    const entry = {
+      entryType: 'first-input',
+      name: firstInputEvent!.type,
+      target: firstInputEvent!.target,
+      cancelable: firstInputEvent!.cancelable,
+      startTime: firstInputEvent!.timeStamp,
+      processingStart: firstInputEvent!.timeStamp + firstInputDelay,
+    } as PerformanceEventTiming;
+    callbacks.forEach(function(callback) {
+      callback(entry);
+    });
+    callbacks = [];
+  }
+}
+
+/**
+ * Handles pointer down events, which are a special case.
+ * Pointer events can trigger main or compositor thread behavior.
+ * We differentiate these cases based on whether or not we see a
+ * 'pointercancel' event, which are fired when we scroll. If we're scrolling
+ * we don't need to report input delay since FID excludes scrolling and
+ * pinch/zooming.
+ */
+const onPointerDown = (delay: number, event: Event) => {
+  /**
+   * Responds to 'pointerup' events and records a delay. If a pointer up event
+   * is the next event after a pointerdown event, then it's not a scroll or
+   * a pinch/zoom.
+   */
+  const onPointerUp = () => {
+    recordFirstInputDelay(delay, event);
+    removePointerEventListeners();
+  }
+
+  /**
+   * Responds to 'pointercancel' events and removes pointer listeners.
+   * If a 'pointercancel' is the next event to fire after a pointerdown event,
+   * it means this is a scroll or pinch/zoom interaction.
+   */
+  const onPointerCancel = () => {
+    removePointerEventListeners();
+  }
+
+  /**
+   * Removes added pointer event listeners.
+   */
+  const removePointerEventListeners = () => {
+    removeEventListener('pointerup', onPointerUp, listenerOpts);
+    removeEventListener('pointercancel', onPointerCancel, listenerOpts);
+  }
+
+  addEventListener('pointerup', onPointerUp, listenerOpts);
+  addEventListener('pointercancel', onPointerCancel, listenerOpts);
+}
+
+/**
+ * Handles all input events and records the time between when the event
+ * was received by the operating system and when it's JavaScript listeners
+ * were able to run.
+ * @param {Event} event
+ */
+const onInput = (event: Event) => {
+  // Only count cancelable events, which should trigger behavior
+  // important to the user.
+  if (event.cancelable) {
+    // In some browsers `event.timeStamp` returns a `DOMTimeStamp` value
+    // (epoch time) instead of the newer `DOMHighResTimeStamp`
+    // (document-origin time). To check for that we assume any timestamp
+    // greater than 1 trillion is a `DOMTimeStamp`, and compare it using
+    // the `Date` object rather than `performance.now()`.
+    // - https://github.com/GoogleChromeLabs/first-input-delay/issues/4
+    const isEpochTime = event.timeStamp > 1e12;
+    const now = isEpochTime ? new Date : performance.now();
+
+    // Input delay is the delta between when the system received the event
+    // (e.g. event.timeStamp) and when it could run the callback (e.g. `now`).
+    const delay = now as number - event.timeStamp;
+
+    if (event.type == 'pointerdown') {
+      onPointerDown(delay, event);
+    } else {
+      recordFirstInputDelay(delay, event);
+    }
+  }
+}
+
+/**
+ * Invokes the passed callback const for =  each event type with t =>he
+ * `onInput` const and =  `listenerOpts =>`.
+ * @param {Function} callback
+ */
+const eachEventType = (callback: addOrRemoveEventListener) => {
+  const eventTypes = [
+    'click',
+    'mousedown',
+    'keydown',
+    'touchstart',
+    'pointerdown',
+  ];
+  eventTypes.forEach((type) => callback(type, onInput, listenerOpts));
+}

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-/**
- * Performantly generate a unique, 30-char string by combining a version
- * number, the current timestamp with a 13-digit number integer.
- * @return {string}
- */
-export const generateUniqueID = () => {
-  return `v1-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
-};
+import {firstInputPolyfill, resetFirstInputPolyfill} from './lib/polyfills/firstInputPolyfill.js';
+import {firstHiddenTime} from './lib/polyfills/firstHiddenTimePolyfill.js';
+
+resetFirstInputPolyfill();
+self['webVitals'] = self['webVitals'] || {};
+self['webVitals']['firstInputPolyfill'] = firstInputPolyfill;
+self['webVitals']['resetFirstInputPolyfill'] = resetFirstInputPolyfill;
+self['webVitals']['firstHiddenTime'] = firstHiddenTime;

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,3 +39,26 @@ export interface Metric {
 export interface ReportHandler {
   (metric: Metric): void;
 }
+
+// https://wicg.github.io/event-timing/#sec-performance-event-timing
+export interface PerformanceEventTiming extends PerformanceEntry {
+  processingStart: DOMHighResTimeStamp;
+  cancelable?: boolean;
+  target?: Element;
+}
+
+export interface WebVitalsGlobal {
+  firstInputPolyfill: (onFirstInput: (entry: PerformanceEventTiming) => void) => void;
+  resetFirstInputPolyfill: () => void;
+  // getFirstHiddenTime: () => number;
+  firstHiddenTime: number;
+}
+
+declare global {
+  interface Window {
+    webVitals: WebVitalsGlobal;
+
+    // Build flags:
+    __WEB_VITALS_EXTERNAL_POLYFILL__: boolean;
+  }
+}

--- a/test/e2e/getFCP-test.js
+++ b/test/e2e/getFCP-test.js
@@ -17,8 +17,8 @@
 const assert = require('assert');
 const {beaconCountIs, clearBeacons, getBeacons} = require('../utils/beacons.js');
 const {browserSupportsEntry} = require('../utils/browserSupportsEntry.js');
+const {stubForwardBack} = require('../utils/stubForwardBack.js');
 const {stubVisibilityChange} = require('../utils/stubVisibilityChange.js');
-
 
 describe('getFCP()', async function() {
   let browserSupportsFCP;
@@ -39,13 +39,13 @@ describe('getFCP()', async function() {
 
     const [fcp] = await getBeacons();
     assert(fcp.value >= 0);
-    assert(fcp.id.match(/\d+-\d+/));
+    assert(fcp.id.match(/^v1-\d+-\d+$/));
     assert.strictEqual(fcp.name, 'FCP');
     assert.strictEqual(fcp.value, fcp.delta);
     assert.strictEqual(fcp.entries.length, 1);
   });
 
-  it('does not report if the browser does not support FCP', async function() {
+  it('does not report if the browser does not support FCP (including bfcache restores)', async function() {
     if (browserSupportsFCP) this.skip();
 
     await browser.url('/test/fcp');
@@ -53,8 +53,17 @@ describe('getFCP()', async function() {
     // Wait a bit to ensure no beacons were sent.
     await browser.pause(1000);
 
-    const beacons = await getBeacons();
-    assert.strictEqual(beacons.length, 0);
+    const loadBeacons = await getBeacons();
+    assert.strictEqual(loadBeacons.length, 0);
+
+    await clearBeacons();
+    await stubForwardBack();
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    const bfcacheRestoreBeacons = await getBeacons();
+    assert.strictEqual(bfcacheRestoreBeacons.length, 0);
   });
 
   it('does not report if the document was hidden at page load time', async function() {
@@ -84,5 +93,84 @@ describe('getFCP()', async function() {
 
     const beacons = await getBeacons();
     assert.strictEqual(beacons.length, 0);
+  });
+
+  it('reports if the page is restored from bfcache', async function() {
+    if (!browserSupportsFCP) this.skip();
+
+    await browser.url('/test/fcp');
+
+    await beaconCountIs(1);
+
+    const [fcp1] = await getBeacons();
+    assert(fcp1.value >= 0);
+    assert(fcp1.id.match(/^v1-\d+-\d+$/));
+    assert.strictEqual(fcp1.name, 'FCP');
+    assert.strictEqual(fcp1.value, fcp1.delta);
+    assert.strictEqual(fcp1.entries.length, 1);
+
+    await clearBeacons();
+    await stubForwardBack();
+
+    await beaconCountIs(1);
+
+    const [fcp2] = await getBeacons();
+    assert(fcp2.value >= 0);
+    assert(fcp2.id.match(/^v1-\d+-\d+$/));
+    assert(fcp2.id !== fcp1.id);
+    assert.strictEqual(fcp2.name, 'FCP');
+    assert.strictEqual(fcp2.value, fcp2.delta);
+    assert.strictEqual(fcp2.entries.length, 0);
+
+    await clearBeacons();
+    await stubForwardBack();
+
+    await beaconCountIs(1);
+
+    const [fcp3] = await getBeacons();
+    assert(fcp3.value >= 0);
+    assert(fcp3.id.match(/^v1-\d+-\d+$/));
+    assert(fcp3.id !== fcp2.id);
+    assert.strictEqual(fcp3.name, 'FCP');
+    assert.strictEqual(fcp3.value, fcp3.delta);
+    assert.strictEqual(fcp3.entries.length, 0);
+  });
+
+  it('reports if the page is restored from bfcache even when the document was hidden at page load time', async function() {
+    if (!browserSupportsFCP) this.skip();
+
+    await browser.url('/test/fcp?hidden=1');
+
+    await stubVisibilityChange('visible');
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    const beacons = await getBeacons();
+    assert.strictEqual(beacons.length, 0);
+
+    await stubForwardBack();
+
+    await beaconCountIs(1);
+
+    const [fcp1] = await getBeacons();
+    assert(fcp1.value >= 0);
+    assert(fcp1.id.match(/^v1-\d+-\d+$/));
+    assert.strictEqual(fcp1.name, 'FCP');
+    assert.strictEqual(fcp1.value, fcp1.delta);
+    assert.strictEqual(fcp1.entries.length, 0);
+
+    await clearBeacons();
+    await stubForwardBack();
+
+    await beaconCountIs(1);
+
+    const [fcp2] = await getBeacons();
+    assert(fcp2.value >= 0);
+    assert(fcp2.id.match(/^v1-\d+-\d+$/));
+    assert(fcp2.id !== fcp1.id);
+    assert.strictEqual(fcp2.name, 'FCP');
+    assert.strictEqual(fcp2.value, fcp2.delta);
+    assert.strictEqual(fcp2.entries.length, 0);
   });
 });

--- a/test/e2e/getFID-test.js
+++ b/test/e2e/getFID-test.js
@@ -17,6 +17,7 @@
 const assert = require('assert');
 const {beaconCountIs, clearBeacons, getBeacons} = require('../utils/beacons.js');
 const {browserSupportsEntry} = require('../utils/browserSupportsEntry.js');
+const {stubForwardBack} = require('../utils/stubForwardBack.js');
 const {stubVisibilityChange} = require('../utils/stubVisibilityChange.js');
 
 
@@ -43,7 +44,7 @@ describe('getFID()', async function() {
 
     const [fid] = await getBeacons();
     assert(fid.value >= 0);
-    assert(fid.id.match(/\d+-\d+/));
+    assert(fid.id.match(/^v1-\d+-\d+$/));
     assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.entries[0].name, 'mousedown');
@@ -61,8 +62,20 @@ describe('getFID()', async function() {
     // Wait a bit to ensure no beacons were sent.
     await browser.pause(1000);
 
-    const beacons = await getBeacons();
-    assert.strictEqual(beacons.length, 0);
+    const loadBeacons = await getBeacons();
+    assert.strictEqual(loadBeacons.length, 0);
+
+    await stubForwardBack();
+
+    // Assert no entries after bfcache restores either (if the browser does
+    // not support native FID and the polyfill is not used).
+    await h1.click();
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    const bfcacheRestoreBeacons = await getBeacons();
+    assert.strictEqual(bfcacheRestoreBeacons.length, 0);
   });
 
   it('falls back to the polyfill in non-supporting browsers', async function() {
@@ -81,7 +94,7 @@ describe('getFID()', async function() {
     const [fid] = await getBeacons();
 
     assert(fid.value >= 0);
-    assert(fid.id.match(/\d+-\d+/));
+    assert(fid.id.match(/^v1-\d+-\d+$/));
     assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.entries[0].name, 'mousedown');
@@ -131,6 +144,41 @@ describe('getFID()', async function() {
 
     const beacons = await getBeacons();
     assert.strictEqual(beacons.length, 0);
+  });
+
+  it('reports the first input delay after bfcache restores', async function() {
+    if (!browserSupportsFID) this.skip();
+
+    await browser.url('/test/fid');
+
+    // Click on the <h1>.
+    const h1 = await $('h1');
+    await h1.click();
+
+    await beaconCountIs(1);
+
+    const [fid1] = await getBeacons();
+    assert(fid1.value >= 0);
+    assert(fid1.id.match(/^v1-\d+-\d+$/));
+    assert.strictEqual(fid1.name, 'FID');
+    assert.strictEqual(fid1.value, fid1.delta);
+    assert.strictEqual(fid1.entries[0].name, 'mousedown');
+
+    await clearBeacons();
+    await stubForwardBack();
+
+    // Click on the <h1>.
+    await h1.click();
+
+    await beaconCountIs(1);
+
+    const [fid2] = await getBeacons();
+    assert(fid2.value >= 0);
+    assert(fid2.id.match(/^v1-\d+-\d+$/));
+    assert(fid1.id !== fid2.id);
+    assert.strictEqual(fid2.name, 'FID');
+    assert.strictEqual(fid2.value, fid2.delta);
+    assert.strictEqual(fid2.entries[0].name, 'mousedown');
   });
 });
 

--- a/test/e2e/getLCP-test.js
+++ b/test/e2e/getLCP-test.js
@@ -227,7 +227,7 @@ const assertStandardReportsAreCorrect = (beacons) => {
   const [lcp] = beacons;
 
   assert(lcp.value > 500); // Greater than the image load delay.
-  assert(lcp.id.match(/\d+-\d+/));
+  assert(lcp.id.match(/^v1-\d+-\d+$/));
   assert.strictEqual(lcp.name, 'LCP');
   assert.strictEqual(lcp.value, lcp.delta);
   assert.strictEqual(lcp.entries.length, 2);
@@ -237,7 +237,7 @@ const assertFullReportsAreCorrect = (beacons) => {
   const [lcp1, lcp2] = beacons;
 
   assert(lcp1.value < 500); // Less than the image load delay.
-  assert(lcp1.id.match(/\d+-\d+/));
+  assert(lcp1.id.match(/^v1-\d+-\d+$/));
   assert.strictEqual(lcp1.name, 'LCP');
   assert.strictEqual(lcp1.value, lcp1.delta);
   assert.strictEqual(lcp1.entries.length, 1);

--- a/test/e2e/getTTFB-test.js
+++ b/test/e2e/getTTFB-test.js
@@ -72,7 +72,7 @@ describe('getTTFB()', async function() {
     assert(ttfb.value >= 0);
     assert(ttfb.value >= ttfb.entries[0].requestStart);
     assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
-    assert(ttfb.id.match(/\d+-\d+/));
+    assert(ttfb.id.match(/^v1-\d+-\d+$/));
     assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.entries.length, 1);
@@ -90,7 +90,7 @@ describe('getTTFB()', async function() {
     assert(ttfb.value >= 0);
     assert(ttfb.value >= ttfb.entries[0].requestStart);
     assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
-    assert(ttfb.id.match(/\d+-\d+/));
+    assert(ttfb.id.match(/^v1-\d+-\d+$/));
     assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.entries.length, 1);

--- a/test/server.js
+++ b/test/server.js
@@ -49,7 +49,13 @@ app.post('/collect', bodyParser.text(), (req, res) => {
 });
 
 app.get('/test/:view', function(req, res) {
-  res.send(nunjucks.render(`${req.params.view}.njk`, req.query));
+  const data = {
+    ...req.query,
+    modulePath: `/dist/web-vitals.${
+        req.query.polyfill ? `external-polyfill` : `full`}.js`,
+    webVitalsPolyfill: fs.readFileSync('./dist/polyfill.js', 'utf-8'),
+  }
+  res.send(nunjucks.render(`${req.params.view}.njk`, data));
 });
 
 app.use(express.static('./'));

--- a/test/views/cls.njk
+++ b/test/views/cls.njk
@@ -25,12 +25,29 @@
     <p>Text below the images that will get pushed down.</p>
   {% endif %}
 
+  <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+
   <script type="module">
-    import {getCLS} from '/dist/web-vitals.es5.min.js';
+    import {getCLS} from '{{ modulePath }}';
 
     getCLS((cls) => {
       // Log for easier manual testing.
       console.log(cls);
+
+      // Sources is verbose to serialize, so remove first.
+      cls = {
+        ...cls,
+        entries: cls.entries.map((e) => {
+          const {entryType, hadRecentInput, startTime, value} = e;
+          const sources = e.sources.map((s) => {
+            let node = s.node.nodeName.toLowerCase() +
+                (s.node.id ? `#${s.node.id}` : ``);
+
+            return {node};
+          });
+          return {entryType, hadRecentInput, sources, startTime, value};
+        }),
+      };
 
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(cls));

--- a/test/views/fcp.njk
+++ b/test/views/fcp.njk
@@ -22,8 +22,10 @@
   </p>
   <p>Text below the image</p>
 
+  <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+
   <script type="module">
-    import {getFCP} from '/dist/web-vitals.es5.min.js';
+    import {getFCP} from '{{ modulePath }}';
 
     getFCP((fcp) => {
       // Log for easier manual testing.

--- a/test/views/fid.njk
+++ b/test/views/fid.njk
@@ -15,22 +15,16 @@
 
 {% extends 'layout.njk' %}
 
-{% block head %}
-  {% if polyfill %}
-    <script>
-      !function(n,e){var t,o,i,c=[],f={passive:!0,capture:!0},r=new Date,a="pointerup",u="pointercancel";function p(n,c){t||(t=c,o=n,i=new Date,w(e),s())}function s(){o>=0&&o<i-r&&(c.forEach(function(n){n(o,t)}),c=[])}function l(t){if(t.cancelable){var o=(t.timeStamp>1e12?new Date:performance.now())-t.timeStamp;"pointerdown"==t.type?function(t,o){function i(){p(t,o),r()}function c(){r()}function r(){e(a,i,f),e(u,c,f)}n(a,i,f),n(u,c,f)}(o,t):p(o,t)}}function w(n){["click","mousedown","keydown","touchstart","pointerdown"].forEach(function(e){n(e,l,f)})}w(n),self.perfMetrics=self.perfMetrics||{},self.perfMetrics.onFirstInputDelay=function(n){c.push(n),s()}}(addEventListener,removeEventListener);
-    </script>
-  {% endif %}
-{% endblock %}
-
 {% block content %}
   <h1>FID Test</h1>
   <p>
     <button>Click me</button>
   </p>
 
+  <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+
   <script type="module">
-    import {getFID} from '/dist/web-vitals.es5.min.js';
+    import {getFID} from '{{ modulePath }}';
 
     getFID((fid) => {
       // Log for easier manual testing.

--- a/test/views/layout.njk
+++ b/test/views/layout.njk
@@ -39,6 +39,9 @@
       }
     }());
   </script>
+  {% if polyfill %}
+    <script>{{ webVitalsPolyfill | safe }}</script>
+  {% endif %}
   {% block head %}{% endblock %}
   <style>
     html {

--- a/test/views/lcp.njk
+++ b/test/views/lcp.njk
@@ -24,13 +24,15 @@
   </p>
   <p>Text below the image</p>
 
+  <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+
   <!-- Include a tall element to ensure scrolling is possible. -->
   <div style="height: 100vh"></div>
 
   <footer>Text below the full-height element.</footer>
 
   <script type="module">
-    import {getLCP} from '/dist/web-vitals.es5.min.js';
+    import {getLCP} from '{{ modulePath }}';
 
     getLCP((lcp) => {
       // Log for easier manual testing.

--- a/test/views/ttfb.njk
+++ b/test/views/ttfb.njk
@@ -22,8 +22,10 @@
 
   <p>Text below the image</p>
 
+  <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+
   <script type="module">
-    import {getTTFB} from '/dist/web-vitals.es5.min.js';
+    import {getTTFB} from '{{ modulePath }}';
 
     (async function() {
       {% if awaitLoad %}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "outDir": "./dist",
+    "outDir": "./dist/modules",
     "preserveConstEnums": true,
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
This PR fixes #83 by reporting each of the user-centric metrics after a page has been restored from the [back/forward cache](https://www.chromestatus.com/feature/5815270035685376) (bfcache), in order to match the new behavior of the metrics as measured by the [Chrome User Experience Report](https://developers.google.com/web/tools/chrome-user-experience-report) (CrUX).

Since dedicated Web APIs do not yet exist to handle bfcache restores, polyfills are used to approximate the values. The polyfills implemented here match those that will be used by CrUX.

## Polyfill deteails

Below is an explanation of each of the polyfills used to measure each metric. See the [code changes](https://github.com/GoogleChrome/web-vitals/pull/87/files) for full implementation details:

### FCP

To measure FCP after a bfcache restore, this library takes the delta between the `pageshow` event's timestamp and a timestamp from calling `performance.now()` in the next rendered frame. To ensure the timestamp comes from the frame _after_ the `pageshow` event, the polyfill actually calls `requestAnimationFrame()` twice (our testing found double-rAF to be more accurate than single-rAF in this case).

### LCP

When a page is stored in the bfcache, a full snapshot of the entire DOM is captured in memory. That means when it's restored it doesn't have to "load" anything, and as a result the full viewport can be painted in a single frame. This means that LCP is generally exactly the same as FCP, so the polyfill here is the same as the one outlined above.

I say "generally" above because technically a page could make network requests in the `pageshow` event and update the DOM, though in practice that is quite rare. This polyfill does not attempt to account for such cases—erring on the side of reporting a faster LCP time.

### FID

Prior to this PR, the `web-vitals` library would look for the presence of the [FID polyfill](https://github.com/GoogleChromeLabs/first-input-delay) as use that for browsers that don't support the [Event Timing API](https://wicg.github.io/event-timing/). After this PR is merged, that library will be deprecated and a new version of the polyfill will be hosted in this repo. The new version will include support for measuring FID after a bfcache restore—largely reusing the existing polyfill logic.

The default build of the web-vitals library will bundle the new FID polyfill, but a custom build with the polyfill separated can also be used so developers who want cross-browser support for FID can inline the polyfill in the `<head>` of their documents. Both options are supported and usage instructions will be documented in the README when v1 is released.

### CLS

Since the [Layout Instability API](https://wicg.github.io/layout-instability/) reports layout shifts that occur throughout the lifespan of a page (including after it's restored from bfcache), it can be used without any specific polyfilling needed.

The only change in the case of a bfcache restore is the metric value will be reset to `0`.

### TTFB

Since TTFB measures network latency, it is not relevant to bfcache and thus no new values will be reported after a bfcache restore. This metric will continue to only be reported once per page load.

## New Bundles

To accommodate for multiples different ways to load the web-vitals modules and polyfills, the following new bundles/builds are included in this PR, comprising the new "standard" and "base+polyfill" versions:

### `dist/web-vitals.js`

~1.5K (gzipped)

An ES module bundle of all metric functions, without any extra polyfills to expand browser support. This is the "standard" version and is the simplest way to consume this library out of the box.

`pkg.module` points to this version.

### `dist/web-vitals.umd.js`

~1.7K (gzipped)

A UMD version of `dist/web-vitals.js` (with the `window.webVitals.*` namespace).

`pkg.main` points to this version in order to support older node versions of tools that cannot import ES modules.

### `dist/web-vitals.base.js`

~1.3K (gzipped)

An ES module bundle containing just the "base" part of the "base+polyfill" version. This script is designed to work with the "polyfill.js" script inlined in the `<head>` of the page.

### `dist/web-vitals.base.umd.js`

~1.5K (gzipped)

A UMD version of `dist/web-vitals.base.umd.js` (with the `window.webVitals.*` namespace).

### `dist/polyfill.js`

~0.5K (gzipped)

The companion polyfill code to be inlined in the `<head>` of your document if using `dist/web-vitals.base.js` or `dist/web-vitals.base.umd.js`.

The polyfill uses the global namespace `window.webVitals.*`, which matches those used by the UMD builds.

The benefit of using the external polyfill is wider browser support and more accurate handling of edge cases (e.g. if a page is loaded in the background but foregrounded before the web-vitals code runs).

