### PR TITLE
Add a new attribution build for debugging issues in the field

### DIFF
--- a/attribution.d.ts
+++ b/attribution.d.ts
@@ -13,4 +13,4 @@
  limitations under the License.
 */
 
-export * from './dist/modules/index.js';
+export * from './dist/modules/attribution.js';

--- a/attribution.js
+++ b/attribution.js
@@ -13,4 +13,6 @@
  limitations under the License.
 */
 
-export * from './dist/modules/index.js';
+// Creates the `web-vitals/attribution` import in node-based bundlers.
+// This will not be needed when export maps are widely supported.
+export * from './dist/web-vitals.attribution.js';

--- a/base.js
+++ b/base.js
@@ -1,3 +1,18 @@
+/*
+ Copyright 2022 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 // Creates the `web-vitals/base` import in node-based bundlers.
 // This will not be needed when export maps are widely supported.
 export * from './dist/web-vitals.base.js';

--- a/package.json
+++ b/package.json
@@ -2,10 +2,88 @@
   "name": "web-vitals",
   "version": "3.0.0-beta.2",
   "description": "Easily measure performance metrics in JavaScript",
+  "type": "module",
+  "typings": "dist/modules/index.d.ts",
   "main": "dist/web-vitals.umd.js",
   "module": "dist/web-vitals.js",
-  "typings": "dist/modules/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/modules/index.d.ts",
+      "require": "./dist/web-vitals.umd.js",
+      "default": "./dist/web-vitals.js"
+    },
+    "./base": {
+      "types": "./dist/modules/index.d.ts",
+      "require": "./dist/web-vitals.base.umd.js",
+      "default": "./dist/web-vitals.base.js"
+    },
+    "./base.js": {
+      "types": "./dist/modules/index.d.ts",
+      "require": "./dist/web-vitals.base.umd.js",
+      "default": "./dist/web-vitals.base.js"
+    },
+    "./attribution": {
+      "types": "./dist/modules/attribution.d.ts",
+      "require": "./dist/web-vitals.attribution.umd.js",
+      "default": "./dist/web-vitals.attribution.js"
+    },
+    "./attribution.js": {
+      "types": "./dist/modules/attribution.d.ts",
+      "require": "./dist/web-vitals.attribution.umd.js",
+      "default": "./dist/web-vitals.attribution.js"
+    },
+    "./onCLS.js": {
+      "types": "./dist/modules/onCLS.d.ts",
+      "default": "./dist/modules/onCLS.js"
+    },
+    "./onFCP.js": {
+      "types": "./dist/modules/onFCP.d.ts",
+      "default": "./dist/modules/onFCP.js"
+    },
+    "./onFID.js": {
+      "types": "./dist/modules/onFID.d.ts",
+      "default": "./dist/modules/onFID.js"
+    },
+    "./onINP.js": {
+      "types": "./dist/modules/onINP.d.ts",
+      "default": "./dist/modules/onINP.js"
+    },
+    "./onLCP.js": {
+      "types": "./dist/modules/onLCP.d.ts",
+      "default": "./dist/modules/onLCP.js"
+    },
+    "./onTTFB.js": {
+      "types": "./dist/modules/onTTFB.d.ts",
+      "default": "./dist/modules/onTTFB.js"
+    },
+    "./attribution/onCLS.js": {
+      "types": "./dist/modules/attribution/onCLS.d.ts",
+      "default": "./dist/modules/attribution/onCLS.js"
+    },
+    "./attribution/onFCP.js": {
+      "types": "./dist/modules/attribution/onFCP.d.ts",
+      "default": "./dist/modules/attribution/onFCP.js"
+    },
+    "./attribution/onFID.js": {
+      "types": "./dist/modules/attribution/onFID.d.ts",
+      "default": "./dist/modules/attribution/onFID.js"
+    },
+    "./attribution/onINP.js": {
+      "types": "./dist/modules/attribution/onINP.d.ts",
+      "default": "./dist/modules/attribution/onINP.js"
+    },
+    "./attribution/onLCP.js": {
+      "types": "./dist/modules/attribution/onLCP.d.ts",
+      "default": "./dist/modules/attribution/onLCP.js"
+    },
+    "./attribution/onTTFB.js": {
+      "types": "./dist/modules/attribution/onTTFB.d.ts",
+      "default": "./dist/modules/attribution/onTTFB.js"
+    }
+  },
   "files": [
+    "attribution.js",
+    "attribution.d.ts",
     "base.js",
     "base.d.ts",
     "dist",
@@ -24,7 +102,7 @@
     "release:minor": "npm version minor -m 'Release v%s' && npm publish",
     "release:patch": "npm version patch -m 'Release v%s' && npm publish",
     "test": "npm-run-all build -p -r test:*",
-    "test:e2e": "wdio wdio.conf.js",
+    "test:e2e": "wdio wdio.conf.cjs",
     "test:server": "node test/server.js",
     "start": "run-s build:ts test:server watch",
     "watch": "run-p watch:*",
@@ -37,9 +115,11 @@
     "crux",
     "performance",
     "metrics",
+    "Core Web Vitals",
     "CLS",
     "FCP",
     "FID",
+    "INP",
     "LCP",
     "TTFB"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -105,6 +105,32 @@ const configs = [
     },
     plugins: configurePlugins({module: false}),
   },
+  {
+    input: 'dist/modules/attribution.js',
+    output: {
+      format: 'esm',
+      file: './dist/web-vitals.attribution.js',
+    },
+    plugins: configurePlugins({module: true, polyfill: false}),
+  },
+  {
+    input: 'dist/modules/attribution.js',
+    output: {
+      format: 'umd',
+      file: `./dist/web-vitals.attribution.umd.js`,
+      name: 'webVitals',
+    },
+    plugins: configurePlugins({module: false, polyfill: false}),
+  },
+  {
+    input: 'dist/modules/attribution.js',
+    output: {
+      format: 'iife',
+      file: './dist/web-vitals.attribution.iife.js',
+      name: 'webVitals',
+    },
+    plugins: configurePlugins({module: false, polyfill: false}),
+  },
 ];
 
 export default configs;

--- a/src/attribution.ts
+++ b/src/attribution.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
+export {onCLS} from './attribution/onCLS.js';
+export {onFCP} from './attribution/onFCP.js';
+export {onFID} from './attribution/onFID.js';
+export {onINP} from './attribution/onINP.js';
+export {onLCP} from './attribution/onLCP.js';
+export {onTTFB} from './attribution/onTTFB.js';
 
-/**
- * Overrides the document's `visibilityState` property, sets the body's hidden
- * attribute (to prevent painting) and dispatches a `visibilitychange` event.
- * @return {Promise<void>}
- */
-export function stubForwardBack(visibilityStateAfterRestore) {
-  return browser.executeAsync((visibilityStateAfterRestore, done) => {
-    self.__stubForwardBack(visibilityStateAfterRestore).then(done);
-  }, visibilityStateAfterRestore);
-}
+export * from './types.js';

--- a/src/attribution/onCLS.ts
+++ b/src/attribution/onCLS.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getLoadState} from '../lib/getLoadState.js';
+import {getSelector} from '../lib/getSelector.js';
+import {onCLS as unattributedOnCLS} from '../onCLS.js';
+import {CLSAttribution, CLSReportCallback, CLSReportCallbackWithAttribution, CLSMetric, CLSMetricWithAttribution, ReportOpts} from '../types.js';
+
+
+const getLargestLayoutShiftEntry = (entries: LayoutShift[]) => {
+  return entries.reduce((a, b) => a && a.value > b.value ? a : b);
+}
+
+const getLargestLayoutShiftSource = (sources: LayoutShiftAttribution[]) => {
+  return sources.find((s) => s.node && s.node.nodeType === 1) || sources[0];
+}
+
+const attributeCLS = (metric: CLSMetric): CLSMetricWithAttribution => {
+  let attribution: CLSAttribution = {};
+  if (metric.entries.length) {
+    const largestEntry = getLargestLayoutShiftEntry(metric.entries);
+    if (largestEntry && largestEntry.sources && largestEntry.sources.length) {
+      const largestSource = getLargestLayoutShiftSource(largestEntry.sources);
+      if (largestSource) {
+        attribution = {
+          largestShiftTarget: getSelector(largestSource.node),
+          largestShiftTime: largestEntry.startTime,
+          largestShiftValue: largestEntry.value,
+          largestShiftSource: largestSource,
+          largestShiftEntry: largestEntry,
+          loadState: getLoadState(largestEntry.startTime),
+        };
+      }
+    }
+  }
+  return Object.assign(metric, {attribution});
+}
+
+/**
+ * Calculates the [CLS](https://web.dev/cls/) value for the current page and
+ * calls the `callback` function once the value is ready to be reported, along
+ * with all `layout-shift` performance entries that were used in the metric
+ * value calculation. The reported value is a `double` (corresponding to a
+ * [layout shift score](https://web.dev/cls/#layout-shift-score)).
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called as soon as the value is initially
+ * determined as well as any time the value changes throughout the page
+ * lifespan.
+ *
+ * _**Important:** CLS should be continually monitored for changes throughout
+ * the entire lifespan of a page—including if the user returns to the page after
+ * it's been hidden/backgrounded. However, since browsers often [will not fire
+ * additional callbacks once the user has backgrounded a
+ * page](https://developer.chrome.com/blog/page-lifecycle-api/#advice-hidden),
+ * `callback` is always called when the page's visibility state changes to
+ * hidden. As a result, the `callback` function might be called multiple times
+ * during the same page load._
+ */
+export const onCLS = (onReport: CLSReportCallbackWithAttribution, opts?: ReportOpts) => {
+  unattributedOnCLS(((metric: CLSMetric) => {
+    onReport(attributeCLS(metric));
+  }) as CLSReportCallback, opts);
+};

