### PR TITLE
Report LCP only if the value changes

### DIFF
--- a/src/getLCP.ts
+++ b/src/getLCP.ts
@@ -40,9 +40,8 @@ export const getLCP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
     if (value < visibilityWatcher.firstHiddenTime) {
       metric.value = value;
       metric.entries.push(entry);
+      report();
     }
-
-    report();
   };
 
   const po = observe('largest-contentful-paint', entryHandler);


### PR DESCRIPTION
Report LCP only if the value changes. To keep things consistent with other metrics