### PR TITLE
Disconnect performance observer when page is already hidden

### DIFF
--- a/src/lib/getVisibilityWatcher.ts
+++ b/src/lib/getVisibilityWatcher.ts
@@ -26,7 +26,7 @@ const initHiddenTime = () => {
 const trackChanges = () => {
   // Update the time if/when the document becomes hidden.
   onHidden(({timeStamp}) => {
-    firstHiddenTime = timeStamp
+    firstHiddenTime = timeStamp || initHiddenTime();
   }, true);
 };
 

--- a/src/lib/onHidden.ts
+++ b/src/lib/onHidden.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
+type Event = { type?: string, timeStamp?: number };
 
-export interface OnHiddenCallback {
-  (event: Event): void;
-}
+export type OnHiddenCallback = (event: Event) => void;
 
 
 export const onHidden = (cb: OnHiddenCallback, once?: boolean) => {
@@ -34,4 +33,7 @@ export const onHidden = (cb: OnHiddenCallback, once?: boolean) => {
   // Some browsers have buggy implementations of visibilitychange,
   // so we use pagehide in addition, just to be safe.
   addEventListener('pagehide', onHiddenOrPageHide, true);
+
+  // if the document is already hidden
+  onHiddenOrPageHide({});
 };


### PR DESCRIPTION
Added a check in onHidden.ts, to check if page is already hidden when onHidden() is called. This would allow listeners like FID, LCP to disconnect performance observer whenever the page is hidden