### PR TITLE
Fix missing typings declaration

### DIFF
--- a/base.d.ts
+++ b/base.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/modules/index.js';

--- a/base.js
+++ b/base.js
@@ -1,3 +1,3 @@
 // Creates the `web-vitals/base` import in node-based bundlers.
-// This will not be needed when export maps are widely suppoprted.
+// This will not be needed when export maps are widely supported.
 export * from './dist/web-vitals.base.js';

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Easily measure performance metrics in JavaScript",
   "main": "dist/web-vitals.umd.js",
   "module": "dist/web-vitals.js",
-  "typings": "dist/index.d.ts",
+  "typings": "dist/modules/index.d.ts",
   "files": [
+    "base.js",
+    "base.d.ts",
     "dist",
     "src"
   ],


### PR DESCRIPTION
This PR fixes #89 by updating `pkg.typings` to point to the new location after the v1 changes. It also adds `base.js` and `base.d.ts` to `pgk.files` since they were also missing.