### PR TITLE
Updates the TTFB link in the README to the web.dev metric page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The library supports all of the [Core Web Vitals](https://web.dev/vitals/#core-w
 ### Other Web Vitals
 
 - [First Contentful Paint (FCP)](https://web.dev/fcp/)
-- [Time to First Byte (TTFB)](https://web.dev/time-to-first-byte/)
+- [Time to First Byte (TTFB)](https://web.dev/ttfb/)
 
 <a name="installation"><a>
 <a name="load-the-library"><a>


### PR DESCRIPTION
Updates `README.md`'s reference to [the current TTFB metric page](https://web.dev/time-to-first-byte/) to point the new page that will eventually live at https://web.dev/ttfb/