--- a/src/attribution/onFCP.ts
+++ b/src/attribution/onFCP.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getBFCacheRestoreTime} from '../lib/bfcache.js';
+import {getLoadState} from '../lib/getLoadState.js';
+import {getNavigationEntry} from '../lib/getNavigationEntry.js';
+import {onFCP as unattributedOnFCP} from '../onFCP.js';
+import {FCPMetricWithAttribution, FCPReportCallback, FCPReportCallbackWithAttribution, ReportOpts} from '../types.js';
+
+
+const attributeFCP = (metric: FCPMetricWithAttribution): void => {
+  if (metric.entries.length) {
+    const navigationEntry = getNavigationEntry();
+    const fcpEntry = metric.entries[metric.entries.length - 1];
+
+    if (navigationEntry) {
+      const activationStart = navigationEntry.activationStart || 0;
+      const ttfb = Math.max(0, navigationEntry.responseStart - activationStart);
+
+      metric.attribution = {
+        timeToFirstByte: ttfb,
+        firstByteToFCP: metric.value - ttfb,
+        loadState: getLoadState(metric.entries[0].startTime),
+        navigationEntry,
+        fcpEntry,
+      };
+    }
+  } else {
+    // There are no entries when restored from bfcache.
+    metric.attribution = {
+      timeToFirstByte: 0,
+      firstByteToFCP: metric.value,
+      loadState: getLoadState(getBFCacheRestoreTime()),
+    };
+  }
+};
+
+/**
+ * Calculates the [FCP](https://web.dev/fcp/) value for the current page and
+ * calls the `callback` function once the value is ready, along with the
+ * relevant `paint` performance entry used to determine the value. The reported
+ * value is a `DOMHighResTimeStamp`.
+ */
+export const onFCP = (onReport: FCPReportCallbackWithAttribution, opts?: ReportOpts) => {
+  unattributedOnFCP(((metric: FCPMetricWithAttribution) => {
+    attributeFCP(metric);
+    onReport(metric);
+  }) as FCPReportCallback, opts);
+};

--- a/src/attribution/onFID.ts
+++ b/src/attribution/onFID.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getLoadState} from '../lib/getLoadState.js';
+import {getSelector} from '../lib/getSelector.js';
+import {onFID as unattributedOnFID} from '../onFID.js';
+import {FIDAttribution, FIDMetricWithAttribution, FIDReportCallback, FIDReportCallbackWithAttribution, ReportOpts} from '../types.js';
+
+
+const attributeFID = (metric: FIDMetricWithAttribution): void => {
+  const fidEntry = metric.entries[0];
+  metric.attribution = {
+    eventTarget: getSelector(fidEntry.target),
+    eventType: fidEntry.name,
+    eventTime: fidEntry.startTime,
+    eventEntry: fidEntry,
+    loadState: getLoadState(fidEntry.startTime),
+  } as FIDAttribution;
+};
+
+/**
+ * Calculates the [FID](https://web.dev/fid/) value for the current page and
+ * calls the `callback` function once the value is ready, along with the
+ * relevant `first-input` performance entry used to determine the value. The
+ * reported value is a `DOMHighResTimeStamp`.
+ *
+ * _**Important:** since FID is only reported after the user interacts with the
+ * page, it's possible that it will not be reported for some page loads._
+ */
+export const onFID = (onReport: FIDReportCallbackWithAttribution, opts?: ReportOpts) => {
+  unattributedOnFID(((metric: FIDMetricWithAttribution) => {
+    attributeFID(metric);
+    onReport(metric);
+  }) as FIDReportCallback, opts);
+};

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getLoadState} from '../lib/getLoadState.js';
+import {getSelector} from '../lib/getSelector.js';
+import {onINP as unattributedOnINP} from '../onINP.js';
+import {INPMetricWithAttribution, INPReportCallback, INPReportCallbackWithAttribution, ReportOpts} from '../types.js';
+
+
+const attributeINP = (metric: INPMetricWithAttribution): void => {
+  if (metric.entries.length) {
+    const longestEntry = metric.entries.sort((a, b) => {
+      // Sort by: 1) duration (DESC), then 2) processing time (DESC)
+      return b.duration - a.duration || (b.processingEnd - b.processingStart) -
+      (a.processingEnd - a.processingStart);
+    })[0];
+
+    metric.attribution = {
+      eventTarget: getSelector(longestEntry.target),
+      eventType: longestEntry.name,
+      eventTime: longestEntry.startTime,
+      eventEntry: longestEntry,
+      loadState: getLoadState(longestEntry.startTime),
+    };
+  } else {
+    metric.attribution = {};
+  }
+};
+
+/**
+ * Calculates the [INP](https://web.dev/responsiveness/) value for the current
+ * page and calls the `callback` function once the value is ready, along with
+ * the `event` performance entries reported for that interaction. The reported
+ * value is a `DOMHighResTimeStamp`.
+ *
+ * A custom `durationThreshold` configuration option can optionally be passed to
+ * control what `event-timing` entries are considered for INP reporting. The
+ * default threshold is `40`, which means INP scores of less than 40 are
+ * reported as 0. Note that this will not affect your 75th percentile INP value
+ * unless that value is also less than 40 (well below the recommended
+ * [good](https://web.dev/inp/#what-is-a-good-inp-score) threshold).
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called as soon as the value is initially
+ * determined as well as any time the value changes throughout the page
+ * lifespan.
+ *
+ * _**Important:** INP should be continually monitored for changes throughout
+ * the entire lifespan of a page—including if the user returns to the page after
+ * it's been hidden/backgrounded. However, since browsers often [will not fire
+ * additional callbacks once the user has backgrounded a
+ * page](https://developer.chrome.com/blog/page-lifecycle-api/#advice-hidden),
+ * `callback` is always called when the page's visibility state changes to
+ * hidden. As a result, the `callback` function might be called multiple times
+ * during the same page load._
+ */
+export const onINP = (onReport: INPReportCallbackWithAttribution, opts?: ReportOpts) => {
+  unattributedOnINP(((metric: INPMetricWithAttribution) => {
+    attributeINP(metric);
+    onReport(metric);
+  }) as INPReportCallback, opts);
+};

--- a/src/attribution/onLCP.ts
+++ b/src/attribution/onLCP.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getNavigationEntry} from '../lib/getNavigationEntry.js';
+import {getSelector} from '../lib/getSelector.js';
+import {onLCP as unattributedOnLCP} from '../onLCP.js';
+import {LCPMetricWithAttribution, LCPReportCallback, LCPReportCallbackWithAttribution, ReportOpts} from '../types.js';
+
+
+const attributeLCP = (metric: LCPMetricWithAttribution): void => {
+  if (metric.entries.length) {
+    const navigationEntry = getNavigationEntry();
+
+    if (navigationEntry) {
+      const activationStart = navigationEntry.activationStart || 0;
+      const lcpEntry = metric.entries[metric.entries.length - 1];
+      const lcpResourceEntry = performance
+          .getEntriesByType('resource')
+          .filter((e) => e.name === lcpEntry.url)[0];
+
+      const ttfb = Math.max(0, navigationEntry.responseStart - activationStart);
+
+      const lcpRequestStart = Math.max(
+        ttfb,
+        // Prefer `requestStart` (if TOA is set), otherwise use `startTime`.
+        lcpResourceEntry ? (lcpResourceEntry.requestStart ||
+            lcpResourceEntry.startTime) - activationStart : 0
+      );
+      const lcpResponseEnd = Math.max(
+        lcpRequestStart,
+        lcpResourceEntry ? lcpResourceEntry.responseEnd - activationStart : 0
+      );
+      const lcpRenderTime = Math.max(
+        lcpResponseEnd,
+        lcpEntry ? lcpEntry.startTime - activationStart : 0
+      );
+
+      metric.attribution = {
+        element: getSelector(lcpEntry.element),
+        timeToFirstByte: ttfb,
+        resourceLoadDelay: lcpRequestStart - ttfb,
+        resourceLoadTime: lcpResponseEnd - lcpRequestStart,
+        elementRenderDelay: lcpRenderTime - lcpResponseEnd,
+        navigationEntry,
+        lcpResourceEntry,
+        lcpEntry,
+      };
+    }
+  } else {
+    // There are no entries when restored from bfcache.
+    metric.attribution = {
+      timeToFirstByte: 0,
+      resourceLoadDelay: 0,
+      resourceLoadTime: 0,
+      elementRenderDelay: metric.value,
+    };
+  }
+};
+
+/**
+ * Calculates the [LCP](https://web.dev/lcp/) value for the current page and
+ * calls the `callback` function once the value is ready (along with the
+ * relevant `largest-contentful-paint` performance entry used to determine the
+ * value). The reported value is a `DOMHighResTimeStamp`.
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called any time a new `largest-contentful-paint`
+ * performance entry is dispatched, or once the final value of the metric has
+ * been determined.
+ */
+export const onLCP = (onReport: LCPReportCallbackWithAttribution, opts?: ReportOpts) => {
+  unattributedOnLCP(((metric: LCPMetricWithAttribution) => {
+    attributeLCP(metric);
+    onReport(metric);
+  }) as LCPReportCallback, opts);
+};

