### PR TITLE
Move value below label for examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,15 +205,15 @@ function sendToGoogleAnalytics({name, delta, id}) {
   ga('send', 'event', {
     eventCategory: 'Web Vitals',
     eventAction: name,
-    // Google Analytics metrics must be integers, so the value is rounded.
-    // For CLS the value is first multiplied by 1000 for greater precision
-    // (note: increase the multiplier for greater precision if needed).
-    eventValue: Math.round(name === 'CLS' ? delta * 1000 : delta),
     // The `id` value will be unique to the current page load. When sending
     // multiple values from the same page (e.g. for CLS), Google Analytics can
     // compute a total by grouping on this ID (note: requires `eventLabel` to
     // be a dimension in your report).
     eventLabel: id,
+    // Google Analytics metrics must be integers, so the value is rounded.
+    // For CLS the value is first multiplied by 1000 for greater precision
+    // (note: increase the multiplier for greater precision if needed).
+    eventValue: Math.round(name === 'CLS' ? delta * 1000 : delta),
     // Use a non-interaction event to avoid affecting bounce rate.
     nonInteraction: true,
     // Use `sendBeacon()` if the browser supports it.
@@ -236,15 +236,15 @@ function sendToGoogleAnalytics({name, delta, id}) {
   // https://developers.google.com/analytics/devguides/collection/gtagjs
   gtag('event', name, {
     event_category: 'Web Vitals',
-    // Google Analytics metrics must be integers, so the value is rounded.
-    // For CLS the value is first multiplied by 1000 for greater precision
-    // (note: increase the multiplier for greater precision if needed).
-    value: Math.round(name === 'CLS' ? delta * 1000 : delta),
     // The `id` value will be unique to the current page load. When sending
     // multiple values from the same page (e.g. for CLS), Google Analytics can
     // compute a total by grouping on this ID (note: requires `eventLabel` to
     // be a dimension in your report).
     event_label: id,
+    // Google Analytics metrics must be integers, so the value is rounded.
+    // For CLS the value is first multiplied by 1000 for greater precision
+    // (note: increase the multiplier for greater precision if needed).
+    value: Math.round(name === 'CLS' ? delta * 1000 : delta),
     // Use a non-interaction event to avoid affecting bounce rate.
     non_interaction: true,
   });

--- a/README.md
+++ b/README.md
@@ -269,15 +269,15 @@ function sendToGTM({name, delta, id}) {
     event: 'web-vitals',
     event_category: 'Web Vitals',
     event_action: name,
-    // Google Analytics metrics must be integers, so the value is rounded.
-    // For CLS the value is first multiplied by 1000 for greater precision
-    // (note: increase the multiplier for greater precision if needed).
-    event_value: Math.round(name === 'CLS' ? delta * 1000 : delta),
     // The `id` value will be unique to the current page load. When sending
     // multiple values from the same page (e.g. for CLS), Google Analytics can
     // compute a total by grouping on this ID (note: requires `eventLabel` to
     // be a dimension in your report).
     event_label: id,
+    // Google Analytics metrics must be integers, so the value is rounded.
+    // For CLS the value is first multiplied by 1000 for greater precision
+    // (note: increase the multiplier for greater precision if needed).
+    event_value: Math.round(name === 'CLS' ? delta * 1000 : delta),
   });
 }
 


### PR DESCRIPTION
Hey!  The order of these in the docs tripped me up.  In GTM the label field comes before the value field.  It's a small thing but I think this makes it a little easier to implement.  🙂 

![image](https://user-images.githubusercontent.com/10101828/104331016-37af1680-54b4-11eb-8fb5-1fe4d27b6f0d.png)