### PR TITLE
Update the UMD config to extend the global

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -69,6 +69,7 @@ const configs = [
       format: 'umd',
       file: `./dist/web-vitals.base.umd.js`,
       name: 'webVitals',
+      extend: true,
     },
     plugins: configurePlugins({module: false, polyfill: true}),
   },


### PR DESCRIPTION
This PR fixes #116 by updating the UMD build config to extend the global instead of overwriteing it.

Previously, if using the UMD version of the base script with the polyfill, the `webVitals` global added by the polyfill would be overridden by the UMD version of the base script. Note this did not happen with the module version of the base script since it didn't use a browser global.