### PR TITLE
Only include last LCP entry in metric entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,9 +550,10 @@ interface Metric {
   // together and calculate a total.
   id: string;
 
-  // Any performance entries used in the metric value calculation.
-  // Note, entries will be added to the array as the value changes.
-  entries: (PerformanceEntry | FirstInputPolyfillEntry | NavigationTimingPolyfillEntry)[];
+  // Any performance entries relevant to the metric value calculation.
+  // The array may also be empty if the metric value was not based on any
+  // entries (e.g. a CLS value of 0 given no layout shifts).
+  entries: (PerformanceEntry | LayoutShift | FirstInputPolyfillEntry | NavigationTimingPolyfillEntry)[];
 }
 ```
 

--- a/test/e2e/getLCP-test.js
+++ b/test/e2e/getLCP-test.js
@@ -233,7 +233,7 @@ const assertStandardReportsAreCorrect = (beacons) => {
   assert(lcp.id.match(/^v2-\d+-\d+$/));
   assert.strictEqual(lcp.name, 'LCP');
   assert.strictEqual(lcp.value, lcp.delta);
-  assert.strictEqual(lcp.entries.length, 2);
+  assert.strictEqual(lcp.entries.length, 1);
 };
 
 const assertFullReportsAreCorrect = (beacons) => {
@@ -249,5 +249,6 @@ const assertFullReportsAreCorrect = (beacons) => {
   assert.strictEqual(lcp2.value, lcp1.value + lcp2.delta);
   assert.strictEqual(lcp2.name, 'LCP');
   assert.strictEqual(lcp2.id, lcp1.id);
-  assert.strictEqual(lcp2.entries.length, 2);
+  assert.strictEqual(lcp2.entries.length, 1);
+  assert(lcp2.entries[0].startTime > lcp1.entries[0].startTime);
 };


### PR DESCRIPTION
Fixes #216.

This PR updates the `getLCP()` logic to only add the last `largest-contentful-paint` entry to the `Metric.entries` object. This is consistent with how entries are exposed for all other metrics.
