### PR TITLE
Add a config object param to all metric functions

### DIFF
--- a/src/lib/bindReporter.ts
+++ b/src/lib/bindReporter.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {Metric, ReportHandler} from '../types.js';
+import {Metric, ReportCallback} from '../types.js';
 
 
 export const bindReporter = (
-  callback: ReportHandler,
+  callback: ReportCallback,
   metric: Metric,
   reportAllChanges?: boolean,
 ) => {

--- a/src/onCLS.ts
+++ b/src/onCLS.ts
@@ -20,13 +20,16 @@ import {observe} from './lib/observe.js';
 import {onHidden} from './lib/onHidden.js';
 import {bindReporter} from './lib/bindReporter.js';
 import {onFCP} from './onFCP.js';
-import {LayoutShift, Metric, ReportHandler} from './types.js';
+import {LayoutShift, Metric, ReportCallback, ReportOpts} from './types.js';
 
 
 let isMonitoringFCP = false;
 let fcpValue = -1;
 
-export const onCLS = (onReport: ReportHandler, reportAllChanges?: boolean) => {
+export const onCLS = (onReport: ReportCallback, opts?: ReportOpts) => {
+  // Set defaults
+  opts = opts || {};
+
   // Start monitoring FCP so we can only report CLS if FCP is also reported.
   // Note: this is done to match the current behavior of CrUX.
   if (!isMonitoringFCP) {
@@ -36,7 +39,7 @@ export const onCLS = (onReport: ReportHandler, reportAllChanges?: boolean) => {
     isMonitoringFCP = true;
   }
 
-  const onReportWrapped: ReportHandler = (arg) => {
+  const onReportWrapped: ReportCallback = (arg) => {
     if (fcpValue > -1) {
       onReport(arg);
     }
@@ -81,7 +84,7 @@ export const onCLS = (onReport: ReportHandler, reportAllChanges?: boolean) => {
 
   const po = observe('layout-shift', handleEntries);
   if (po) {
-    report = bindReporter(onReportWrapped, metric, reportAllChanges);
+    report = bindReporter(onReportWrapped, metric, opts.reportAllChanges);
 
     onHidden(() => {
       handleEntries(po.takeRecords());
@@ -92,7 +95,7 @@ export const onCLS = (onReport: ReportHandler, reportAllChanges?: boolean) => {
       sessionValue = 0;
       fcpValue = -1;
       metric = initMetric('CLS', 0);
-      report = bindReporter(onReportWrapped, metric, reportAllChanges);
+      report = bindReporter(onReportWrapped, metric, opts!.reportAllChanges);
     });
   }
 };

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -19,10 +19,13 @@ import {bindReporter} from './lib/bindReporter.js';
 import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
 import {initMetric} from './lib/initMetric.js';
 import {observe} from './lib/observe.js';
-import {Metric, ReportHandler} from './types.js';
+import {Metric, ReportCallback, ReportOpts} from './types.js';
 
 
-export const onFCP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
+export const onFCP = (onReport: ReportCallback, opts?: ReportOpts) => {
+  // Set defaults
+  opts = opts || {};
+
   const visibilityWatcher = getVisibilityWatcher();
   let metric = initMetric('FCP');
   let report: ReturnType<typeof bindReporter>;
@@ -56,7 +59,7 @@ export const onFCP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
   const po = fcpEntry ? null : observe('paint', handleEntries);
 
   if (fcpEntry || po) {
-    report = bindReporter(onReport, metric, reportAllChanges);
+    report = bindReporter(onReport, metric, opts.reportAllChanges);
 
     if (fcpEntry) {
       handleEntries([fcpEntry]);
@@ -64,7 +67,7 @@ export const onFCP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
 
     onBFCacheRestore((event) => {
       metric = initMetric('FCP');
-      report = bindReporter(onReport, metric, reportAllChanges);
+      report = bindReporter(onReport, metric, opts!.reportAllChanges);
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           metric.value = performance.now() - event.timeStamp;

--- a/src/onFID.ts
+++ b/src/onFID.ts
@@ -21,10 +21,13 @@ import {initMetric} from './lib/initMetric.js';
 import {observe} from './lib/observe.js';
 import {onHidden} from './lib/onHidden.js';
 import {firstInputPolyfill, resetFirstInputPolyfill} from './lib/polyfills/firstInputPolyfill.js';
-import {FirstInputPolyfillCallback, Metric, PerformanceEventTiming, ReportHandler} from './types.js';
+import {FirstInputPolyfillCallback, Metric, PerformanceEventTiming, ReportCallback, ReportOpts} from './types.js';
 
 
-export const onFID = (onReport: ReportHandler, reportAllChanges?: boolean) => {
+export const onFID = (onReport: ReportCallback, opts?: ReportOpts) => {
+  // Set defaults
+  opts = opts || {};
+
   const visibilityWatcher = getVisibilityWatcher();
   let metric = initMetric('FID');
   let report: ReturnType<typeof bindReporter>;
@@ -43,7 +46,7 @@ export const onFID = (onReport: ReportHandler, reportAllChanges?: boolean) => {
   }
 
   const po = observe('first-input', handleEntries);
-  report = bindReporter(onReport, metric, reportAllChanges);
+  report = bindReporter(onReport, metric, opts.reportAllChanges);
 
   if (po) {
     onHidden(() => {
@@ -59,7 +62,7 @@ export const onFID = (onReport: ReportHandler, reportAllChanges?: boolean) => {
     }
     onBFCacheRestore(() => {
       metric = initMetric('FID');
-      report = bindReporter(onReport, metric, reportAllChanges);
+      report = bindReporter(onReport, metric, opts!.reportAllChanges);
       window.webVitals.resetFirstInputPolyfill();
       window.webVitals.firstInputPolyfill(handleEntry as FirstInputPolyfillCallback);
     });
@@ -68,7 +71,7 @@ export const onFID = (onReport: ReportHandler, reportAllChanges?: boolean) => {
     if (po) {
       onBFCacheRestore(() => {
         metric = initMetric('FID');
-        report = bindReporter(onReport, metric, reportAllChanges);
+        report = bindReporter(onReport, metric, opts!.reportAllChanges);
         resetFirstInputPolyfill();
         firstInputPolyfill(handleEntry as FirstInputPolyfillCallback);
       });

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -20,7 +20,7 @@ import {initMetric} from './lib/initMetric.js';
 import {observe} from './lib/observe.js';
 import {onHidden} from './lib/onHidden.js';
 import {getInteractionCount, initInteractionCountPolyfill} from './lib/polyfills/interactionCountPolyfill.js';
-import {Metric, PerformanceEventTiming, ReportHandler} from './types.js';
+import {Metric, PerformanceEventTiming, ReportCallback, ReportOpts} from './types.js';
 
 interface Interaction {
   id: number;
@@ -104,7 +104,10 @@ const estimateP98LongestInteraction = () => {
 	return longestInteractionList[candidateInteractionIndex];
 }
 
-export const onINP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
+export const onINP = (onReport: ReportCallback, opts?: ReportOpts) => {
+  // Set defaults
+  opts = opts || {};
+
   // TODO(philipwalton): remove once the polyfill is no longer needed.
   initInteractionCountPolyfill();
 
@@ -134,10 +137,10 @@ export const onINP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
     // and performance. Running this callback for any interaction that spans
     // just one or two frames is likely not worth the insight that could be
     // gained.
-    durationThreshold: 40,
+    durationThreshold: opts.durationThreshold || 40,
   } as PerformanceObserverInit);
 
-  report = bindReporter(onReport, metric, reportAllChanges);
+  report = bindReporter(onReport, metric, opts.reportAllChanges);
 
   if (po) {
     onHidden(() => {
@@ -160,7 +163,7 @@ export const onINP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
       prevInteractionCount = getInteractionCount();
 
       metric = initMetric('INP');
-      report = bindReporter(onReport, metric, reportAllChanges);
+      report = bindReporter(onReport, metric, opts!.reportAllChanges);
     });
   }
 };

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -20,12 +20,15 @@ import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
 import {initMetric} from './lib/initMetric.js';
 import {observe} from './lib/observe.js';
 import {onHidden} from './lib/onHidden.js';
-import {Metric, ReportHandler} from './types.js';
+import {Metric, ReportCallback, ReportOpts} from './types.js';
 
 
 const reportedMetricIDs: Record<string, boolean> = {};
 
-export const onLCP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
+export const onLCP = (onReport: ReportCallback, opts?: ReportOpts) => {
+  // Set defaults
+  opts = opts || {};
+
   const visibilityWatcher = getVisibilityWatcher();
   let metric = initMetric('LCP');
   let report: ReturnType<typeof bindReporter>;
@@ -50,7 +53,7 @@ export const onLCP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
   const po = observe('largest-contentful-paint', handleEntries);
 
   if (po) {
-    report = bindReporter(onReport, metric, reportAllChanges);
+    report = bindReporter(onReport, metric, opts.reportAllChanges);
 
     const stopListening = () => {
       if (!reportedMetricIDs[metric.id]) {
@@ -72,7 +75,7 @@ export const onLCP = (onReport: ReportHandler, reportAllChanges?: boolean) => {
 
     onBFCacheRestore((event) => {
       metric = initMetric('LCP');
-      report = bindReporter(onReport, metric, reportAllChanges);
+      report = bindReporter(onReport, metric, opts!.reportAllChanges);
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           metric.value = performance.now() - event.timeStamp;

--- a/src/onTTFB.ts
+++ b/src/onTTFB.ts
@@ -18,7 +18,7 @@ import {bindReporter} from './lib/bindReporter.js';
 import {initMetric} from './lib/initMetric.js';
 import {onBFCacheRestore} from './lib/bfcache.js';
 import {getNavigationEntry} from './lib/getNavigationEntry.js';
-import {ReportHandler} from './types.js';
+import {ReportCallback, ReportOpts} from './types.js';
 
 
 const afterLoad = (callback: () => void) => {
@@ -31,9 +31,12 @@ const afterLoad = (callback: () => void) => {
   }
 }
 
-export const onTTFB = (onReport: ReportHandler, reportAllChanges?: boolean) => {
+export const onTTFB = (onReport: ReportCallback, opts?: ReportOpts) => {
+  // Set defaults
+  opts = opts || {};
+
   let metric = initMetric('TTFB');
-  let report = bindReporter(onReport, metric, reportAllChanges);
+  let report = bindReporter(onReport, metric, opts.reportAllChanges);
 
   afterLoad(() => {
     const navigationEntry = getNavigationEntry();
@@ -55,7 +58,7 @@ export const onTTFB = (onReport: ReportHandler, reportAllChanges?: boolean) => {
 
   onBFCacheRestore((event) => {
     metric = initMetric('TTFB');
-    report = bindReporter(onReport, metric, reportAllChanges);
+    report = bindReporter(onReport, metric, opts!.reportAllChanges);
     metric.value = performance.now() - event.timeStamp;
     report(true);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,11 +46,16 @@ export interface Metric {
   navigationType:  NavigationType | 'back_forward_cache' | undefined;
 }
 
-export interface ReportHandler {
+export interface ReportCallback {
   (metric: Metric): void;
 }
 
- interface PerformanceEntryMap {
+export interface ReportOpts {
+  reportAllChanges?: boolean;
+  durationThreshold?: number;
+}
+
+interface PerformanceEntryMap {
   'navigation': PerformanceNavigationTiming;
   'resource': PerformanceResourceTiming;
   'paint': PerformancePaintTiming;

--- a/test/views/cls.njk
+++ b/test/views/cls.njk
@@ -51,6 +51,6 @@
 
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(cls));
-    }, self.__reportAllChanges);
+    }, {reportAllChanges: self.__reportAllChanges});
   </script>
 {% endblock %}

--- a/test/views/fcp.njk
+++ b/test/views/fcp.njk
@@ -33,6 +33,6 @@
 
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(fcp));
-    }, self.__reportAllChanges);
+    }, {reportAllChanges: self.__reportAllChanges});
   </script>
 {% endblock %}

--- a/test/views/fid.njk
+++ b/test/views/fid.njk
@@ -32,6 +32,6 @@
 
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(fid));
-    }, self.__reportAllChanges);
+    }, {reportAllChanges: self.__reportAllChanges});
   </script>
 {% endblock %}

--- a/test/views/inp.njk
+++ b/test/views/inp.njk
@@ -94,6 +94,9 @@
 
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(inp));
-    }, self.__reportAllChanges);
+    }, {
+      reportAllChanges: self.__reportAllChanges,
+      durationThreshold: self.__durationThreshold,
+    });
   </script>
 {% endblock %}

--- a/test/views/layout.njk
+++ b/test/views/layout.njk
@@ -26,7 +26,13 @@
 
       const params = new URL(location.href).searchParams;
 
-      self.__reportAllChanges = params.has('reportAllChanges');
+      if (params.has('reportAllChanges')) {
+        self.__reportAllChanges = Boolean(params.get('reportAllChanges'));
+      }
+
+      if (params.has('durationThreshold')) {
+        self.__durationThreshold = Number(params.get('durationThreshold'));
+      }
 
       if (params.has('hidden')) {
         // Stub the page being loaded in the hidden state, but defer to the

--- a/test/views/lcp.njk
+++ b/test/views/lcp.njk
@@ -50,6 +50,6 @@
 
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(lcp));
-    }, self.__reportAllChanges);
+    }, {reportAllChanges: self.__reportAllChanges});
   </script>
 {% endblock %}

--- a/test/views/ttfb.njk
+++ b/test/views/ttfb.njk
@@ -38,7 +38,7 @@
 
         // Test sending the metric to an analytics endpoint.
         navigator.sendBeacon(`/collect`, JSON.stringify(ttfb));
-      }, self.__reportAllChanges);
+      }, {reportAllChanges: self.__reportAllChanges});
     }());
   </script>
 {% endblock %}


### PR DESCRIPTION
Fixes #224 by adding a optional, configuration object as the second parameter for all metric function.

This PR also adds the ability to set the `durationThreshold` parameter when measuring INP, which is useful if you to get more granular debug data on interactions that are already relatively fast (the default `durationThreshold` is `40`).

Here's an example of how you can set the lowest supported `durationThreshold` value supported in browsers.

```js
import {onINP} from 'web-vitals';

onINP(console.log, {
  durationThreshold: 16,
  reportAllChanges: true,
});
```
