### PR TITLE
Remove Firefox detection code

### DIFF
--- a/test/e2e/getTTFB-test.js
+++ b/test/e2e/getTTFB-test.js
@@ -49,10 +49,13 @@ function assertValidEntry(entry) {
 
   assert.strictEqual(entry.entryType, 'navigation');
   for (const timingProp of timingProps) {
-    if (!(entry[timingProp] >= 0)) {
-      console.log(timingProp, entry[timingProp]);
+    if (browser.capabilities.browserName === 'firefox' &&
+        timingProp === 'fetchStart' &&
+        entry[timingProp] === -1) {
+      // Firefox sometimes reports the fetchStart value as -1
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1429422
+      continue;
     }
-
     assert(entry[timingProp] >= 0);
   }
 }


### PR DESCRIPTION
Fixes #124.

This PR removes the use of browser detection by referencing legacy API `InstallTrigger`. Now that the bug this detect was needed for has been fixed. It's no longer necessary.