### PR TITLE
Only report CLS when FCP is reported

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,11 +444,14 @@ The following table lists all the bundles distributed with the `web-vitals` pack
 
 Most developers will generally want to use the "standard" bundle (either the ES module or UMD version, depending on your build system), as it's the easiest to use out of the box and integrate into existing build tools.
 
-However, developers willing to manage the additional usage complexity should consider the "base+polyfill" bundle if they would like to measure FID in all browsers.
+However, there are a few good reasons to consider using the "base+polyfill" version, for example:
+
+- FID can be measured in all browsers.
+- CLS, FCP, FID, and LCP will be more accurate in some cases (since the polyfill detects the page's initial `visibilityState` earlier).
 
 ### How the polyfill works
 
-The `polyfill.js` script adds event listeners that record the event processing delay of the first input, and then removes those event listeners after the first input occurs.
+The `polyfill.js` script adds event listeners (to track FID cross-browser), and it records initial page visibility state as well as the timestamp of the first visibility change to hidden (to improve the accuracy of CLS, FCP, LCP, and FID).
 
 In order for it to work properly, the script must be the first script added to the page, and it must run before the browser renders any content to the screen. This is why it needs to be added to the `<head>` of the document.
 
@@ -527,6 +530,7 @@ If using the "base+polyfill" build, the `polyfill.js` script creates the global 
 interface WebVitalsGlobal {
   firstInputPolyfill: (onFirstInput: FirstInputPolyfillCallback) => void;
   resetFirstInputPolyfill: () => void;
+  firstHiddenTime: number;
 }
 ```
 

--- a/src/lib/polyfills/getFirstHiddenTimePolyfill.ts
+++ b/src/lib/polyfills/getFirstHiddenTimePolyfill.ts
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-import {firstInputPolyfill, resetFirstInputPolyfill} from './lib/polyfills/firstInputPolyfill.js';
-import {getFirstHiddenTime} from './lib/polyfills/getFirstHiddenTimePolyfill.js';
+let firstHiddenTime =
+    document.visibilityState === 'hidden' ? 0 : Infinity;
 
-resetFirstInputPolyfill();
-self.webVitals = {
-  firstInputPolyfill: firstInputPolyfill,
-  resetFirstInputPolyfill: resetFirstInputPolyfill,
-  get firstHiddenTime() {
-    return getFirstHiddenTime();
-  },
-};
+const onVisibilityChange = (event: Event) => {
+  if (document.visibilityState === 'hidden') {
+    firstHiddenTime = event.timeStamp;
+    removeEventListener('visibilitychange', onVisibilityChange, true);
+  }
+}
+
+// Note: do not add event listeners unconditionally (outside of polyfills).
+addEventListener('visibilitychange', onVisibilityChange, true);
+
+export const getFirstHiddenTime = () => firstHiddenTime;

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export type NavigationTimingPolyfillEntry = Omit<PerformanceNavigationTiming,
 export interface WebVitalsGlobal {
   firstInputPolyfill: (onFirstInput: FirstInputPolyfillCallback) => void;
   resetFirstInputPolyfill: () => void;
+  firstHiddenTime: number;
 }
 
 declare global {

--- a/test/e2e/getCLS-test.js
+++ b/test/e2e/getCLS-test.js
@@ -17,12 +17,16 @@
 const assert = require('assert');
 const {beaconCountIs, clearBeacons, getBeacons} = require('../utils/beacons.js');
 const {browserSupportsEntry} = require('../utils/browserSupportsEntry.js');
+const {afterLoad} = require('../utils/afterLoad.js');
 const {imagesPainted} = require('../utils/imagesPainted.js');
 const {stubForwardBack} = require('../utils/stubForwardBack.js');
 const {stubVisibilityChange} = require('../utils/stubVisibilityChange.js');
 
 
 describe('getCLS()', async function() {
+  // Retry all tests in this suite up to 2 times.
+  this.retries(2);
+
   let browserSupportsCLS;
   before(async function() {
     browserSupportsCLS = await browserSupportsEntry('layout-shift');
@@ -432,6 +436,8 @@ describe('getCLS()', async function() {
 
     await browser.url(`/test/cls?noLayoutShifts=1`);
 
+    // Wait until the page is loaded before hiding.
+    await afterLoad();
     await stubVisibilityChange('hidden');
 
     await beaconCountIs(1);
@@ -449,6 +455,8 @@ describe('getCLS()', async function() {
 
     await browser.url(`/test/cls?reportAllChanges=1&noLayoutShifts=1`);
 
+    // Wait until the page is loaded before hiding.
+    await afterLoad();
     await stubVisibilityChange('hidden');
 
     await beaconCountIs(1);
@@ -466,6 +474,8 @@ describe('getCLS()', async function() {
 
     await browser.url(`/test/cls?noLayoutShifts=1`);
 
+    // Wait until the page is loaded before navigating away.
+    await afterLoad();
     await browser.url('about:blank');
 
     await beaconCountIs(1);
@@ -483,6 +493,8 @@ describe('getCLS()', async function() {
 
     await browser.url(`/test/cls?noLayoutShifts=1&reportAllChanges=1`);
 
+    // Wait until the page is loaded before navigating away.
+    await afterLoad();
     await browser.url('about:blank');
 
     await beaconCountIs(1);

--- a/test/e2e/getFCP-test.js
+++ b/test/e2e/getFCP-test.js
@@ -21,6 +21,9 @@ const {stubForwardBack} = require('../utils/stubForwardBack.js');
 const {stubVisibilityChange} = require('../utils/stubVisibilityChange.js');
 
 describe('getFCP()', async function() {
+  // Retry all tests in this suite up to 2 times.
+  this.retries(2);
+
   let browserSupportsFCP;
   before(async function() {
     browserSupportsFCP = await browserSupportsEntry('paint');

--- a/test/e2e/getFID-test.js
+++ b/test/e2e/getFID-test.js
@@ -22,6 +22,9 @@ const {stubVisibilityChange} = require('../utils/stubVisibilityChange.js');
 
 
 describe('getFID()', async function() {
+  // Retry all tests in this suite up to 2 times.
+  this.retries(2);
+
   let browserSupportsFID;
   before(async function() {
     browserSupportsFID = await browserSupportsEntry('first-input');

--- a/test/e2e/getLCP-test.js
+++ b/test/e2e/getLCP-test.js
@@ -22,6 +22,9 @@ const {stubVisibilityChange} = require('../utils/stubVisibilityChange.js');
 
 
 describe('getLCP()', async function() {
+  // Retry all tests in this suite up to 2 times.
+  this.retries(2);
+
   let browserSupportsLCP;
   before(async function() {
     browserSupportsLCP = await browserSupportsEntry('largest-contentful-paint');

--- a/test/e2e/getTTFB-test.js
+++ b/test/e2e/getTTFB-test.js
@@ -61,6 +61,9 @@ function assertValidEntry(entry) {
 }
 
 describe('getTTFB()', async function() {
+  // Retry all tests in this suite up to 2 times.
+  this.retries(2);
+
   beforeEach(async function() {
     await clearBeacons();
   });


### PR DESCRIPTION
This PR updates the work done in #149 to only report CLS if the page also reported FCP.

The downside of this change is measuring CLS now includes a dependency on the FCP logic (even for developers not monitoring FCP directly). The benefit, though, is that it better aligns with the current behavior of CrUX.

The goal of this library is to align with CrUX as much as possible, so the additional dependency is necessary to achieve the best alignment.