### PR TITLE
Add workaround for Safari FCP bug

### DIFF
--- a/src/getFCP.ts
+++ b/src/getFCP.ts
@@ -44,9 +44,17 @@ export const getFCP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
     }
   };
 
-  const po = observe('paint', entryHandler);
-  if (po) {
+  // TODO(philipwalton): remove the use of `fcpEntry` once this bug is fixed.
+  // https://bugs.webkit.org/show_bug.cgi?id=225305
+  const fcpEntry = performance.getEntriesByName('first-contentful-paint')[0];
+  const po = fcpEntry ? null : observe('paint', entryHandler);
+
+  if (fcpEntry || po) {
     report = bindReporter(onReport, metric, reportAllChanges);
+
+    if (fcpEntry) {
+      entryHandler(fcpEntry);
+    }
 
     onBFCacheRestore((event) => {
       metric = initMetric('FCP');


### PR DESCRIPTION
This PR fixes #144 by first checking `performance.getEntriesByName('first-contentful-paint')` before registering the `PerformanceObserver`. If a valid entry is returned, then using `PerformanceObserver` is not needed. If no entry is returned it means either:

- Paint Timing is not supported, or
- The browser has not painted yet

In either case `PerformanceObserver` can be used as a fallback.