### PR TITLE
Ignore negative TTFB values in Firefox

### DIFF
--- a/src/getTTFB.ts
+++ b/src/getTTFB.ts
@@ -59,6 +59,10 @@ export const getTTFB = (onReport: ReportHandler) => {
       metric.value = metric.delta =
           (navigationEntry as PerformanceNavigationTiming).responseStart;
 
+      // In some cases the value reported is negative. Ignore these cases:
+      // https://github.com/GoogleChrome/web-vitals/issues/137
+      if (metric.value < 0) return;
+
       metric.entries = [navigationEntry];
 
       onReport(metric);

--- a/test/utils/afterLoad.js
+++ b/test/utils/afterLoad.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Returns a promise that resolves once the browser window has loaded and
+ * all load callbacks have finished executing.
+ * @return {Promise<void>}
+ */
+function afterLoad() {
+  return browser.executeAsync((done) => {
+    if (document.readyState === 'complete') {
+      setTimeout(done, 0);
+    } else {
+      addEventListener('pageshow', done);
+    }
+  });
+}
+
+module.exports = {
+  afterLoad,
+};


### PR DESCRIPTION
This PR fixes https://github.com/GoogleChrome/web-vitals/issues/137 by ignoring (i.e. not reporting) any negative TTFB values it encounters, under the assumption that those values cannot be trusted.

The implication of this is that TTFB may not be reported on all pages.