### PR TITLE
Prevent TTFB from reporting after bfcache restore

### DIFF
--- a/src/getTTFB.ts
+++ b/src/getTTFB.ts
@@ -23,8 +23,8 @@ const afterLoad = (callback: () => void) => {
     // Queue a task so the callback runs after `loadEventEnd`.
     setTimeout(callback, 0);
   } else {
-    // Use `pageshow` so the callback runs after `loadEventEnd`.
-    addEventListener('pageshow', callback);
+    // Queue a task so the callback runs after `loadEventEnd`.
+    addEventListener('load', () => setTimeout(callback, 0));
   }
 }
 

--- a/test/utils/afterLoad.js
+++ b/test/utils/afterLoad.js
@@ -25,7 +25,7 @@ function afterLoad() {
     if (document.readyState === 'complete') {
       setTimeout(done, 0);
     } else {
-      addEventListener('pageshow', done);
+      addEventListener('load', () => setTimeout(done, 0));
     }
   });
 }


### PR DESCRIPTION
Fixes #200.

This PR updates the event used to wait for load in `getTTFB()` from `pageshow` to `load` + `setTimeout(0)`. It also adds a test to check that no metrics are reported after a bfcache restore.