### PR TITLE
Update CLS to max session window 5s cap 1s gap

### DIFF
--- a/test/views/layout.njk
+++ b/test/views/layout.njk
@@ -44,19 +44,22 @@
   {% endif %}
   {% block head %}{% endblock %}
   <style>
-    html {
-      height: 100%
+    * {
+      box-sizing: border-box;
+    }
+    *[hidden] {
+      visibility: hidden;
     }
     body {
       font: 1em/1.5 sans-serif;
       margin: 0;
-      min-height: 100%;
     }
     main {
+      border: 1px solid transparent; /* Prevent margin collapsing */
+      min-height: 100vh;
       padding: 0 1em;
-    }
-    *[hidden] {
-      visibility: hidden;
+      position: relative;
+      width: 100%;
     }
   </style>
 </head>


### PR DESCRIPTION
Fixes #136. This PR updates the implementation of CLS to use new definition outlined in the post [Evolving CLS](https://web.dev/evolving-cls/)—a max session window with 5-second max and 1-second gap.

The only observable difference developers might notice to the API is previously the `metric.entries` array would only ever add new entries as additional shifts occurred on the page. With this change, only the entries from the max session window are reported, which means it could be the case the some of the entries referenced when CLS is first reported (e.g. after the tab is backgrounded), may not be the entries that are referenced the next time the tab is backgrounded. Developers not referencing the `metric.entries` array should not notice any differences other than a possible reduction in the value reported.