### PR TITLE
Finish adding getINP()

### DIFF
--- a/src/lib/polyfills/interactionCountPolyfill.ts
+++ b/src/lib/polyfills/interactionCountPolyfill.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {observe} from '../observe.js';
+import {Metric, PerformanceEventTiming} from '../../types.js';
+
+
+declare global {
+  interface Performance {
+    interactionCount: number;
+  }
+}
+
+let interactionCountEstimate = 0;
+let minKnownInteractionId = Infinity;
+let maxKnownInteractionId = 0;
+
+const updateEstimate = (entries: Metric['entries']) => {
+  (entries as PerformanceEventTiming[]).forEach((e) => {
+    if (e.interactionId) {
+      minKnownInteractionId = Math.min(minKnownInteractionId, e.interactionId);
+      maxKnownInteractionId = Math.max(maxKnownInteractionId, e.interactionId);
+
+      interactionCountEstimate = maxKnownInteractionId ?
+          (maxKnownInteractionId - minKnownInteractionId) / 7 + 1 : 0;
+    }
+  });
+}
+
+let po: PerformanceObserver | undefined;
+
+/**
+ * Returns the `interactionCount` value using the native API (if available)
+ * or the polyfill estimate in this module.
+ */
+export const getInteractionCount = () => {
+  return po ? interactionCountEstimate : performance.interactionCount || 0;
+}
+
+/**
+ * Feature detects native support or initializes the polyfill if needed.
+ */
+export const initInteractionCountPolyfill = () => {
+  if ('interactionCount' in performance || po) return;
+
+  po = observe('event', updateEstimate, {
+    type: 'event',
+    buffered: true,
+    durationThreshold: 0,
+  } as PerformanceObserverInit);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,10 @@ export interface LayoutShift extends PerformanceEntry {
   hadRecentInput: boolean;
 }
 
+export interface PerformanceObserverInit {
+  durationThreshold?: number;
+}
+
 export type FirstInputPolyfillEntry =
     Omit<PerformanceEventTiming, 'processingEnd'>
 

--- a/test/e2e/getINP-test.js
+++ b/test/e2e/getINP-test.js
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('assert');
+const {beaconCountIs, clearBeacons, getBeacons} = require('../utils/beacons.js');
+const {browserSupportsEntry} = require('../utils/browserSupportsEntry.js');
+const {stubForwardBack} = require('../utils/stubForwardBack.js');
+const {stubVisibilityChange} = require('../utils/stubVisibilityChange.js');
+
+
+describe('getINP()', async function() {
+  // Retry all tests in this suite up to 2 times.
+  this.retries(2);
+
+  let browserSupportsINP;
+  before(async function() {
+    browserSupportsINP = await browserSupportsEntry('event');
+  });
+
+  beforeEach(async function() {
+    await clearBeacons();
+  });
+
+  it('reports the correct value on visibility hidden after interactions (reportAllChanges === false)', async function() {
+    if (!browserSupportsINP) this.skip();
+
+    await browser.url('/test/inp?click=100');
+
+    const h1 = await $('h1');
+    await h1.click();
+
+    await stubVisibilityChange('hidden');
+
+    await beaconCountIs(1);
+
+    const [inp] = await getBeacons();
+    assert(inp.value >= 0);
+    assert(inp.id.match(/^v2-\d+-\d+$/));
+    assert.strictEqual(inp.name, 'INP');
+    assert.strictEqual(inp.value, inp.delta);
+    assert(containsEntry(inp.entries, 'click', 'h1'));
+    assert(interactionIDsMatch(inp.entries));
+    assert(inp.entries[0].interactionId > 0);
+    assert.match(inp.navigationType, /navigate|reload/);
+  });
+
+  it('reports the correct value on visibility hidden after interactions (reportAllChanges === true)', async function() {
+    if (!browserSupportsINP) this.skip();
+
+    await browser.url('/test/inp?click=100&reportAllChanges=1');
+
+    const h1 = await $('h1');
+    await h1.click();
+
+    await stubVisibilityChange('hidden');
+
+    await beaconCountIs(1);
+
+    const [inp] = await getBeacons();
+    assert(inp.value >= 0);
+    assert(inp.id.match(/^v2-\d+-\d+$/));
+    assert.strictEqual(inp.name, 'INP');
+    assert.strictEqual(inp.value, inp.delta);
+    assert(containsEntry(inp.entries, 'click', 'h1'));
+    assert(interactionIDsMatch(inp.entries));
+    assert(inp.entries[0].interactionId > 0);
+    assert.match(inp.navigationType, /navigate|reload/);
+  });
+
+  it('reports the correct value on page unload after interactions (reportAllChanges === false)', async function() {
+    if (!browserSupportsINP) this.skip();
+
+    await browser.url('/test/inp?click=100');
+
+    const h1 = await $('h1');
+    await h1.click();
+
+    await browser.url('about:blank');
+
+    await beaconCountIs(1);
+
+    const [inp] = await getBeacons();
+    assert(inp.value >= 0);
+    assert(inp.id.match(/^v2-\d+-\d+$/));
+    assert.strictEqual(inp.name, 'INP');
+    assert.strictEqual(inp.value, inp.delta);
+    assert(containsEntry(inp.entries, 'click', 'h1'));
+    assert(interactionIDsMatch(inp.entries));
+    assert(inp.entries[0].interactionId > 0);
+    assert.match(inp.navigationType, /navigate|reload/);
+  });
+
+  it('reports the correct value on page unload after interactions (reportAllChanges === true)', async function() {
+    if (!browserSupportsINP) this.skip();
+
+    await browser.url('/test/inp?click=100&reportAllChanges=1');
+
+    const h1 = await $('h1');
+    await h1.click();
+
+    await browser.url('about:blank');
+
+    await beaconCountIs(1);
+
+    const [inp] = await getBeacons();
+    assert(inp.value >= 0);
+    assert(inp.id.match(/^v2-\d+-\d+$/));
+    assert.strictEqual(inp.name, 'INP');
+    assert.strictEqual(inp.value, inp.delta);
+    assert(containsEntry(inp.entries, 'click', 'h1'));
+    assert(interactionIDsMatch(inp.entries));
+    assert(inp.entries[0].interactionId > 0);
+    assert.match(inp.navigationType, /navigate|reload/);
+  });
+
+  it('reports approx p98 interaction when 50+ interactions (reportAllChanges === false)', async function() {
+    if (!browserSupportsINP) this.skip();
+
+    await browser.url('/test/inp?click=60&pointerdown=600');
+
+    const h1 = await $('h1');
+    await h1.click();
+
+    await setBlockingTime('pointerdown', 400);
+    await h1.click();
+
+    await setBlockingTime('pointerdown', 200);
+    await h1.click();
+
+    await setBlockingTime('pointerdown', 0);
+
+    await stubVisibilityChange('hidden');
+    await beaconCountIs(1);
+
+    const [inp1] = await getBeacons();
+    assert(inp1.value >= 600); // Initial pointerdown blocking time.
+
+    await clearBeacons();
+    await stubVisibilityChange('visible');
+
+    let count = 3;
+    while (count < 50) {
+      await h1.click();
+      count++;
+    }
+
+    await stubVisibilityChange('hidden');
+    await beaconCountIs(1);
+
+    const [inp2] = await getBeacons();
+    assert(inp2.value >= 400); // Initial pointerdown blocking time.
+    assert(inp2.value < inp1.value); // Should have gone down.
+
+    await clearBeacons();
+    await stubVisibilityChange('visible');
+
+    while (count < 100) {
+      await h1.click();
+      count++;
+    }
+
+    await stubVisibilityChange('hidden');
+    await beaconCountIs(1);
+
+    const [inp3] = await getBeacons();
+    assert(inp3.value >= 200); // 2nd-highest pointerdown blocking time.
+    assert(inp3.value < inp2.value); // Should have gone down.
+  });
+
+  it('reports approx p98 interaction when 50+ interactions (reportAllChanges === true)', async function() {
+    if (!browserSupportsINP) this.skip();
+
+    await browser.url('/test/inp?click=60&pointerdown=600&reportAllChanges=1');
+
+    const h1 = await $('h1');
+    await h1.click();
+
+    await setBlockingTime('pointerdown', 400);
+    await h1.click();
+
+    await setBlockingTime('pointerdown', 200);
+    await h1.click();
+
+    await setBlockingTime('pointerdown', 0);
+
+    let count = 3;
+    while (count < 100) {
+      await h1.click();
+      count++;
+    }
+
+    await beaconCountIs(3);
+
+    const [inp1, inp2, inp3] = await getBeacons();
+    assert(inp1.value >= 600); // Initial pointerdown blocking time.
+    assert(inp2.value >= 400); // Initial pointerdown blocking time.
+    assert(inp2.value < inp1.value); // Should have gone down.
+    assert(inp3.value >= 200); // 2nd-highest pointerdown blocking time.
+    assert(inp3.value < inp2.value); // Should have gone down.
+  });
+
+  it('reports a new interaction after bfcache restore', async function() {
+    if (!browserSupportsINP) this.skip();
+
+    await browser.url('/test/inp');
+
+    await setBlockingTime('click', 100);
+
+    const h1 = await $('h1');
+    await h1.click();
+
+    await stubForwardBack();
+    await beaconCountIs(1);
+
+    const [inp1] = await getBeacons();
+    assert(inp1.value >= 0);
+    assert(inp1.id.match(/^v2-\d+-\d+$/));
+    assert.strictEqual(inp1.name, 'INP');
+    assert.strictEqual(inp1.value, inp1.delta);
+    assert(containsEntry(inp1.entries, 'click', 'h1'));
+    assert(interactionIDsMatch(inp1.entries));
+    assert.match(inp1.navigationType, /navigate|reload/);
+
+    await clearBeacons();
+
+    await setBlockingTime('click', 0);
+    await setBlockingTime('keydown', 50);
+
+    const textarea = await $('#textarea');
+    await textarea.click();
+
+    await browser.keys(['a', 'b', 'c']);
+
+    await stubForwardBack();
+    await beaconCountIs(1);
+
+    const [inp2] = await getBeacons();
+    assert(inp2.value >= 0);
+    assert(inp2.id.match(/^v2-\d+-\d+$/));
+    assert(inp1.id !== inp2.id);
+    assert.strictEqual(inp2.name, 'INP');
+    assert.strictEqual(inp2.value, inp2.delta);
+    assert(containsEntry(inp2.entries, 'keydown', 'textarea'));
+    assert(interactionIDsMatch(inp2.entries));
+    assert(inp2.entries[0].interactionId > inp1.entries[0].interactionId);
+    assert.strictEqual(inp2.navigationType, 'back_forward_cache');
+
+    await stubForwardBack();
+
+    await setBlockingTime('keydown', 0);
+    await setBlockingTime('pointerdown', 200);
+
+    const button = await $('button');
+    await button.click();
+
+    // Pause to ensure the interaction finishes (test is flakey without this).
+    await browser.pause(500);
+
+    await stubVisibilityChange('hidden');
+    await beaconCountIs(1);
+
+    const [inp3] = await getBeacons();
+    assert(inp3.value >= 0);
+    assert(inp3.id.match(/^v2-\d+-\d+$/));
+    assert(inp1.id !== inp3.id);
+    assert.strictEqual(inp3.name, 'INP');
+    assert.strictEqual(inp3.value, inp3.delta);
+    assert(containsEntry(inp3.entries, 'pointerdown', 'button'));
+    assert(interactionIDsMatch(inp3.entries));
+    assert(inp3.entries[0].interactionId > inp2.entries[0].interactionId);
+    assert.strictEqual(inp3.navigationType, 'back_forward_cache');
+  });
+
+  it('does not reports if there were no interactions', async function() {
+    if (!browserSupportsINP) this.skip();
+
+    await browser.url('/test/inp');
+
+    await stubVisibilityChange('hidden');
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    const beacons = await getBeacons();
+    assert.strictEqual(beacons.length, 0);
+  });
+});
+
+
+const containsEntry = (entries, name, target) => {
+  return entries.findIndex((e) => e.name === name && e.target === target) > -1;
+};
+
+const interactionIDsMatch = (entries) => {
+  return entries.every((e) => e.interactionId === entries[0].interactionId);
+};
+
+const setBlockingTime = (event, value) => {
+  return browser.execute((event, value) => {
+    document.getElementById(`${event}-blocking-time`).value = value;
+  }, event, value);
+};

--- a/test/utils/browserSupportsEntry.js
+++ b/test/utils/browserSupportsEntry.js
@@ -28,6 +28,12 @@ function browserSupportsEntry(type) {
       return false;
     }
 
+    // Firefox supports the event timing API but not `interactionId`.
+    if (type === 'event' && self.PerformanceEventTiming &&
+        !('interactionId' in PerformanceEventTiming.prototype)) {
+      return false;
+    }
+
     return window.PerformanceObserver &&
         window.PerformanceObserver.supportedEntryTypes &&
         window.PerformanceObserver.supportedEntryTypes.includes(type);

--- a/test/views/inp.njk
+++ b/test/views/inp.njk
@@ -1,0 +1,99 @@
+<!--
+ Copyright 2022 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends 'layout.njk' %}
+
+{% block content %}
+  <h1>INP Test</h1>
+  <p>
+    <label><input type="number" value="0" id="pointerdown-blocking-time">
+    <code>pointerdown</code> blocking time</label>
+  </p>
+  <p>
+    <label><input type="number" value="0" id="pointerup-blocking-time">
+    <code>pointerup</code> blocking time</label>
+  </p>
+  <p>
+    <label><input type="number" value="0" id="keydown-blocking-time">
+    <code>keydown</code> blocking time</label>
+  </p>
+  <p>
+    <label><input type="number" value="0" id="keyup-blocking-time">
+    <code>keyup</code> blocking time</label>
+  </p>
+  <p>
+    <label><input type="number" value="0" id="click-blocking-time">
+    <code>click</code> blocking time</label>
+  </p>
+  <p>
+    <button id="reset">Reset blocking time to zero</button>
+  </p>
+
+  <p>
+    <textarea id="textarea" style="width:40em;height:5em"></textarea>
+  </p>
+
+  <script>
+    // Set the blocking values based on query params if present.
+    const params = new URLSearchParams(location.search);
+    for (const [key, value] of params) {
+      const el = document.getElementById(`${key}-blocking-time`);
+      if (el && el.nodeName.toLowerCase() === 'input') {
+        el.value = value;
+      }
+    }
+
+    function block(event) {
+      const blockingTime = Number(document.getElementById(`${event.type}-blocking-time`).value);
+      const startTime = performance.now();
+      while (performance.now() < startTime + blockingTime) {
+        // Block...
+      }
+    }
+
+    addEventListener('pointerdown', block, true);
+    addEventListener('pointerup', block, true);
+    addEventListener('keydown', block, true);
+    addEventListener('keyup', block, true);
+    addEventListener('click', block, true);
+
+    document.getElementById('reset').addEventListener('click', () => {
+      [...document.querySelectorAll('label>input')].forEach((n) => n.value = 0);
+    });
+  </script>
+
+  <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec porta orci, ac sagittis augue. Nullam orci tellus, suscipit sed magna id, mattis iaculis ex. Etiam felis lectus, accumsan eu magna lacinia, lobortis tempus lacus. Donec nulla metus, blandit eget ullamcorper in, placerat eu massa. Curabitur vitae elementum orci, ac tincidunt neque. Maecenas accumsan odio sit amet arcu elementum, non vestibulum enim finibus. Phasellus malesuada lacinia suscipit. Cras ac gravida urna. In et mauris non tellus pretium ultrices. Fusce mattis a risus at tincidunt. Donec ac fringilla magna, nec suscipit lectus. Sed risus massa, rutrum ut leo quis, tempor dapibus dui. Proin in mauris non risus maximus tincidunt quis a mauris.</p>
+
+  <script type="module">
+    import {getINP} from '{{ modulePath }}';
+
+    getINP((inp) => {
+      // Log for easier manual testing.
+      console.log(inp);
+
+      // Elements can't be serialized, so we convert first.
+      inp.entries = inp.entries.map((e) => ({
+        ...e.toJSON(),
+        interactionId: e.interactionId,
+        target: e.target.nodeName.toLowerCase(),
+      }));
+
+      // Test sending the metric to an analytics endpoint.
+      navigator.sendBeacon(`/collect`, JSON.stringify(inp));
+    }, self.__reportAllChanges);
+  </script>
+{% endblock %}


### PR DESCRIPTION
Fixes #208.

This PR builds on top of what @mmocny added in #213 with the following:

- Updates the `observe` module logic to support processing a list of entries rather than each individually.
- Moves the `interactionCount` logic into its own module and rewrites it as a "polyfill" so it won't run if the browser natively supports `interactionCount` (hopefully coming to Chrome soon).
- Sets the `Metric.entries` value to all reported entries from the INP interaction, rather than just the longest. (As discussed we should extend this to all entries in the frame, but we probably need a dedicated API for this first.)
- Updates the `durationThreshold` to 50 as a compromise between performance and more accurate duration values at lower percentiles.
- Adds bfcache support.
- Adds tests

