### PR TITLE
Remove redundant key from typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface PerformanceEventTiming extends PerformanceEntry {
 }
 
 export type FirstInputPolyfillEntry =
-    Omit<PerformanceEventTiming, 'processingEnd' | 'processingEnd' | 'toJSON'>
+    Omit<PerformanceEventTiming, 'processingEnd' | 'toJSON'>
 
 export interface FirstInputPolyfillCallback {
   (entry: FirstInputPolyfillEntry): void;


### PR DESCRIPTION
This PR fixes #105 by removing the redundant key the the `types.ts` file.