### PR TITLE
Add support for Set in place of WeakSet

### DIFF
--- a/src/lib/finalMetrics.ts
+++ b/src/lib/finalMetrics.ts
@@ -16,5 +16,6 @@
 
 import {Metric} from '../types.js';
 
-
-export const finalMetrics: WeakSet<Metric> = new WeakSet();
+export const finalMetrics: WeakSet<Metric>|Set<Metric> = 'WeakSet' in window
+  ? new WeakSet()
+  : new Set();

--- a/src/lib/finalMetrics.ts
+++ b/src/lib/finalMetrics.ts
@@ -16,6 +16,6 @@
 
 import {Metric} from '../types.js';
 
-export const finalMetrics: WeakSet<Metric>|Set<Metric> = 'WeakSet' in window
+export const finalMetrics: WeakSet<Metric>|Set<Metric> = typeof WeakSet === 'function'
   ? new WeakSet()
   : new Set();


### PR DESCRIPTION
Fixes #104 

IE11 does not support WeakSet but does support Set. It is still maintained until Aug 2021.
Since the Weakset is created on import, even when the module is loaded and not executed a breakage is caused.

A plain Set implements the necessary API required by this module.

Error: `ReferenceError: 'WeakSet' is undefined`
User agent string: `Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko` (IE11, Win10)