--- a/src/attribution/onTTFB.ts
+++ b/src/attribution/onTTFB.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {onTTFB as unattributedOnTTFB} from '../onTTFB.js';
+import {TTFBMetricWithAttribution, TTFBReportCallback, TTFBReportCallbackWithAttribution, ReportOpts} from '../types.js';
+
+
+const attributeTTFB = (metric: TTFBMetricWithAttribution): void => {
+  if (metric.entries.length) {
+    const navigationEntry = metric.entries[0];
+    const activationStart = navigationEntry.activationStart || 0;
+
+    const dnsStart = Math.max(
+        navigationEntry.domainLookupStart - activationStart, 0);
+    const connectStart = Math.max(
+        navigationEntry.connectStart - activationStart, 0);
+    const requestStart = Math.max(
+        navigationEntry.requestStart - activationStart, 0);
+
+    metric.attribution = {
+      waitingTime: dnsStart,
+      dnsTime: connectStart - dnsStart,
+      connectionTime: requestStart - connectStart,
+      requestTime: metric.value - requestStart,
+      navigationEntry: navigationEntry,
+    };
+  } else {
+    metric.attribution = {
+      waitingTime: 0,
+      dnsTime: 0,
+      connectionTime: 0,
+      requestTime: 0,
+    };
+  }
+};
+
+/**
+ * Calculates the [TTFB](https://web.dev/time-to-first-byte/) value for the
+ * current page and calls the `callback` function once the page has loaded,
+ * along with the relevant `navigation` performance entry used to determine the
+ * value. The reported value is a `DOMHighResTimeStamp`.
+ *
+ * Note, this function waits until after the page is loaded to call `callback`
+ * in order to ensure all properties of the `navigation` entry are populated.
+ * This is useful if you want to report on other metrics exposed by the
+ * [Navigation Timing API](https://w3c.github.io/navigation-timing/). For
+ * example, the TTFB metric starts from the page's [time
+ * origin](https://www.w3.org/TR/hr-time-2/#sec-time-origin), which means it
+ * includes time spent on DNS lookup, connection negotiation, network latency,
+ * and server processing time.
+ */
+export const onTTFB = (onReport: TTFBReportCallbackWithAttribution, opts?: ReportOpts) => {
+  unattributedOnTTFB(((metric: TTFBMetricWithAttribution) => {
+    attributeTTFB(metric);
+    onReport(metric);
+  }) as TTFBReportCallback, opts);
+};

--- a/src/lib/bfcache.ts
+++ b/src/lib/bfcache.ts
@@ -18,14 +18,14 @@ interface onBFCacheRestoreCallback {
   (event: PageTransitionEvent): void;
 }
 
-let isPersisted = false;
+let bfcacheRestoreTime = -1;
 
-export const isBFCacheRestore = () => isPersisted;
+export const getBFCacheRestoreTime = () => bfcacheRestoreTime;
 
 export const onBFCacheRestore = (cb: onBFCacheRestoreCallback) => {
   addEventListener('pageshow', (event) => {
     if (event.persisted) {
-      isPersisted = true;
+      bfcacheRestoreTime = event.timeStamp;
       cb(event);
     }
   }, true);

--- a/src/lib/getLoadState.ts
+++ b/src/lib/getLoadState.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getNavigationEntry} from './getNavigationEntry.js';
+import {LoadState} from '../types.js';
+
+
+export const getLoadState = (timestamp: number): LoadState => {
+  if (document.readyState === 'loading') {
+    // If the `readyState` is 'loading' there's no need to look at timestamps
+    // since the timestamp has to be the current time or earlier.
+    return 'loading';
+  } else {
+    const navigationEntry = getNavigationEntry();
+    if (navigationEntry) {
+
+      if (timestamp < navigationEntry.domInteractive) {
+        return 'loading';
+      } else if (navigationEntry.domContentLoadedEventStart === 0 ||
+          timestamp < navigationEntry.domContentLoadedEventStart) {
+        // If the `domContentLoadedEventStart` timestamp has not yet been
+        // set, or if the given timestamp is less than that value.
+        return 'domInteractive';
+      } else if (navigationEntry.domComplete === 0 ||
+          timestamp < navigationEntry.domComplete) {
+        // If the `domComplete` timestamp has not yet been
+        // set, or if the given timestamp is less than that value.
+        return 'domContentloaded';
+      }
+    }
+  }
+  // If any of the above fail, default to loaded. This could really only
+  // happy if the browser doesn't support the performance timeline, which
+  // most likely means this code would never run anyway.
+  return 'loaded';
+}

