### PR TITLE
Ensure all deprecated symbols are annotated

### DIFF
--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -14,9 +14,51 @@
  * limitations under the License.
  */
 
-export {onCLS as getCLS} from './onCLS.js';
-export {onFCP as getFCP} from './onFCP.js';
-export {onFID as getFID} from './onFID.js';
-export {onINP as getINP} from './onINP.js';
-export {onLCP as getLCP} from './onLCP.js';
-export {onTTFB as getTTFB} from './onTTFB.js';
+export {
+  /**
+   * @deprecated Use `onCLS()` instead.
+   */
+  onCLS as getCLS,
+} from './onCLS.js';
+
+export {
+  /**
+   * @deprecated Use `onFCP()` instead.
+   */
+  onFCP as getFCP,
+} from './onFCP.js';
+
+export {
+  /**
+   * @deprecated Use `onFID()` instead.
+   */
+  onFID as getFID,
+} from './onFID.js';
+
+export {
+  /**
+   * @deprecated Use `onINP()` instead.
+   */
+  onINP as getINP,
+} from './onINP.js';
+
+export {
+  /**
+   * @deprecated Use `onLCP()` instead.
+   */
+  onLCP as getLCP,
+} from './onLCP.js';
+
+export {
+  /**
+   * @deprecated Use `onTTFB()` instead.
+   */
+  onTTFB as getTTFB,
+} from './onTTFB.js';
+
+export {
+  /**
+   * @deprecated Use `ReportCallback` instead.
+   */
+  ReportCallback as ReportHandler,
+} from './types.js';


### PR DESCRIPTION
This PR updates all of the symbols in `deprecated.ts` and adds `@deprecated` annotations in the JSDoc comments. This should help ensure developers using VSCode (or similar editors that support this) will know that the symbol is deprecated as well as what the updated name is.

This PR also adds back the `ReportHandler` type that was accidentally removed in #225. It aliases it to `ReportCallback` and marks it as deprecated so the change won't be breaking in v3 when it lands. 