### PR TITLE
Add more extensive FID feature detect

### DIFF
--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -32,6 +32,12 @@ export const observe = (
 ): PerformanceObserver | undefined => {
   try {
     if (PerformanceObserver.supportedEntryTypes.includes(type)) {
+      // More extensive feature detect needed for Firefox due to:
+      // https://github.com/GoogleChrome/web-vitals/issues/142
+      if (type === 'first-input' && !('PerformanceEventTiming' in self)) {
+        return;
+      }
+
       const po: PerformanceObserver =
           new PerformanceObserver((l) => l.getEntries().map(callback));
 

--- a/test/utils/browserSupportsEntry.js
+++ b/test/utils/browserSupportsEntry.js
@@ -22,6 +22,12 @@
  */
 function browserSupportsEntry(type) {
   return browser.execute((type) => {
+    // More extensive feature detect needed for Firefox due to:
+    // https://github.com/GoogleChrome/web-vitals/issues/142
+    if (type === 'first-input' && !('PerformanceEventTiming' in window)) {
+      return false;
+    }
+
     return window.PerformanceObserver &&
         window.PerformanceObserver.supportedEntryTypes &&
         window.PerformanceObserver.supportedEntryTypes.includes(type);


### PR DESCRIPTION
This PR fixes #142 by adding a more extensive FID feature detect. With this new feature detect Firefox 88 correctly uses the FID polyfill and Firefox 89 (beta) correctly uses the native version.