### PR TITLE
Add support for prerendered pages

### DIFF
--- a/src/lib/getActivationStart.ts
+++ b/src/lib/getActivationStart.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
+import {getNavigationEntry} from './getNavigationEntry.js';
 
-/**
- * Overrides the document's `visibilityState` property, sets the body's hidden
- * attribute (to prevent painting) and dispatches a `visibilitychange` event.
- * @return {Promise<void>}
- */
-function stubForwardBack(visibilityStateAfterRestore) {
-  return browser.executeAsync((visibilityStateAfterRestore, done) => {
-    self.__stubForwardBack(visibilityStateAfterRestore).then(done);
-  }, visibilityStateAfterRestore);
-}
 
-module.exports = {
-  stubForwardBack,
+export const getActivationStart = (): number => {
+  const navEntry = getNavigationEntry();
+  return navEntry && navEntry.activationStart || 0;
 };

--- a/src/lib/getVisibilityWatcher.ts
+++ b/src/lib/getVisibilityWatcher.ts
@@ -20,7 +20,10 @@ import {onHidden} from './onHidden.js';
 let firstHiddenTime = -1;
 
 const initHiddenTime = () => {
-  return document.visibilityState === 'hidden' ? 0 : Infinity;
+  // If the document is hidden and not prerendering, assume it was always
+  // hidden and the page was loaded in the background.
+  return document.visibilityState === 'hidden' &&
+      !document.prerendering ? 0 : Infinity;
 }
 
 const trackChanges = () => {

--- a/src/lib/initMetric.ts
+++ b/src/lib/initMetric.ts
@@ -16,19 +16,31 @@
 
 import {isBFCacheRestore} from './bfcache.js';
 import {generateUniqueID} from './generateUniqueID.js';
+import {getActivationStart} from './getActivationStart.js';
 import {getNavigationEntry} from './getNavigationEntry.js';
 import {Metric} from '../types.js';
 
 
 export const initMetric = (name: Metric['name'], value?: number): Metric => {
-  const navigationEntry = getNavigationEntry();
+  const navEntry = getNavigationEntry();
+  let navigationType: Metric['navigationType'];
+
+  if (isBFCacheRestore()) {
+    navigationType = 'back_forward_cache';
+  } else if (navEntry) {
+    if (document.prerendering || getActivationStart() > 0) {
+      navigationType = 'prerender';
+    } else {
+      navigationType = navEntry.type;
+    }
+  }
+
   return {
     name,
     value: typeof value === 'undefined' ? -1 : value,
     delta: 0,
     entries: [],
     id: generateUniqueID(),
-    navigationType: isBFCacheRestore() ? 'back_forward_cache' :
-        navigationEntry && navigationEntry.type,
+    navigationType,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export interface Metric {
   // by the Navigation Timing API (or `undefined` if the browser doesn't
   // support that API). For pages that are restored from the bfcache, this
   // value will be 'back_forward_cache'.
-  navigationType:  NavigationTimingType | 'back_forward_cache' | undefined;
+  navigationType:  NavigationTimingType | 'back_forward_cache' | 'prerender' | undefined;
 }
 
 export interface ReportCallback {
@@ -61,9 +61,22 @@ interface PerformanceEntryMap {
   'paint': PerformancePaintTiming;
 }
 
+// Update built-in types to be more accurate.
 declare global {
+  // https://wicg.github.io/nav-speculation/prerendering.html#document-prerendering
+  interface Document {
+    prerendering?: boolean
+  }
   interface Performance {
     getEntriesByType<K extends keyof PerformanceEntryMap>(type: K): PerformanceEntryMap[K][]
+  }
+  // https://w3c.github.io/event-timing/#sec-modifications-perf-timeline
+  interface PerformanceObserverInit {
+    durationThreshold?: number;
+  }
+  // https://wicg.github.io/nav-speculation/prerendering.html#performance-navigation-timing-extension
+  interface PerformanceNavigationTiming {
+    activationStart?: number;
   }
 }
 
@@ -83,8 +96,14 @@ export interface LayoutShift extends PerformanceEntry {
   hadRecentInput: boolean;
 }
 
-export interface PerformanceObserverInit {
-  durationThreshold?: number;
+// https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface
+export interface LargestContentfulPaint extends PerformanceEntry {
+  renderTime: DOMHighResTimeStamp;
+  loadTime: DOMHighResTimeStamp;
+  size: number;
+  id: string;
+  url: string;
+  element?: Element;
 }
 
 export type FirstInputPolyfillEntry =
@@ -96,7 +115,9 @@ export interface FirstInputPolyfillCallback {
 
 export type NavigationTimingPolyfillEntry = Omit<PerformanceNavigationTiming,
     'initiatorType' | 'nextHopProtocol' | 'redirectCount' | 'transferSize' |
-    'encodedBodySize' | 'decodedBodySize'>
+    'encodedBodySize' | 'decodedBodySize' | 'type'> & {
+  type?: PerformanceNavigationTiming['type'];
+}
 
 export interface WebVitalsGlobal {
   firstInputPolyfill: (onFirstInput: FirstInputPolyfillCallback) => void;

--- a/test/utils/stubVisibilityChange.js
+++ b/test/utils/stubVisibilityChange.js
@@ -22,17 +22,7 @@
  */
 function stubVisibilityChange(visibilityState) {
   return browser.execute((visibilityState) => {
-    if (visibilityState === 'hidden') {
-      Object.defineProperty(document, 'visibilityState', {
-        value: visibilityState,
-        configurable: true,
-      });
-      document.body.hidden = true;
-    } else {
-      delete document.visibilityState;
-      document.body.hidden = false;
-    }
-    document.dispatchEvent(new Event('visibilitychange'));
+    self.__stubVisibilityChange(visibilityState);
   }, visibilityState);
 }
 

--- a/test/views/layout.njk
+++ b/test/views/layout.njk
@@ -13,13 +13,93 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<html lang="en">
+<html lang="en" {% if invisible or hidden %}hidden{% endif %}>
 <head>
   <meta charset="utf-8">
   <title>Web Vitals Test</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>
     (function() {
+      /**
+       * @param {string} visibilityState
+       * @return {void}
+       */
+      self.__stubVisibilityState = (visibilityState) => {
+        if (visibilityState === 'hidden') {
+          Object.defineProperty(document, 'visibilityState', {
+            value: visibilityState,
+            configurable: true,
+          });
+          document.documentElement.hidden = true;
+        } else {
+          delete document.visibilityState;
+          document.documentElement.hidden = false;
+        }
+      }
+
+      /**
+       * @param {string} visibilityState
+       * @return {void}
+       */
+      self.__stubVisibilityChange = (visibilityState) => {
+        self.__stubVisibilityState(visibilityState)
+        document.dispatchEvent(new Event('visibilitychange'));
+      }
+
+      /**
+       * @param {string} visibilityStateAfterRestore
+       * @return {Promise<void>}
+       */
+      self.__stubForwardBack = (visibilityStateAfterRestore) => {
+        return new Promise((resolve) => {
+          window.dispatchEvent(new PageTransitionEvent('pagehide', {
+            persisted: true,
+          }));
+          self.__stubVisibilityChange('hidden');
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              if (visibilityStateAfterRestore !== 'hidden') {
+                self.__stubVisibilityChange('visible');
+              }
+              window.dispatchEvent(new PageTransitionEvent('pageshow', {
+                persisted: true,
+              }));
+              resolve();
+            });
+          });
+        });
+      }
+
+      /**
+       * @return {Promise<void>}
+       */
+      self.__stubPrerender = () => {
+        return new Promise((resolve) => {
+          const navEntry = performance.getEntriesByType('navigation')[0];
+          // Only stub if the page isn't actually prerendered.
+          if (!(document.prerendering || navEntry.activationStart > 0)) {
+            self.__stubVisibilityState('hidden');
+            Object.defineProperty(document, 'prerendering', {
+              value: true,
+              configurable: true,
+            });
+            setTimeout(() => {
+              self.__stubVisibilityChange('visible');
+              const time = self.performance ? performance.now() : 0;
+              const fcpEntry = performance.getEntriesByName('first-contentful-paint')[0];
+              Object.defineProperty(navEntry, 'activationStart', {
+                configurable: true,
+                enumerable: true,
+                value: Math.min(time, fcpEntry && fcpEntry.startTime || time),
+              });
+              delete document.prerendering;
+              document.dispatchEvent(new Event('prerenderingchange'));
+              resolve();
+            }, Number(params.get('prerender')) || 0);
+          }
+        });
+      }
+
       // Uncomment to stub running in a browser that doesn't support performance APIs
       // (e.g. some version of Opera support this).
       // delete self.performance;
@@ -47,6 +127,10 @@
           }
         }, true);
       }
+
+      if (params.has('prerender')) {
+        self.__stubPrerender();
+      }
     }());
   </script>
   {% if polyfill %}
