### PR TITLE
Update the unique ID version prefix

### DIFF
--- a/src/lib/generateUniqueID.ts
+++ b/src/lib/generateUniqueID.ts
@@ -20,5 +20,5 @@
  * @return {string}
  */
 export const generateUniqueID = () => {
-  return `v1-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
+  return `v2-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
 };

--- a/test/e2e/getCLS-test.js
+++ b/test/e2e/getCLS-test.js
@@ -49,7 +49,7 @@ describe('getCLS()', async function() {
 
     const [cls] = await getBeacons();
     assert(cls.value >= 0);
-    assert(cls.id.match(/^v1-\d+-\d+$/));
+    assert(cls.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, cls.delta);
     assert.strictEqual(cls.entries.length, 2);
@@ -68,7 +68,7 @@ describe('getCLS()', async function() {
 
     const [cls] = await getBeacons();
     assert(cls.value >= 0);
-    assert(cls.id.match(/^v1-\d+-\d+$/));
+    assert(cls.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, cls.delta);
     assert.strictEqual(cls.entries.length, 2);
@@ -89,7 +89,7 @@ describe('getCLS()', async function() {
     const [cls1] = await getBeacons();
 
     assert(cls1.value >= 0);
-    assert(cls1.id.match(/^v1-\d+-\d+$/));
+    assert(cls1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.entries.length, 2);
@@ -118,7 +118,7 @@ describe('getCLS()', async function() {
     assert.strictEqual(cls2.name, 'CLS');
     assert.strictEqual(cls2.value, cls1.value + cls2.delta);
     assert.strictEqual(cls2.entries.length, 2);
-    assert(cls2.id.match(/^v1-\d+-\d+$/));
+    assert(cls2.id.match(/^v2-\d+-\d+$/));
 
     await browser.pause(1000);
     await stubVisibilityChange('visible');
@@ -149,7 +149,7 @@ describe('getCLS()', async function() {
     assert.strictEqual(cls3.name, 'CLS');
     assert.strictEqual(cls3.value, cls2.value + cls3.delta);
     assert.strictEqual(cls3.entries.length, 4);
-    assert(cls3.id.match(/^v1-\d+-\d+$/));
+    assert(cls3.id.match(/^v2-\d+-\d+$/));
 
     await browser.pause(1000);
     await stubVisibilityChange('visible');
@@ -203,7 +203,7 @@ describe('getCLS()', async function() {
     const [cls1, cls2] = await getBeacons();
 
     assert(cls1.value >= 0);
-    assert(cls1.id.match(/^v1-\d+-\d+$/));
+    assert(cls1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.entries.length, 1);
@@ -235,7 +235,7 @@ describe('getCLS()', async function() {
     const [cls1, cls2] = await getBeacons();
 
     assert(cls1.value >= 0);
-    assert(cls1.id.match(/^v1-\d+-\d+$/));
+    assert(cls1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.entries.length, 1);
 
@@ -271,7 +271,7 @@ describe('getCLS()', async function() {
 
     assert(cls1.value >= 0);
     assert(cls1.delta >= 0);
-    assert(cls1.id.match(/^v1-\d+-\d+$/));
+    assert(cls1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.entries.length, 2);
@@ -306,7 +306,7 @@ describe('getCLS()', async function() {
     const [cls1, cls2] = await getBeacons();
 
     assert(cls1.value > 0);
-    assert(cls1.id.match(/^v1-\d+-\d+$/));
+    assert(cls1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.entries.length, 1);
@@ -351,7 +351,7 @@ describe('getCLS()', async function() {
     const [cls1] = await getBeacons();
 
     assert(cls1.value >= 0);
-    assert(cls1.id.match(/^v1-\d+-\d+$/));
+    assert(cls1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls1.delta, cls1.value);
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
@@ -366,7 +366,7 @@ describe('getCLS()', async function() {
     const [cls2] = await getBeacons();
 
     assert(cls2.value >= 0);
-    assert(cls2.id.match(/^v1-\d+-\d+$/));
+    assert(cls2.id.match(/^v2-\d+-\d+$/));
     assert(cls2.id !== cls1.id);
 
     assert.strictEqual(cls2.delta, cls2.value);
@@ -383,7 +383,7 @@ describe('getCLS()', async function() {
     const [cls3] = await getBeacons();
 
     assert(cls3.value >= 0);
-    assert(cls3.id.match(/^v1-\d+-\d+$/));
+    assert(cls3.id.match(/^v2-\d+-\d+$/));
     assert(cls3.id !== cls2.id);
 
     assert.strictEqual(cls3.delta, cls3.value);
@@ -401,7 +401,7 @@ describe('getCLS()', async function() {
     const [cls1, cls2] = await getBeacons();
 
     assert(cls1.value > 0);
-    assert(cls1.id.match(/^v1-\d+-\d+$/));
+    assert(cls1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.entries.length, 1);
@@ -424,7 +424,7 @@ describe('getCLS()', async function() {
     const [cls3] = await getBeacons();
 
     assert(cls3.value > 0);
-    assert(cls3.id.match(/^v1-\d+-\d+$/));
+    assert(cls3.id.match(/^v2-\d+-\d+$/));
     assert(cls3.id !== cls2.id);
     assert.strictEqual(cls3.name, 'CLS');
     assert.strictEqual(cls3.value, cls3.delta);
@@ -443,7 +443,7 @@ describe('getCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls] = await getBeacons();
-    assert(cls.id.match(/^v1-\d+-\d+$/));
+    assert(cls.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
@@ -462,7 +462,7 @@ describe('getCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls] = await getBeacons();
-    assert(cls.id.match(/^v1-\d+-\d+$/));
+    assert(cls.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
@@ -481,7 +481,7 @@ describe('getCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls] = await getBeacons();
-    assert(cls.id.match(/^v1-\d+-\d+$/));
+    assert(cls.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
@@ -500,7 +500,7 @@ describe('getCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls] = await getBeacons();
-    assert(cls.id.match(/^v1-\d+-\d+$/));
+    assert(cls.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
@@ -537,7 +537,7 @@ describe('getCLS()', async function() {
     const [cls] = await getBeacons();
 
     assert(cls.value >= 0);
-    assert(cls.id.match(/^v1-\d+-\d+$/));
+    assert(cls.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.delta, cls.value);
     assert.strictEqual(cls.entries.length, 1);

--- a/test/e2e/getFCP-test.js
+++ b/test/e2e/getFCP-test.js
@@ -42,7 +42,7 @@ describe('getFCP()', async function() {
 
     const [fcp] = await getBeacons();
     assert(fcp.value >= 0);
-    assert(fcp.id.match(/^v1-\d+-\d+$/));
+    assert(fcp.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(fcp.name, 'FCP');
     assert.strictEqual(fcp.value, fcp.delta);
     assert.strictEqual(fcp.entries.length, 1);
@@ -107,7 +107,7 @@ describe('getFCP()', async function() {
 
     const [fcp1] = await getBeacons();
     assert(fcp1.value >= 0);
-    assert(fcp1.id.match(/^v1-\d+-\d+$/));
+    assert(fcp1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(fcp1.name, 'FCP');
     assert.strictEqual(fcp1.value, fcp1.delta);
     assert.strictEqual(fcp1.entries.length, 1);
@@ -119,7 +119,7 @@ describe('getFCP()', async function() {
 
     const [fcp2] = await getBeacons();
     assert(fcp2.value >= 0);
-    assert(fcp2.id.match(/^v1-\d+-\d+$/));
+    assert(fcp2.id.match(/^v2-\d+-\d+$/));
     assert(fcp2.id !== fcp1.id);
     assert.strictEqual(fcp2.name, 'FCP');
     assert.strictEqual(fcp2.value, fcp2.delta);
@@ -132,7 +132,7 @@ describe('getFCP()', async function() {
 
     const [fcp3] = await getBeacons();
     assert(fcp3.value >= 0);
-    assert(fcp3.id.match(/^v1-\d+-\d+$/));
+    assert(fcp3.id.match(/^v2-\d+-\d+$/));
     assert(fcp3.id !== fcp2.id);
     assert.strictEqual(fcp3.name, 'FCP');
     assert.strictEqual(fcp3.value, fcp3.delta);
@@ -158,7 +158,7 @@ describe('getFCP()', async function() {
 
     const [fcp1] = await getBeacons();
     assert(fcp1.value >= 0);
-    assert(fcp1.id.match(/^v1-\d+-\d+$/));
+    assert(fcp1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(fcp1.name, 'FCP');
     assert.strictEqual(fcp1.value, fcp1.delta);
     assert.strictEqual(fcp1.entries.length, 0);
@@ -170,7 +170,7 @@ describe('getFCP()', async function() {
 
     const [fcp2] = await getBeacons();
     assert(fcp2.value >= 0);
-    assert(fcp2.id.match(/^v1-\d+-\d+$/));
+    assert(fcp2.id.match(/^v2-\d+-\d+$/));
     assert(fcp2.id !== fcp1.id);
     assert.strictEqual(fcp2.name, 'FCP');
     assert.strictEqual(fcp2.value, fcp2.delta);

--- a/test/e2e/getFID-test.js
+++ b/test/e2e/getFID-test.js
@@ -47,7 +47,7 @@ describe('getFID()', async function() {
 
     const [fid] = await getBeacons();
     assert(fid.value >= 0);
-    assert(fid.id.match(/^v1-\d+-\d+$/));
+    assert(fid.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.entries[0].name, 'mousedown');
@@ -97,7 +97,7 @@ describe('getFID()', async function() {
     const [fid] = await getBeacons();
 
     assert(fid.value >= 0);
-    assert(fid.id.match(/^v1-\d+-\d+$/));
+    assert(fid.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.entries[0].name, 'mousedown');
@@ -162,7 +162,7 @@ describe('getFID()', async function() {
 
     const [fid1] = await getBeacons();
     assert(fid1.value >= 0);
-    assert(fid1.id.match(/^v1-\d+-\d+$/));
+    assert(fid1.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(fid1.name, 'FID');
     assert.strictEqual(fid1.value, fid1.delta);
     assert.strictEqual(fid1.entries[0].name, 'mousedown');
@@ -177,7 +177,7 @@ describe('getFID()', async function() {
 
     const [fid2] = await getBeacons();
     assert(fid2.value >= 0);
-    assert(fid2.id.match(/^v1-\d+-\d+$/));
+    assert(fid2.id.match(/^v2-\d+-\d+$/));
     assert(fid1.id !== fid2.id);
     assert.strictEqual(fid2.name, 'FID');
     assert.strictEqual(fid2.value, fid2.delta);

--- a/test/e2e/getLCP-test.js
+++ b/test/e2e/getLCP-test.js
@@ -230,7 +230,7 @@ const assertStandardReportsAreCorrect = (beacons) => {
   const [lcp] = beacons;
 
   assert(lcp.value > 500); // Greater than the image load delay.
-  assert(lcp.id.match(/^v1-\d+-\d+$/));
+  assert(lcp.id.match(/^v2-\d+-\d+$/));
   assert.strictEqual(lcp.name, 'LCP');
   assert.strictEqual(lcp.value, lcp.delta);
   assert.strictEqual(lcp.entries.length, 2);
@@ -240,7 +240,7 @@ const assertFullReportsAreCorrect = (beacons) => {
   const [lcp1, lcp2] = beacons;
 
   assert(lcp1.value < 500); // Less than the image load delay.
-  assert(lcp1.id.match(/^v1-\d+-\d+$/));
+  assert(lcp1.id.match(/^v2-\d+-\d+$/));
   assert.strictEqual(lcp1.name, 'LCP');
   assert.strictEqual(lcp1.value, lcp1.delta);
   assert.strictEqual(lcp1.entries.length, 1);

--- a/test/e2e/getTTFB-test.js
+++ b/test/e2e/getTTFB-test.js
@@ -81,7 +81,7 @@ describe('getTTFB()', async function() {
     assert(ttfb.value >= 0);
     assert(ttfb.value >= ttfb.entries[0].requestStart);
     assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
-    assert(ttfb.id.match(/^v1-\d+-\d+$/));
+    assert(ttfb.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.entries.length, 1);
@@ -102,7 +102,7 @@ describe('getTTFB()', async function() {
     assert(ttfb.value >= 0);
     assert(ttfb.value >= ttfb.entries[0].requestStart);
     assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
-    assert(ttfb.id.match(/^v1-\d+-\d+$/));
+    assert(ttfb.id.match(/^v2-\d+-\d+$/));
     assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.entries.length, 1);


### PR DESCRIPTION
This PR updates the unique ID version prefix, which is exposed in the `id` property of the [`Metric`](https://github.com/GoogleChrome/web-vitals#metric) object. This change will allow users to detect the (upcoming) major version change from this library in their RUM data.