### PR TITLE
check for getEntriesByName in performance before calling

### DIFF
--- a/src/getFCP.ts
+++ b/src/getFCP.ts
@@ -46,7 +46,7 @@ export const getFCP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
 
   // TODO(philipwalton): remove the use of `fcpEntry` once this bug is fixed.
   // https://bugs.webkit.org/show_bug.cgi?id=225305
-  const fcpEntry = performance.getEntriesByName('first-contentful-paint')[0];
+  const fcpEntry = 'getEntriesByName' in performance ? performance.getEntriesByName('first-contentful-paint')[0] : null;
   const po = fcpEntry ? null : observe('paint', entryHandler);
 
   if (fcpEntry || po) {


### PR DESCRIPTION
Resolves https://github.com/GoogleChrome/web-vitals/issues/159

Fixes the web-vitals package breaking applications in Opera Mini.

`getEntriesByName` is [not supported](https://caniuse.com/?search=getEntriesByName) in some version of Opera.

First reported here https://github.com/bbc/simorgh/pull/9153