@@ -73,7 +157,7 @@
     }
   </style>
 </head>
-<body {% if invisible or hidden %}hidden{% endif %}>
+<body>
   <main>
     {% block content %}{% endblock %}
   </main>

--- a/test/views/ttfb.njk
+++ b/test/views/ttfb.njk
@@ -17,7 +17,7 @@
 {% block content %}
   <h1>TTFB Test</h1>
   <p>
-    <img src="/test/img/square.png">
+    <img src="/test/img/square.png{% if imgDelay %}?delay={{imgDelay}}{% endif %}">
   </p>
 
   <p>Text below the image</p>
@@ -35,6 +35,17 @@
       onTTFB((ttfb) => {
         // Log for easier manual testing.
         console.log(ttfb);
+
+        // The stubbed `activationStart` is lost when stringified, so we convert first.
+        ttfb.entries = ttfb.entries.map((e) => {
+          const newObj = {};
+          for (const k in e) {
+            if (typeof e[k] !== 'function') {
+              newObj[k] = e[k];
+            }
+          }
+          return newObj;
+        });
 
         // Test sending the metric to an analytics endpoint.
         navigator.sendBeacon(`/collect`, JSON.stringify(ttfb));


### PR DESCRIPTION
Chrome started rolling out [Omnibox prerendering](https://web.dev/speculative-prerendering/#prerendering-from-the-address-bar) in version 101, via the [Prerendering API](https://wicg.github.io/nav-speculation/prerendering.html).

This API has [timing implications](https://github.com/WICG/nav-speculation/blob/main/ua-initiated-prerendering.md#timing) for prerendered pages—specifically, all load-related metrics should be relative to when the page was ["activated"](https://github.com/WICG/nav-speculation/blob/main/ua-initiated-prerendering.md#how-it-works) rather than when it started loading (for non-prerendered pages these values are the same).

To support prerendering in this library, this PR updates the `onLCP()`, `onFCP()`, and `onTTFB()` functions to report their value relative to the `activationStart` time via the [Navigation Timing API extension](https://wicg.github.io/nav-speculation/prerendering.html#performance-navigation-timing-extension) rather than from the time origin of the page.

This PR also adds a new `prerender` value to the `navigationType` property of the [`Metric`](https://github.com/GoogleChrome/web-vitals/tree/v3.0.0-beta.2#metric) object, so developers can be aware when prerendering is having an effect on the metric values and filter by just those values (or exclude them from a report if they wish).

One important implication of this change is that the value reported by the library may not match the value reported by the `PerformanceEntry` object in the [`Metric.entries`](https://github.com/GoogleChrome/web-vitals/tree/next#metric) array. For example:

```js
{
  name: 'LCP',
  value: 123,  // Doesn't match the value in `entries[0].startTime`.
  navigationType: 'prerender' // New option for the property.
  entries: [
    {
      entryType: 'largest-contentful-paint',
      startTime: 456, // Doesn't match the metric `value`
      // ...
    }
  ],
  // ...
}
```

The values in the `entries` array are never modified, so if someone wanted to report both the "raw" LCP value and the LCP value relative to `activationStart` they could do so using the values from the `entries` array.

One situation where this may be desirable is the TTFB metric, since prerendered pages will often get their first byte of content before activating, this means the TTFB value will be zero. In these cases developers may choose to report the underlying Navigation Timing API value, including `activationStart` to help them diagnose and fix network issues. However, when using TTFB as a [sub-component of LCP](https://web.dev/optimize-lcp/#lcp-breakdown), it's important to compare them using the same start time (e.g. `activationStart`).

