### PR TITLE
Fix 228: Change onINP to also use FID `duration` when under `durationTheshold`

### DIFF
--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -30,19 +30,21 @@ interface PerformanceEntriesHandler {
  * try/catch to avoid errors in unsupporting browsers.
  */
 export const observe = (
-  type: string,
+  types: string[],
   callback: PerformanceEntriesHandler,
   opts?: PerformanceObserverInit,
 ): PerformanceObserver | undefined => {
   try {
-    if (PerformanceObserver.supportedEntryTypes.includes(type)) {
+    if (types.every(type => PerformanceObserver.supportedEntryTypes.includes(type))) {
       const po: PerformanceObserver = new PerformanceObserver((list) => {
         callback(list.getEntries());
       });
-      po.observe(Object.assign({
-        type,
-        buffered: true,
-      }, opts || {}) as PerformanceObserverInit);
+      for (let type of types) {
+        po.observe(Object.assign({
+          type,
+          buffered: true,
+        }, opts || {}) as PerformanceObserverInit);
+      }
       return po;
     }
   } catch (e) {

--- a/src/lib/polyfills/interactionCountPolyfill.ts
+++ b/src/lib/polyfills/interactionCountPolyfill.ts
@@ -56,7 +56,7 @@ export const getInteractionCount = () => {
 export const initInteractionCountPolyfill = () => {
   if ('interactionCount' in performance || po) return;
 
-  po = observe('event', updateEstimate, {
+  po = observe(['event'], updateEstimate, {
     type: 'event',
     buffered: true,
     durationThreshold: 0,

--- a/src/onCLS.ts
+++ b/src/onCLS.ts
@@ -82,7 +82,7 @@ export const onCLS = (onReport: ReportCallback, opts?: ReportOpts) => {
     });
   };
 
-  const po = observe('layout-shift', handleEntries);
+  const po = observe(['layout-shift'], handleEntries);
   if (po) {
     report = bindReporter(onReportWrapped, metric, opts.reportAllChanges);
 

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -56,7 +56,7 @@ export const onFCP = (onReport: ReportCallback, opts?: ReportOpts) => {
   const fcpEntry = window.performance && window.performance.getEntriesByName &&
       window.performance.getEntriesByName('first-contentful-paint')[0];
 
-  const po = fcpEntry ? null : observe('paint', handleEntries);
+  const po = fcpEntry ? null : observe(['paint'], handleEntries);
 
   if (fcpEntry || po) {
     report = bindReporter(onReport, metric, opts.reportAllChanges);

--- a/src/onFID.ts
+++ b/src/onFID.ts
@@ -45,7 +45,7 @@ export const onFID = (onReport: ReportCallback, opts?: ReportOpts) => {
     (entries as PerformanceEventTiming[]).forEach(handleEntry);
   }
 
-  const po = observe('first-input', handleEntries);
+  const po = observe(['first-input'], handleEntries);
   report = bindReporter(onReport, metric, opts.reportAllChanges);
 
   if (po) {

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -116,7 +116,7 @@ export const onINP = (onReport: ReportCallback, opts?: ReportOpts) => {
 
   const handleEntries = (entries: Metric['entries']) => {
     (entries as PerformanceEventTiming[]).forEach((entry) => {
-      if (entry.interactionId) {
+      if (entry.entryType == 'first-input' || entry.interactionId) {
         processEntry(entry);
       }
     });
@@ -130,7 +130,7 @@ export const onINP = (onReport: ReportCallback, opts?: ReportOpts) => {
     }
   };
 
-  const po = observe('event', handleEntries, {
+  const po = observe(['first-input', 'event'], handleEntries, {
     // Event Timing entries have their durations rounded to the nearest 8ms,
     // so a duration of 40ms would be any event that spans 2.5 or more frames
     // at 60Hz. This threshold is chosen to strike a balance between usefulness

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -50,7 +50,7 @@ export const onLCP = (onReport: ReportCallback, opts?: ReportOpts) => {
     }
   };
 
-  const po = observe('largest-contentful-paint', handleEntries);
+  const po = observe(['largest-contentful-paint'], handleEntries);
 
   if (po) {
     report = bindReporter(onReport, metric, opts.reportAllChanges);


### PR DESCRIPTION
This is a **PROTOTYPE** for adding support for registering multiple observer types with the same PO observer -- specifically to use both `first-input` and `event` timing together, with the same PerformanceObserver / handler.

I have not tested this thoroughly, just checking to see how it would look for now and to continue conversation.

Context:
* https://github.com/GoogleChrome/web-vitals/issues/228#issuecomment-1128147203
* Chromium is [fixing the fact that FID does not have interactionID](https://crbug.com/1325826)