### PR TITLE
Add getter to polyfill

### DIFF
--- a/src/lib/polyfills/getFirstHiddenTimePolyfill.ts
+++ b/src/lib/polyfills/getFirstHiddenTimePolyfill.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export let firstHiddenTime =
+let firstHiddenTime =
     document.visibilityState === 'hidden' ? 0 : Infinity;
 
 const onVisibilityChange = (event: Event) => {
@@ -26,3 +26,5 @@ const onVisibilityChange = (event: Event) => {
 
 // Note: do not add event listeners unconditionally (outside of polyfills).
 addEventListener('visibilitychange', onVisibilityChange, true);
+
+export const getFirstHiddenTime = () => firstHiddenTime;

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -15,10 +15,15 @@
  */
 
 import {firstInputPolyfill, resetFirstInputPolyfill} from './lib/polyfills/firstInputPolyfill.js';
-import {firstHiddenTime} from './lib/polyfills/firstHiddenTimePolyfill.js';
+import {getFirstHiddenTime} from './lib/polyfills/getFirstHiddenTimePolyfill.js';
 
 resetFirstInputPolyfill();
-self['webVitals'] = self['webVitals'] || {};
-self['webVitals']['firstInputPolyfill'] = firstInputPolyfill;
-self['webVitals']['resetFirstInputPolyfill'] = resetFirstInputPolyfill;
-self['webVitals']['firstHiddenTime'] = firstHiddenTime;
+self.webVitals = {
+  firstInputPolyfill: firstInputPolyfill,
+  resetFirstInputPolyfill: resetFirstInputPolyfill,
+  // TODO: in v2 this should just be `getFirstHiddenTime()`,
+  // but in v1 it needs to be a getter to avoid creating a breaking change.
+  get firstHiddenTime() {
+    return getFirstHiddenTime();
+  },
+};


### PR DESCRIPTION
This PR fixes #113 by adding a getter to the polyfill to make the `firstHiddenTime` value "live".

In v2 we may want to simplify and make this an explicit getter (e.g. `getFirstHiddenTime()`), but to avoid a breaking change, using a getter is the best solution for now.