--- a/src/lib/getSelector.ts
+++ b/src/lib/getSelector.ts
@@ -1,0 +1,42 @@
+
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const getName = (node: Node) => {
+  const name = node.nodeName;
+  return node.nodeType === 1 ?
+      name.toLowerCase() : name.toUpperCase().replace(/^#/, '');
+}
+
+export const getSelector = (node: Node | null | undefined, maxLen?: number) => {
+  let sel = '';
+
+  try {
+    while (node && node.nodeType !== 9) {
+      const el: Element = (node as Element);
+      const part = el.id ? '#' + el.id : getName(el) + (
+          (el.className && el.className.length) ?
+          '.' + el.className.replace(/\s+/g, '.') : '');
+      if (sel.length + part.length > (maxLen || 100) - 1) return sel || part;
+      sel = sel ? part + '>' + sel : part;
+      if (el.id) break;
+      node = el.parentNode;
+    }
+  } catch (err) {
+    // Do nothing...
+  }
+  return sel;
+};

--- a/src/lib/initMetric.ts
+++ b/src/lib/initMetric.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {isBFCacheRestore} from './bfcache.js';
+import {getBFCacheRestoreTime} from './bfcache.js';
 import {generateUniqueID} from './generateUniqueID.js';
 import {getActivationStart} from './getActivationStart.js';
 import {getNavigationEntry} from './getNavigationEntry.js';
@@ -25,7 +25,7 @@ export const initMetric = (name: Metric['name'], value?: number): Metric => {
   const navEntry = getNavigationEntry();
   let navigationType: Metric['navigationType'];
 
-  if (isBFCacheRestore()) {
+  if (getBFCacheRestoreTime() >= 0) {
     navigationType = 'back_forward_cache';
   } else if (navEntry) {
     if (document.prerendering || getActivationStart() > 0) {

--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-import {Metric} from '../types.js';
+import {FirstInputPolyfillEntry, NavigationTimingPolyfillEntry} from '../types.js';
 
 
-interface PerformanceEntriesHandler {
-  (entries: Metric['entries']): void;
+interface PerformanceEntryMap {
+  'event': PerformanceEventTiming[];
+  'paint': PerformancePaintTiming[];
+  'layout-shift': LayoutShift[];
+  'largest-contentful-paint': LargestContentfulPaint[];
+  'first-input': PerformanceEventTiming[] | FirstInputPolyfillEntry[];
+  'navigation': PerformanceNavigationTiming[] | NavigationTimingPolyfillEntry[];
+  'resource': PerformanceResourceTiming[];
 }
 
 /**
@@ -29,15 +35,15 @@ interface PerformanceEntriesHandler {
  * This function also feature-detects entry support and wraps the logic in a
  * try/catch to avoid errors in unsupporting browsers.
  */
-export const observe = (
-  type: string,
-  callback: PerformanceEntriesHandler,
+export const observe = <K extends keyof PerformanceEntryMap>(
+  type: K,
+  callback: (entries: PerformanceEntryMap[K]) => void,
   opts?: PerformanceObserverInit,
 ): PerformanceObserver | undefined => {
   try {
     if (PerformanceObserver.supportedEntryTypes.includes(type)) {
-      const po: PerformanceObserver = new PerformanceObserver((list) => {
-        callback(list.getEntries());
+      const po = new PerformanceObserver((list) => {
+        callback(list.getEntries() as PerformanceEntryMap[K]);
       });
       po.observe(Object.assign({
         type,

--- a/src/lib/polyfills/interactionCountPolyfill.ts
+++ b/src/lib/polyfills/interactionCountPolyfill.ts
@@ -15,7 +15,7 @@
  */
 
 import {observe} from '../observe.js';
-import {Metric, PerformanceEventTiming} from '../../types.js';
+import {Metric} from '../../types.js';
 
 
 declare global {

--- a/src/onCLS.ts
+++ b/src/onCLS.ts
@@ -20,13 +20,34 @@ import {observe} from './lib/observe.js';
 import {onHidden} from './lib/onHidden.js';
 import {bindReporter} from './lib/bindReporter.js';
 import {onFCP} from './onFCP.js';
-import {LayoutShift, Metric, ReportCallback, ReportOpts} from './types.js';
+import {CLSMetric, CLSReportCallback, ReportOpts} from './types.js';
 
 
 let isMonitoringFCP = false;
 let fcpValue = -1;
 
-export const onCLS = (onReport: ReportCallback, opts?: ReportOpts) => {
+/**
+ * Calculates the [CLS](https://web.dev/cls/) value for the current page and
+ * calls the `callback` function once the value is ready to be reported, along
+ * with all `layout-shift` performance entries that were used in the metric
+ * value calculation. The reported value is a `double` (corresponding to a
+ * [layout shift score](https://web.dev/cls/#layout-shift-score)).
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called as soon as the value is initially
+ * determined as well as any time the value changes throughout the page
+ * lifespan.
+ *
+ * _**Important:** CLS should be continually monitored for changes throughout
+ * the entire lifespan of a page—including if the user returns to the page after
+ * it's been hidden/backgrounded. However, since browsers often [will not fire
+ * additional callbacks once the user has backgrounded a
+ * page](https://developer.chrome.com/blog/page-lifecycle-api/#advice-hidden),
+ * `callback` is always called when the page's visibility state changes to
+ * hidden. As a result, the `callback` function might be called multiple times
+ * during the same page load._
+ */
+export const onCLS = (onReport: CLSReportCallback, opts?: ReportOpts) => {
   // Set defaults
   opts = opts || {};
 
@@ -39,7 +60,7 @@ export const onCLS = (onReport: ReportCallback, opts?: ReportOpts) => {
     isMonitoringFCP = true;
   }
 
-  const onReportWrapped: ReportCallback = (arg) => {
+  const onReportWrapped: CLSReportCallback = (arg) => {
     if (fcpValue > -1) {
       onReport(arg);
     }
@@ -51,8 +72,9 @@ export const onCLS = (onReport: ReportCallback, opts?: ReportOpts) => {
   let sessionValue = 0;
   let sessionEntries: PerformanceEntry[] = [];
 
-  const handleEntries = (entries: Metric['entries']) => {
-    (entries as LayoutShift[]).forEach((entry) => {
+  // const handleEntries = (entries: Metric['entries']) => {
+  const handleEntries = (entries: LayoutShift[]) => {
+    entries.forEach((entry) => {
       // Only count layout shifts without recent user input.
       if (!entry.hadRecentInput) {
         const firstSessionEntry = sessionEntries[0];
@@ -87,7 +109,7 @@ export const onCLS = (onReport: ReportCallback, opts?: ReportOpts) => {
     report = bindReporter(onReportWrapped, metric, opts.reportAllChanges);
 
     onHidden(() => {
-      handleEntries(po.takeRecords());
+      handleEntries(po.takeRecords() as CLSMetric['entries']);
       report(true);
     });
 

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -20,10 +20,15 @@ import {getActivationStart} from './lib/getActivationStart.js';
 import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
 import {initMetric} from './lib/initMetric.js';
 import {observe} from './lib/observe.js';
-import {Metric, ReportCallback, ReportOpts} from './types.js';
+import {FCPMetric, FCPReportCallback, ReportOpts} from './types.js';
 
-
-export const onFCP = (onReport: ReportCallback, opts?: ReportOpts) => {
+/**
+ * Calculates the [FCP](https://web.dev/fcp/) value for the current page and
+ * calls the `callback` function once the value is ready, along with the
+ * relevant `paint` performance entry used to determine the value. The reported
+ * value is a `DOMHighResTimeStamp`.
+ */
+export const onFCP = (onReport: FCPReportCallback, opts?: ReportOpts) => {
   // Set defaults
   opts = opts || {};
 
@@ -31,7 +36,7 @@ export const onFCP = (onReport: ReportCallback, opts?: ReportOpts) => {
   let metric = initMetric('FCP');
   let report: ReturnType<typeof bindReporter>;
 
-  const handleEntries = (entries: Metric['entries']) => {
+  const handleEntries = (entries: FCPMetric['entries']) => {
     (entries as PerformancePaintTiming[]).forEach((entry) => {
       if (entry.name === 'first-contentful-paint') {
         if (po) {

--- a/src/onFID.ts
+++ b/src/onFID.ts
@@ -21,9 +21,17 @@ import {initMetric} from './lib/initMetric.js';
 import {observe} from './lib/observe.js';
 import {onHidden} from './lib/onHidden.js';
 import {firstInputPolyfill, resetFirstInputPolyfill} from './lib/polyfills/firstInputPolyfill.js';
-import {FirstInputPolyfillCallback, Metric, PerformanceEventTiming, ReportCallback, ReportOpts} from './types.js';
+import {FIDMetric, FirstInputPolyfillCallback, ReportCallback, ReportOpts} from './types.js';
 
-
+/**
+ * Calculates the [FID](https://web.dev/fid/) value for the current page and
+ * calls the `callback` function once the value is ready, along with the
+ * relevant `first-input` performance entry used to determine the value. The
+ * reported value is a `DOMHighResTimeStamp`.
+ *
+ * _**Important:** since FID is only reported after the user interacts with the
+ * page, it's possible that it will not be reported for some page loads._
+ */
 export const onFID = (onReport: ReportCallback, opts?: ReportOpts) => {
   // Set defaults
   opts = opts || {};
@@ -41,7 +49,7 @@ export const onFID = (onReport: ReportCallback, opts?: ReportOpts) => {
     }
   }
 
-  const handleEntries = (entries: Metric['entries']) => {
+  const handleEntries = (entries: FIDMetric['entries']) => {
     (entries as PerformanceEventTiming[]).forEach(handleEntry);
   }
 
@@ -50,7 +58,7 @@ export const onFID = (onReport: ReportCallback, opts?: ReportOpts) => {
 
   if (po) {
     onHidden(() => {
-      handleEntries(po.takeRecords());
+      handleEntries(po.takeRecords() as FIDMetric['entries']);
       po.disconnect();
     }, true);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,110 +14,22 @@
  * limitations under the License.
  */
 
-export interface Metric {
-  // The name of the metric (in acronym form).
-  name: 'CLS' | 'FCP' | 'FID' | 'INP' | 'LCP' | 'TTFB';
+import {FirstInputPolyfillCallback} from './types/polyfills.js';
 
-  // The current value of the metric.
-  value: number;
+export * from './types/base.js';
+export * from './types/polyfills.js';
 
-  // The delta between the current value and the last-reported value.
-  // On the first report, `delta` and `value` will always be the same.
-  delta: number;
+export * from './types/cls.js';
+export * from './types/fcp.js';
+export * from './types/fid.js';
+export * from './types/inp.js';
+export * from './types/lcp.js';
+export * from './types/ttfb.js';
 
-  // A unique ID representing this particular metric instance. This ID can
-  // be used by an analytics tool to dedupe multiple values sent for the same
-  // metric instance, or to group multiple deltas together and calculate a
-  // total. It can also be used to differentiate multiple different metric
-  // instances sent from the same page, which can happen if the page is
-  // restored from the back/forward cache (in that case new metrics object
-  // get created).
-  id: string;
 
-  // Any performance entries relevant to the metric value calculation.
-  // The array may also be empty if the metric value was not based on any
-  // entries (e.g. a CLS value of 0 given no layout shifts).
-  entries: (PerformanceEntry | LayoutShift | FirstInputPolyfillEntry | NavigationTimingPolyfillEntry)[];
-
-  // For regular navigations, the type will be the same as the type indicated
-  // by the Navigation Timing API (or `undefined` if the browser doesn't
-  // support that API). For pages that are restored from the bfcache, this
-  // value will be 'back_forward_cache'.
-  navigationType:  NavigationTimingType | 'back_forward_cache' | 'prerender' | undefined;
-}
-
-export interface ReportCallback {
-  (metric: Metric): void;
-}
-
-export interface ReportOpts {
-  reportAllChanges?: boolean;
-  durationThreshold?: number;
-}
-
-interface PerformanceEntryMap {
-  'navigation': PerformanceNavigationTiming;
-  'resource': PerformanceResourceTiming;
-  'paint': PerformancePaintTiming;
-}
-
-// Update built-in types to be more accurate.
-declare global {
-  // https://wicg.github.io/nav-speculation/prerendering.html#document-prerendering
-  interface Document {
-    prerendering?: boolean
-  }
-  interface Performance {
-    getEntriesByType<K extends keyof PerformanceEntryMap>(type: K): PerformanceEntryMap[K][]
-  }
-  // https://w3c.github.io/event-timing/#sec-modifications-perf-timeline
-  interface PerformanceObserverInit {
-    durationThreshold?: number;
-  }
-  // https://wicg.github.io/nav-speculation/prerendering.html#performance-navigation-timing-extension
-  interface PerformanceNavigationTiming {
-    activationStart?: number;
-  }
-}
-
-// https://wicg.github.io/event-timing/#sec-performance-event-timing
-export interface PerformanceEventTiming extends PerformanceEntry {
-  processingStart: DOMHighResTimeStamp;
-  processingEnd: DOMHighResTimeStamp;
-  duration: DOMHighResTimeStamp;
-  cancelable?: boolean;
-  target?: Element;
-  interactionId?: number;
-}
-
-// https://wicg.github.io/layout-instability/#sec-layout-shift
-export interface LayoutShift extends PerformanceEntry {
-  value: number;
-  hadRecentInput: boolean;
-}
-
-// https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface
-export interface LargestContentfulPaint extends PerformanceEntry {
-  renderTime: DOMHighResTimeStamp;
-  loadTime: DOMHighResTimeStamp;
-  size: number;
-  id: string;
-  url: string;
-  element?: Element;
-}
-
-export type FirstInputPolyfillEntry =
-    Omit<PerformanceEventTiming, 'processingEnd'>
-
-export interface FirstInputPolyfillCallback {
-  (entry: FirstInputPolyfillEntry): void;
-}
-
-export type NavigationTimingPolyfillEntry = Omit<PerformanceNavigationTiming,
-    'initiatorType' | 'nextHopProtocol' | 'redirectCount' | 'transferSize' |
-    'encodedBodySize' | 'decodedBodySize' | 'type'> & {
-  type?: PerformanceNavigationTiming['type'];
-}
+// --------------------------------------------------------------------------
+// Web Vitals package globals
+// --------------------------------------------------------------------------
 
 export interface WebVitalsGlobal {
   firstInputPolyfill: (onFirstInput: FirstInputPolyfillCallback) => void;
@@ -131,5 +43,67 @@ declare global {
 
     // Build flags:
     __WEB_VITALS_POLYFILL__: boolean;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Everything below is modifications to built-in modules.
+// --------------------------------------------------------------------------
+
+interface PerformanceEntryMap {
+  'navigation': PerformanceNavigationTiming;
+  'resource': PerformanceResourceTiming;
+  'paint': PerformancePaintTiming;
+}
+
+// Update built-in types to be more accurate.
+declare global {
+  // https://wicg.github.io/nav-speculation/prerendering.html#document-prerendering
+  interface Document {
+    prerendering?: boolean
+  }
+
+  interface Performance {
+    getEntriesByType<K extends keyof PerformanceEntryMap>(type: K): PerformanceEntryMap[K][]
+  }
+
+  // https://w3c.github.io/event-timing/#sec-modifications-perf-timeline
+  interface PerformanceObserverInit {
+    durationThreshold?: number;
+  }
+
+  // https://wicg.github.io/nav-speculation/prerendering.html#performance-navigation-timing-extension
+  interface PerformanceNavigationTiming {
+    activationStart?: number;
+  }
+
+  // https://wicg.github.io/event-timing/#sec-performance-event-timing
+  interface PerformanceEventTiming extends PerformanceEntry {
+    duration: DOMHighResTimeStamp;
+    interactionId?: number;
+  }
+
+  // https://wicg.github.io/layout-instability/#sec-layout-shift-attribution
+  interface LayoutShiftAttribution {
+    node?: Node;
+    previousRect: DOMRectReadOnly;
+    currentRect: DOMRectReadOnly;
+  }
+
+  // https://wicg.github.io/layout-instability/#sec-layout-shift
+  interface LayoutShift extends PerformanceEntry {
+    value: number;
+    sources: LayoutShiftAttribution[];
+    hadRecentInput: boolean;
+  }
+
+  // https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface
+  interface LargestContentfulPaint extends PerformanceEntry {
+    renderTime: DOMHighResTimeStamp;
+    loadTime: DOMHighResTimeStamp;
+    size: number;
+    id: string;
+    url: string;
+    element?: Element;
   }
 }

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {FirstInputPolyfillEntry, NavigationTimingPolyfillEntry} from './polyfills.js';
+
+
+export interface Metric {
+  /**
+   * The name of the metric (in acronym form).
+   */
+  name: 'CLS' | 'FCP' | 'FID' | 'INP' | 'LCP' | 'TTFB';
+
+  /**
+   * The current value of the metric.
+   */
+  value: number;
+
+  /**
+   * The delta between the current value and the last-reported value.
+   * On the first report, `delta` and `value` will always be the same.
+   */
+  delta: number;
+
+  /**
+   * A unique ID representing this particular metric instance. This ID can
+   * be used by an analytics tool to dedupe multiple values sent for the same
+   * metric instance, or to group multiple deltas together and calculate a
+   * total. It can also be used to differentiate multiple different metric
+   * instances sent from the same page, which can happen if the page is
+   * restored from the back/forward cache (in that case new metrics object
+   * get created).
+   */
+  id: string;
+
+  /**
+   * Any performance entries relevant to the metric value calculation.
+   * The array may also be empty if the metric value was not based on any
+   * entries (e.g. a CLS value of 0 given no layout shifts).
+   */
+  entries: (PerformanceEntry | LayoutShift | FirstInputPolyfillEntry | NavigationTimingPolyfillEntry)[];
+
+  /**
+   * For regular navigations, the type will be the same as the type indicated
+   * by the Navigation Timing API (or `undefined` if the browser doesn't
+   * support that API). For pages that are restored from the bfcache, this
+   * value will be 'back_forward_cache'.
+   */
+  navigationType:  NavigationTimingType | 'back_forward_cache' | 'prerender' | undefined;
+}
+
+/**
+ * A version of the `Metric` that is used with the attribution build.
+ */
+export interface MetricWithAttribution extends Metric {
+  /**
+   * An object containing potentially-helpful debugging information that
+   * can be sent along with the metric value for the current page visit in
+   * order to help identify issues happening to real-users in the field.
+   */
+  attribution: {[key: string]: unknown};
+}
+
+export interface ReportCallback {
+  (metric: Metric): void;
+}
+
+export interface ReportOpts {
+  reportAllChanges?: boolean;
+  durationThreshold?: number;
+}
+
+/**
+ * The loading state of the document. Note: this value is similar to
+ * `document.readyState` but it subdivides the "interactive" state into the
+ * time before and after the DOMContentLoaded event fires.
+ *
+ * State descriptions:
+ * - `loading`: the initial document response has not yet been fully downloaded
+ *   and parsed. This is equivalent to the corresponding `readyState` value.
+ * - `domInteractive`: the document has been fully loaded and parsed, but
+ *   scripts may not have yet finished loading and executing.
+ * - `domContentLoaded`: the document is fully loaded and parsed, and all
+ *   scripts (except `async` scripts) have loaded and finished executing.
+ * - `loaded`: the document and all of its sub-resources have finished loading.
+ *   This is equivalent to a document `readyState` of "complete".
+ */
+export type LoadState = 'loading' | 'domInteractive' | 'domContentloaded' | 'loaded';

--- a/src/types/cls.ts
+++ b/src/types/cls.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LoadState, Metric, ReportCallback} from './base.js';
+
+
+/**
+ * A CLS-specific version of the Metric object.
+ */
+export interface CLSMetric extends Metric {
+  name: 'CLS';
+  entries: LayoutShift[];
+}
+
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the CLS value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+ export interface CLSAttribution {
+  /**
+   * A selector identifying the first element (in document order) that
+   * shifted when the single largest layout shift contributing to the page's
+   * CLS score occurred.
+   */
+  largestShiftTarget?: string;
+  /**
+   * The time when the single largest layout shift contributing to the page's
+   * CLS score occurred.
+   */
+  largestShiftTime?: DOMHighResTimeStamp;
+  /**
+   * The layout shift score of the single largest layout shift contributing to
+   * the page's CLS score.
+   */
+  largestShiftValue?: number;
+  /**
+   * The `LayoutShiftEntry` representing the single largest layout shift
+   * contributing to the page's CLS score. (Useful when you need more than just
+   * `largestShiftTarget`, `largestShiftTime`, and `largestShiftValue`).
+   */
+  largestShiftEntry?: LayoutShift;
+  /**
+   * The first element source (in document order) among the `sources` list
+   * of the `largestShiftEntry` object. (Also useful when you need more than
+   * just `largestShiftTarget`, `largestShiftTime`, and `largestShiftValue`).
+   */
+  largestShiftSource?: LayoutShiftAttribution;
+  /**
+   * The loading state of the document at the time when the largest layout
+   * shift contribution to the page's CLS score occurred (see `LoadState`
+   * for details).
+   */
+  loadState?: LoadState;
+}
+
+/**
+ * A CLS-specific version of the Metric object with attribution.
+ */
+export interface CLSMetricWithAttribution extends CLSMetric {
+  attribution: CLSAttribution;
+}
+
+/**
+ * A CLS-specific version of the ReportCallback function.
+ */
+export interface CLSReportCallback extends ReportCallback {
+  (metric: CLSMetric): void;
+}
+
+/**
+ * A CLS-specific version of the ReportCallback function with attribution.
+ */
+export interface CLSReportCallbackWithAttribution extends CLSReportCallback {
+  (metric: CLSMetricWithAttribution): void;
+}

--- a/src/types/fcp.ts
+++ b/src/types/fcp.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LoadState, Metric, ReportCallback} from './base.js';
+import {NavigationTimingPolyfillEntry} from './polyfills.js';
+
+
+/**
+ * An FCP-specific version of the Metric object.
+ */
+export interface FCPMetric extends Metric {
+  name: 'FCP';
+  entries: PerformancePaintTiming[];
+}
+
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the FCP value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+ export interface FCPAttribution {
+  /**
+   * The time from when the user initiates loading the page until when the
+   * browser receives the first byte of the response (a.k.a. TTFB).
+   */
+  timeToFirstByte: number;
+  /**
+   * The delta between TTFB and the first contentful paint (FCP).
+   */
+  firstByteToFCP: number;
+  /**
+   * The loading state of the document at the time when FCP `occurred (see
+   * `LoadState` for details). Ideally, documents can paint before they finish
+   * loading (e.g. the `loading` or `domInteractive` phases).
+   */
+  loadState: LoadState,
+  /**
+   * The `PerformancePaintTiming` entry corresponding to FCP.
+   */
+  fcpEntry?: PerformancePaintTiming,
+  /**
+   * The `navigation` entry of the current page, which is useful for diagnosing
+   * general page load issues.
+   */
+  navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
+}
+
+/**
+ * An FCP-specific version of the Metric object with attribution.
+ */
+export interface FCPMetricWithAttribution extends FCPMetric {
+  attribution: FCPAttribution;
+}
+
+/**
+ * An FCP-specific version of the ReportCallback function.
+ */
+export interface FCPReportCallback extends ReportCallback {
+  (metric: FCPMetric): void;
+}
+
+/**
+ * An FCP-specific version of the ReportCallback function with attribution.
+ */
+export interface FCPReportCallbackWithAttribution extends FCPReportCallback {
+  (metric: FCPMetricWithAttribution): void;
+}

--- a/src/types/fid.ts
+++ b/src/types/fid.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LoadState, Metric, ReportCallback} from './base.js';
+import {FirstInputPolyfillEntry} from './polyfills.js';
+
+
+/**
+ * An FID-specific version of the Metric object.
+ */
+export interface FIDMetric extends Metric {
+  name: 'FID';
+  entries: (PerformanceEventTiming | FirstInputPolyfillEntry)[];
+}
+
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the FID value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+export interface FIDAttribution {
+  /**
+   * A selector identifying the element that the user interacted with. This
+   * element will be the `target` of the `event` dispatched.
+   */
+  eventTarget: string;
+  /**
+   * The time when the user interacted. This time will match the `timeStamp`
+   * value of the `event` dispatched.
+   */
+  eventTime: number;
+  /**
+   * The `type` of the `event` dispatched from the user interaction.
+   */
+  eventType: string;
+  /**
+   * The `PerformanceEventTiming` entry corresponding to FID (or the
+   * polyfill entry in browsers that don't support Event Timing).
+   */
+  eventEntry: PerformanceEventTiming | FirstInputPolyfillEntry,
+  /**
+   * The loading state of the document at the time when the first interaction
+   * occurred (see `LoadState` for details). If the first interaction occurred
+   * while the document was loading and executing script (e.g. usually in the
+   * `domInteractive` phase) it can result in long input delays.
+   */
+  loadState: LoadState;
+}
+
+/**
+ * An FID-specific version of the Metric object with attribution.
+ */
+export interface FIDMetricWithAttribution extends FIDMetric {
+  attribution: FIDAttribution;
+}
+
+/**
+ * An FID-specific version of the ReportCallback function.
+ */
+export interface FIDReportCallback extends ReportCallback {
+  (metric: FIDMetric): void;
+}
+
+/**
+ * An FID-specific version of the ReportCallback function with attribution.
+ */
+export interface FIDReportCallbackWithAttribution extends FIDReportCallback {
+  (metric: FIDMetricWithAttribution): void;
+}

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LoadState, Metric, ReportCallback} from './base.js';
+
+
+/**
+ * An INP-specific version of the Metric object.
+ */
+export interface INPMetric extends Metric {
+  name: 'INP';
+  entries: PerformanceEventTiming[];
+}
+
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the INP value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+export interface INPAttribution {
+  /**
+   * A selector identifying the element that the user interacted with for
+   * the event corresponding to INP. This element will be the `target` of the
+   * `event` dispatched.
+   */
+  eventTarget?: string;
+  /**
+   * The time when the user interacted for the event corresponding to INP.
+   * This time will match the `timeStamp` value of the `event` dispatched.
+   */
+  eventTime?: number;
+  /**
+   * The `type` of the `event` dispatched corresponding to INP.
+   */
+  eventType?: string;
+  /**
+   * The `PerformanceEventTiming` entry corresponding to INP.
+   */
+  eventEntry?: PerformanceEventTiming;
+  /**
+   * The loading state of the document at the time when the even corresponding
+   * to INP occurred (see `LoadState` for details). If the interaction occurred
+   * while the document was loading and executing script (e.g. usually in the
+   * `domInteractive` phase) it can result in long delays.
+   */
+  loadState?: LoadState;
+}
+
+/**
+ * An INP-specific version of the Metric object with attribution.
+ */
+export interface INPMetricWithAttribution extends INPMetric {
+  attribution: INPAttribution;
+}
+
+/**
+ * An INP-specific version of the ReportCallback function.
+ */
+export interface INPReportCallback extends ReportCallback {
+  (metric: INPMetric): void;
+}
+
+/**
+ * An INP-specific version of the ReportCallback function with attribution.
+ */
+export interface INPReportCallbackWithAttribution extends INPReportCallback {
+  (metric: INPMetricWithAttribution): void;
+}

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Metric, ReportCallback} from './base.js';
+import {NavigationTimingPolyfillEntry} from './polyfills.js';
+
+
+/**
+ * An LCP-specific version of the Metric object.
+ */
+export interface LCPMetric extends Metric {
+  name: 'LCP';
+  entries: LargestContentfulPaint[];
+}
+
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the LCP value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+export interface LCPAttribution {
+  /**
+   * The element corresponding to the largest contentful paint for the page.
+   */
+  element?: string,
+  /**
+   * The time from when the user initiates loading the page until when the
+   * browser receives the first byte of the response (a.k.a. TTFB). See
+   * [Optimize LCP](https://web.dev/optimize-lcp/) for details.
+   */
+  timeToFirstByte: number;
+  /**
+   * The delta between TTFB and when the browser starts loading the LCP
+   * resource (if there is one, otherwise 0). See [Optimize
+   * LCP](https://web.dev/optimize-lcp/) for details.
+   */
+  resourceLoadDelay: number;
+  /**
+   * The total time it takes to load the LCP resource itself (if there is one,
+   * otherwise 0). See [Optimize LCP](https://web.dev/optimize-lcp/) for
+   * details.
+   */
+  resourceLoadTime: number;
+  /**
+   * The delta between when the LCP resource finishes loading until the LCP
+   * element is fully rendered. See [Optimize
+   * LCP](https://web.dev/optimize-lcp/) for details.
+   */
+  elementRenderDelay: number;
+  /**
+   * The `navigation` entry of the current page, which is useful for diagnosing
+   * general page load issues.
+   */
+  navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
+  /**
+   * The `resource` entry for the LCP resource (if applicable), which is useful
+   * for diagnosing resource load issues.
+   */
+  lcpResourceEntry?: PerformanceResourceTiming;
+  /**
+   * The `LargestContentfulPaint` entry corresponding to LCP.
+   */
+  lcpEntry?: LargestContentfulPaint;
+}
+
+/**
+ * An LCP-specific version of the Metric object with attribution.
+ */
+export interface LCPMetricWithAttribution extends LCPMetric {
+  attribution: LCPAttribution;
+}
+
+/**
+ * An LCP-specific version of the ReportCallback function.
+ */
+export interface LCPReportCallback extends ReportCallback {
+  (metric: LCPMetric): void;
+}
+
+/**
+ * An LCP-specific version of the ReportCallback function with attribution.
+ */
+export interface LCPReportCallbackWithAttribution extends LCPReportCallback {
+  (metric: LCPMetricWithAttribution): void;
+}

--- a/src/types/polyfills.ts
+++ b/src/types/polyfills.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+export type FirstInputPolyfillEntry = Omit<PerformanceEventTiming, 'processingEnd'>;
 
-/**
- * Overrides the document's `visibilityState` property, sets the body's hidden
- * attribute (to prevent painting) and dispatches a `visibilitychange` event.
- * @return {Promise<void>}
- */
-export function stubForwardBack(visibilityStateAfterRestore) {
-  return browser.executeAsync((visibilityStateAfterRestore, done) => {
-    self.__stubForwardBack(visibilityStateAfterRestore).then(done);
-  }, visibilityStateAfterRestore);
+export interface FirstInputPolyfillCallback {
+  (entry: FirstInputPolyfillEntry): void;
+}
+
+export type NavigationTimingPolyfillEntry = Omit<PerformanceNavigationTiming,
+    'initiatorType' | 'nextHopProtocol' | 'redirectCount' | 'transferSize' |
+    'encodedBodySize' | 'decodedBodySize' | 'type'> & {
+  type?: PerformanceNavigationTiming['type'];
 }

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Metric, ReportCallback} from './base.js';
+import {NavigationTimingPolyfillEntry} from './polyfills.js';
+
+
+/**
+ * A TTFB-specific version of the Metric object.
+ */
+export interface TTFBMetric extends Metric {
+  name: 'TTFB';
+  entries: PerformanceNavigationTiming[] | NavigationTimingPolyfillEntry[];
+}
+
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the TTFB value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+ export interface TTFBAttribution {
+  /**
+   * The total time from when the user initiates loading the page to when the
+   * DNS lookup begins. This includes redirects, service worker startup, and
+   * HTTP cache lookup times.
+   */
+  waitingTime: number;
+  /**
+   * The total time to resolve the DNS for the current request.
+   */
+  dnsTime: number;
+  /**
+   * The total time to create the connection to the requested domain.
+   */
+  connectionTime: number;
+  /**
+   * The time time from when the request was sent until the first byte of the
+   * response was received. This includes network time as well as server
+   * processing time.
+   */
+  requestTime: number;
+  /**
+   * The `PerformanceNavigationTiming` entry used to determine TTFB (or the
+   * polyfill entry in browsers that don't support Navigation Timing).
+   */
+  navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
+}
+
+/**
+ * A TTFB-specific version of the Metric object with attribution.
+ */
+export interface TTFBMetricWithAttribution extends TTFBMetric {
+  attribution: TTFBAttribution;
+}
+
+/**
+ * A TTFB-specific version of the ReportCallback function.
+ */
+export interface TTFBReportCallback extends ReportCallback {
+  (metric: TTFBMetric): void;
+}
+
+/**
+ * A TTFB-specific version of the ReportCallback function with attribution.
+ */
+export interface TTFBReportCallbackWithAttribution extends TTFBReportCallback {
+  (metric: TTFBMetricWithAttribution): void;
+}

--- a/test/script/async.js
+++ b/test/script/async.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,4 @@
  * limitations under the License.
  */
 
-
-/**
- * Overrides the document's `visibilityState` property, sets the body's hidden
- * attribute (to prevent painting) and dispatches a `visibilitychange` event.
- * @return {Promise<void>}
- */
-export function stubForwardBack(visibilityStateAfterRestore) {
-  return browser.executeAsync((visibilityStateAfterRestore, done) => {
-    self.__stubForwardBack(visibilityStateAfterRestore).then(done);
-  }, visibilityStateAfterRestore);
-}
+console.log('async script executed!', performance.now());

--- a/test/script/defer.js
+++ b/test/script/defer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,4 @@
  * limitations under the License.
  */
 
-
-/**
- * Overrides the document's `visibilityState` property, sets the body's hidden
- * attribute (to prevent painting) and dispatches a `visibilitychange` event.
- * @return {Promise<void>}
- */
-export function stubForwardBack(visibilityStateAfterRestore) {
-  return browser.executeAsync((visibilityStateAfterRestore, done) => {
-    self.__stubForwardBack(visibilityStateAfterRestore).then(done);
-  }, visibilityStateAfterRestore);
-}
+console.log('defer script executed!', performance.now());

--- a/test/server.js
+++ b/test/server.js
@@ -13,10 +13,10 @@
  limitations under the License.
 */
 
-const bodyParser = require('body-parser');
-const express = require('express');
-const fs = require('fs-extra');
-const nunjucks = require('nunjucks');
+import bodyParser from 'body-parser';
+import express from 'express';
+import fs from 'fs-extra';
+import nunjucks from 'nunjucks';
 
 
 const BEACON_FILE = 'test/beacons.log';
@@ -42,20 +42,39 @@ app.use((req, res, next) => {
 // Add a "collect" endpoint to simulate analytics beacons.
 app.post('/collect', bodyParser.text(), (req, res) => {
   // Uncomment to log the metric when manually testing.
-  // console.log(JSON.stringify(JSON.parse(req.body), null, 2));
+  console.log(JSON.stringify(JSON.parse(req.body), null, 2));
+  console.log('-'.repeat(80));
 
   fs.appendFileSync(BEACON_FILE, req.body + '\n');
   res.end();
 });
 
-app.get('/test/:view', function(req, res) {
+app.get('/test/:view', function(req, res, next) {
+  let modulePath = `/dist/web-vitals.js`;
+  if (req.query.polyfill) {
+    modulePath = `/dist/web-vitals.base.js`;
+  }
+  if (req.query.attribution) {
+    modulePath = `/dist/web-vitals.attribution.js`;
+  }
+
   const data = {
     ...req.query,
-    modulePath: `/dist/web-vitals${
-        req.query.polyfill ? `.base` : ``}.js`,
+    modulePath: modulePath,
     webVitalsPolyfill: fs.readFileSync('./dist/polyfill.js', 'utf-8'),
   }
-  res.send(nunjucks.render(`${req.params.view}.njk`, data));
+
+  const content = nunjucks.render(`${req.params.view}.njk`, data);
+  if (req.query.delayResponse) {
+    res.write(content + '\n');
+    setTimeout(() => {
+      res.write(`</body></html>`);
+      res.end();
+      next();
+    }, Number(req.query.delayResponse));
+  } else {
+    res.send(content);
+  }
 });
 
 app.use(express.static('./'));

--- a/test/utils/beacons.js
+++ b/test/utils/beacons.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const fs = require('fs-extra');
+import fs from 'fs-extra';
 
 
 const BEACON_FILE = './test/beacons.log';
@@ -23,7 +23,7 @@ const BEACON_FILE = './test/beacons.log';
  * @param {Object} count
  * @return {Promise<boolean>} True if the beacon count matches.
  */
-async function beaconCountIs(count) {
+export async function beaconCountIs(count) {
   await browser.waitUntil(async () => {
     const beacons = await getBeacons();
     return beacons.length === count;
@@ -35,7 +35,7 @@ async function beaconCountIs(count) {
  * most recently sent beacons with the same metric ID).
  * @return {Promise<Array>}
  */
-async function getBeacons(id = undefined) {
+export async function getBeacons(id = undefined) {
   const json = await fs.readFile(BEACON_FILE, 'utf-8');
   const allBeacons = json.trim().split('\n').filter(Boolean).map(JSON.parse);
 
@@ -50,12 +50,6 @@ async function getBeacons(id = undefined) {
  * Clears the array of beacons on the page.
  * @return {Promise<void>}
  */
-async function clearBeacons() {
+ export async function clearBeacons() {
   await fs.truncate(BEACON_FILE);
 }
-
-module.exports = {
-  beaconCountIs,
-  getBeacons,
-  clearBeacons,
-};

--- a/test/utils/browserSupportsEntry.js
+++ b/test/utils/browserSupportsEntry.js
@@ -20,7 +20,7 @@
  * @param {string} type The performance entry type.
  * @return {boolean}
  */
-function browserSupportsEntry(type) {
+export function browserSupportsEntry(type) {
   return browser.execute((type) => {
     // More extensive feature detect needed for Firefox due to:
     // https://github.com/GoogleChrome/web-vitals/issues/142
@@ -39,7 +39,3 @@ function browserSupportsEntry(type) {
         window.PerformanceObserver.supportedEntryTypes.includes(type);
   }, type);
 }
-
-module.exports = {
-  browserSupportsEntry,
-};

--- a/test/utils/domReadyState.js
+++ b/test/utils/domReadyState.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,20 @@
 
 
 /**
- * Overrides the document's `visibilityState` property, sets the body's hidden
- * attribute (to prevent painting) and dispatches a `visibilitychange` event.
+ * Returns a promise that resolves once the browser window has loaded and
+ * all load callbacks have finished executing.
  * @return {Promise<void>}
  */
-export function stubForwardBack(visibilityStateAfterRestore) {
-  return browser.executeAsync((visibilityStateAfterRestore, done) => {
-    self.__stubForwardBack(visibilityStateAfterRestore).then(done);
-  }, visibilityStateAfterRestore);
+export function domReadyState(state) {
+  return browser.executeAsync((state, done) => {
+    if (document.readyState === 'complete' || document.readyState === state) {
+      setTimeout(done, 0);
+    } else {
+      document.addEventListener('readystatechange', () => {
+        if (document.readyState === state) {
+          setTimeout(done, 0);
+        }
+      });
+    }
+  }, state);
 }

--- a/test/utils/imagesPainted.js
+++ b/test/utils/imagesPainted.js
@@ -20,7 +20,7 @@
  * the images in the document have decoded and rendered.
  * @return {Promise<void>}
  */
-function imagesPainted() {
+export function imagesPainted() {
   return browser.executeAsync((done) => {
     const windowLoaded = new Promise((resolve) => {
       if (document.readyState === 'complete') {
@@ -41,7 +41,3 @@ function imagesPainted() {
     });
   });
 }
-
-module.exports = {
-  imagesPainted,
-};

--- a/test/utils/nextFrame.js
+++ b/test/utils/nextFrame.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,16 +20,12 @@
  * all load callbacks have finished executing.
  * @return {Promise<void>}
  */
-function afterLoad() {
+export function nextFrame(state) {
   return browser.executeAsync((done) => {
-    if (document.readyState === 'complete') {
-      setTimeout(done, 0);
-    } else {
-      addEventListener('load', () => setTimeout(done, 0));
-    }
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        done();
+      });
+    });
   });
 }
-
-module.exports = {
-  afterLoad,
-};

--- a/test/utils/stubVisibilityChange.js
+++ b/test/utils/stubVisibilityChange.js
@@ -20,12 +20,8 @@
  * attribute (to prevent painting) and dispatches a `visibilitychange` event.
  * @return {Promise<void>}
  */
-function stubVisibilityChange(visibilityState) {
+export function stubVisibilityChange(visibilityState) {
   return browser.execute((visibilityState) => {
     self.__stubVisibilityChange(visibilityState);
   }, visibilityState);
 }
-
-module.exports = {
-  stubVisibilityChange,
-};

--- a/test/views/cls.njk
+++ b/test/views/cls.njk
@@ -18,36 +18,53 @@
 {% block content %}
   <h1>CLS Test</h1>
   {% if noLayoutShifts %}
-    <p>This text does not shift.</p>
+    <p id="p1">This text does not shift.</p>
   {% else %}
-    <p><img src="/test/img/square.png?delay=500" alt="Gray square" /></p>
-    <p><img src="/test/img/square.png?delay=1000" alt="Gray square" /></p>
-    <p>Text below the images that will get pushed down.</p>
+    <p id="p2">
+      <img id="img1" src="/test/img/square.png?delay=500" alt="Gray square" />
+      [text node contents]
+    </p>
+    <p id="p3"><img id="img3" src="/test/img/square.png?delay=1000" alt="Gray square" /></p>
+    <p id="p4">Text below the images that will get pushed down.</p>
   {% endif %}
 
-  <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+  <p id="p5"><a id="navigate-away" href="https://example.com">Navigate away</a></p>
 
   <script type="module">
     import {onCLS} from '{{ modulePath }}';
 
+    function jsonifyNode(node) {
+      return node.id ? `#${node.id}` : node.nodeName.toLowerCase();
+    }
+
+    function jsonifySource(source) {
+      const node = jsonifyNode(source.node);
+      return {node, previousRect: source.previousRect, currentRect: source.currentRect};
+    }
+
+    function jsonifyEntry(entry) {
+      const {entryType, hadRecentInput, startTime, value} = entry;
+      const sources = entry.sources.map(jsonifySource);
+      return {entryType, hadRecentInput, sources, startTime, value};
+    }
+
     onCLS((cls) => {
       // Log for easier manual testing.
-      console.log(cls);
+      console.log(window.cls = cls);
 
       // Sources is verbose to serialize, so remove first.
       cls = {
         ...cls,
-        entries: cls.entries.map((e) => {
-          const {entryType, hadRecentInput, startTime, value} = e;
-          const sources = e.sources.map((s) => {
-            let node = s.node.nodeName.toLowerCase() +
-                (s.node.id ? `#${s.node.id}` : ``);
-
-            return {node};
-          });
-          return {entryType, hadRecentInput, sources, startTime, value};
-        }),
+        entries: cls.entries.map(jsonifyEntry),
       };
+
+      if (cls.attribution) {
+        cls.attribution = Object.keys(cls.attribution).length ? {
+          ...cls.attribution,
+          largestShiftSource: jsonifySource(cls.attribution.largestShiftSource),
+          largestShiftEntry: jsonifyEntry(cls.attribution.largestShiftEntry),
+        } : {};
+      }
 
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(cls));

--- a/test/views/fcp.njk
+++ b/test/views/fcp.njk
@@ -18,7 +18,10 @@
 {% block content %}
   <h1>FCP Test</h1>
   <p>
-    <img src="/test/img/square.png?delay=500">
+    {% if not imgDelay %}
+      {% set imgDelay = 500 %}
+    {% endif %}
+    <img {% if imgHidden %}hidden{% endif %} src="/test/img/square.png?delay={{ imgDelay }}">
   </p>
   <p>Text below the image</p>
 

--- a/test/views/inp.njk
+++ b/test/views/inp.njk
@@ -81,6 +81,10 @@
   <script type="module">
     import {onINP} from '{{ modulePath }}';
 
+    function jsonifyNode(node) {
+      return node && node.id ? `#${node.id}` : node.nodeName.toLowerCase();
+    }
+
     onINP((inp) => {
       // Log for easier manual testing.
       console.log(inp);
@@ -89,7 +93,7 @@
       inp.entries = inp.entries.map((e) => ({
         ...e.toJSON(),
         interactionId: e.interactionId,
-        target: e.target?.nodeName.toLowerCase(),
+        target: jsonifyNode(e.target),
       }));
 
       // Test sending the metric to an analytics endpoint.

--- a/test/views/layout.njk
+++ b/test/views/layout.njk
@@ -161,5 +161,11 @@
   <main>
     {% block content %}{% endblock %}
   </main>
-</body>
-</html>
+  {% if delayDCL %}
+    <script defer src="/test/script/defer.js?delay={{ delayDCL }}"></script>
+  {% endif %}
+
+  {% if delayLoad %}
+    <script async src="/test/script/async.js?delay={{ delayLoad }}"></script>
+  {% endif %}
+

--- a/test/views/lcp.njk
+++ b/test/views/lcp.njk
@@ -34,19 +34,24 @@
   <script type="module">
     import {onLCP} from '{{ modulePath }}';
 
+    function jsonifyEntry(entry) {
+      return {
+        element: entry.element.nodeName.toLowerCase(),
+        size: entry.size,
+        startTime: entry.startTime,
+      };
+    }
+
     onLCP((lcp) => {
       // Log for easier manual testing.
       console.log(lcp);
 
       // Elements can't be serialized, so we convert first.
-      lcp = {
-        ...lcp,
-        entries: lcp.entries.map((e) => ({
-          element: e.element.nodeName.toLowerCase(),
-          size: e.size,
-          startTime: e.startTime,
-        })),
-      };
+      lcp.entries = lcp.entries.map(jsonifyEntry);
+
+      if (lcp.attribution && lcp.attribution.lcpEntry) {
+        lcp.attribution.lcpEntry = jsonifyEntry(lcp.attribution.lcpEntry);
+      }
 
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(lcp));

--- a/test/views/ttfb.njk
+++ b/test/views/ttfb.njk
@@ -27,6 +27,16 @@
   <script type="module">
     import {onTTFB} from '{{ modulePath }}';
 
+    function jsonifyEntry(entry) {
+      const newObj = {};
+      for (const k in entry) {
+        if (typeof entry[k] !== 'function') {
+          newObj[k] = entry[k];
+        }
+      }
+      return newObj;
+    }
+
     (async function() {
       {% if awaitLoad %}
         await new Promise((resolve) => addEventListener('load', resolve));
@@ -37,15 +47,10 @@
         console.log(ttfb);
 
         // The stubbed `activationStart` is lost when stringified, so we convert first.
-        ttfb.entries = ttfb.entries.map((e) => {
-          const newObj = {};
-          for (const k in e) {
-            if (typeof e[k] !== 'function') {
-              newObj[k] = e[k];
-            }
-          }
-          return newObj;
-        });
+        ttfb.entries = ttfb.entries.map(jsonifyEntry);
+        if (ttfb.attribution && ttfb.attribution.navigationEntry) {
+          ttfb.attribution.navigationEntry = jsonifyEntry(ttfb.attribution.navigationEntry);
+        }
 
         // Test sending the metric to an analytics endpoint.
         navigator.sendBeacon(`/collect`, JSON.stringify(ttfb));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "lib": ["es2017", "DOM"],
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,

--- a/wdio.conf.cjs
+++ b/wdio.conf.cjs
@@ -66,6 +66,7 @@ module.exports.config = {
   //
   capabilities: [
     {
+      'pageLoadStrategy': 'none',
       // maxInstances can get overwritten per capability. So if you have an in-house Selenium
       // grid with only 5 firefox instances available you can make sure that not more than
       // 5 instances get started at a time.
@@ -83,12 +84,14 @@ module.exports.config = {
       },
     },
     {
-      maxInstances: 1,
       browserName: 'firefox',
+      maxInstances: 1,
+      pageLoadStrategy: 'none',
     },
     {
-      maxInstances: 1,
       browserName: 'safari',
+      maxInstances: 1,
+      pageLoadStrategy: 'none',
     },
   ],
   //


### PR DESCRIPTION
Addresses #203. 

This PR adds a new "attribution" build to this library. When used, it augments the `Metric` object with an `attribution` property that contains useful information to debug issues that occur in the field.

This is essentially a codification of the recommendations outlined in the post [Debug Web Vitals in the field](https://web.dev/debug-web-vitals-in-the-field/), and it also includes some additional diagnostic information like outlined in the updated [Optimize LCP](https://web.dev/optimize-lcp/#lcp-breakdown) guide.

The API to use this library doesn't change, to get the attribution data you have to important from `web-vitals/attribution` rather than `web-vitals`:

```diff
- import {onLCP, onFID, onCLS} from 'web-vitals';
+ import {onLCP, onFID, onCLS} from 'web-vitals/attribution';
```

Then, when the metric callback functions are invokes, the `Metric` object passed to them contain a new `attribution` property:

```ts
interface MetricWithAttribution extends Metric {
  attribution: {[key: string]: unknown};
}
```

And as an example of how you might use this in code, where's how you would send data about what element was involved in the largest layout shift contributing to CLS on the page:

```js
import {onCLS} from 'web-vitals/attribution';

onCLS((metric) => {
  navigator.sendBeacon('/analytics', JSON.stringify({
    name: metric.name,
    value: metric.value,
    id: metric.id,

    // This will be a string selector helping identifying the element that shifted.
    // For example: "html>body>main>section>h1.main-heading"
    largestShiftTarget: metric.attribution.largestShiftTarget,
  }));
});
```

The following type definitions gives an overview of what attribution data could be set on each object, depending on which metric is being observed.

**CLS**:

```ts
interface CLSAttribution {
  /**
   * A selector identifying the first element (in document order) that
   * shifted when the single largest layout shift contributing to the page's
   * CLS score occurred.
   */
  largestShiftTarget?: string;
  /**
   * The time when the single largest layout shift contributing to the page's
   * CLS score occurred.
   */
  largestShiftTime?: DOMHighResTimeStamp;
  /**
   * The layout shift score of the single largest layout shift contributing to
   * the page's CLS score.
   */
  largestShiftValue?: number;
  /**
   * The `LayoutShiftEntry` representing the single largest layout shift
   * contributing to the page's CLS score. (Useful when you need more than just
   * `largestShiftTarget`, `largestShiftTime`, and `largestShiftValue`).
   */
  largestShiftEntry?: LayoutShift;
  /**
   * The first element source (in document order) among the `sources` list
   * of the `largestShiftEntry` object. (Also useful when you need more than
   * just `largestShiftTarget`, `largestShiftTime`, and `largestShiftValue`).
   */
  largestShiftSource?: LayoutShiftAttribution;
  /**
   * The loading state of the document at the time when the largest layout
   * shift contribution to the page's CLS score occurred (see `LoadState`
   * for details).
   */
  loadState?: LoadState;
}
```

**FCP**:

```ts
interface FCPAttribution {
  /**
   * The time from when the user initiates loading the page until when the
   * browser receives the first byte of the response (a.k.a. TTFB).
   */
  timeToFirstByte: number;
  /**
   * The time between TTFB and the first contentful paint (FCP).
   */
  renderDelay: number;
  /**
   * The loading state of the document at the time when FCP `occurred (see
   * `LoadState` for details). Ideally, documents can paint before they finish
   * loading (e.g. the `loading` or `domInteractive` phases).
   */
  loadState: LoadState,
  /**
   * The `navigation` entry of the current page, which is useful for diagnosing
   * general page load issues.
   */
  navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
}
```

**FID**:

```ts
interface FIDAttribution {
  /**
   * A selector identifying the element that the user interacted with. This
   * element will be the `target` of the `event` dispatched.
   */
  eventTarget: string;
  /**
   * The time when the user interacted. This time will match the `timeStamp`
   * value of the `event` dispatched.
   */
  eventTime: number;
  /**
   * The `type` of the `event` dispatched from the user interaction.
   */
  eventType: string;
  /**
   * The loading state of the document at the time when the first interaction
   * occurred (see `LoadState` for details). If the first interaction occurred
   * while the document was loading and executing script (e.g. usually in the
   * `domInteractive` phase) it can result in long input delays.
   */
  loadState: LoadState;
}
```

**INP**:

```ts
interface INPAttribution {
  /**
   * A selector identifying the element that the user interacted with. This
   * element will be the `target` of the `event` dispatched.
   */
  eventTarget?: string;
  /**
   * The time when the user interacted. This time will match the `timeStamp`
   * value of the `event` dispatched.
   */
  eventTime?: number;
  /**
   * The `type` of the `event` dispatched from the user interaction.
   */
  eventType?: string;
  /**
   * The loading state of the document at the time when the interaction
   * occurred (see `LoadState` for details). If the interaction occurred
   * while the document was loading and executing script (e.g. usually in the
   * `domInteractive` phase) it can result in long delays.
   */
  loadState?: LoadState;
}
```

**LCP**:

```ts
interface LCPAttribution {
  /**
   * The element corresponding to the largest contentful paint for the page.
   */
  element?: string,
  /**
   * The time from when the user initiates loading the page until when the
   * browser receives the first byte of the response (a.k.a. TTFB). See
   * [Optimize LCP](https://web.dev/optimize-lcp/) for details.
   */
  timeToFirstByte: number;
  /**
   * The delta between TTFB and when the browser starts loading the LCP
   * resource (if there is one, otherwise 0). See [Optimize
   * LCP](https://web.dev/optimize-lcp/) for details.
   */
  resourceLoadDelay: number;
  /**
   * The total time it takes to load the LCP resource itself (if there is one,
   * otherwise 0). See [Optimize LCP](https://web.dev/optimize-lcp/) for
   * details.
   */
  resourceLoadTime: number;
  /**
   * The delta between when the LCP resource finishes loading until the LCP
   * element is fully rendered. See [Optimize
   * LCP](https://web.dev/optimize-lcp/) for details.
   */
  elementRenderDelay: number;
  /**
   * The `navigation` entry of the current page, which is useful for diagnosing
   * general page load issues.
   */
  navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
  /**
   * The `resource` entry for the LCP resource (if applicable), which is useful
   * for diagnosing resource load issues.
   */
  lcpResourceEntry?: PerformanceResourceTiming;
}
```

One downside of exposing the attribution data via a separate build is it means you either have to get attribution for all metrics or none of them—you can't just get attribution for one, e.g. `onCLS()`, and then use the unattributed versions of all the other metrics (well, you can, but doing so would import both versions and double the file size).

However, given the full attribution code for all metrics only adds 500 bytes (brotli'd) to the download size, I think that's worth the convenience of not changing the API. _Note: in the future, if the [pipeline operator](https://github.com/tc39/proposal-pipeline-operator) comes to JavaScript, it may be worth revisiting this decision._

Another downside is there's no easy way to make the attribution build work with the base+polyfill build without massively increasing complexity (to support ESM, UMD, and IIFE versions of each build, making a base+polyfill+attribution build would double the number of builds).

Based on the analysis done in #238, in this initial PR the attribution build does not make use of the polyfill.

* * *

In addition to the above, this PR also updates this package to use `type: module` as well as package exports, now that they are widely supported. As a result, there are additional changes from `require()` to `import` in this PR that are not related to the above changes.
