### PR TITLE
Add a URL property to LCP attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1015,6 +1015,11 @@ interface LCPAttribution {
    */
   element?: string,
   /**
+   * The URL (if applicable) of the LCP image resource. If the LCP element
+   * is a text node, this value will not be set.
+   */
+  url?: string,
+  /**
    * The time from when the user initiates loading the page until when the
    * browser receives the first byte of the response (a.k.a. TTFB). See
    * [Optimize LCP](https://web.dev/optimize-lcp/) for details.

--- a/src/attribution/onFCP.ts
+++ b/src/attribution/onFCP.ts
@@ -18,10 +18,10 @@ import {getBFCacheRestoreTime} from '../lib/bfcache.js';
 import {getLoadState} from '../lib/getLoadState.js';
 import {getNavigationEntry} from '../lib/getNavigationEntry.js';
 import {onFCP as unattributedOnFCP} from '../onFCP.js';
-import {FCPMetricWithAttribution, FCPReportCallback, FCPReportCallbackWithAttribution, ReportOpts} from '../types.js';
+import {FCPMetric, FCPMetricWithAttribution, FCPReportCallback, FCPReportCallbackWithAttribution, ReportOpts} from '../types.js';
 
 
-const attributeFCP = (metric: FCPMetricWithAttribution): void => {
+const attributeFCP = (metric: FCPMetric): void => {
   if (metric.entries.length) {
     const navigationEntry = getNavigationEntry();
     const fcpEntry = metric.entries[metric.entries.length - 1];
@@ -30,7 +30,7 @@ const attributeFCP = (metric: FCPMetricWithAttribution): void => {
       const activationStart = navigationEntry.activationStart || 0;
       const ttfb = Math.max(0, navigationEntry.responseStart - activationStart);
 
-      metric.attribution = {
+      (metric as FCPMetricWithAttribution).attribution = {
         timeToFirstByte: ttfb,
         firstByteToFCP: metric.value - ttfb,
         loadState: getLoadState(metric.entries[0].startTime),
@@ -40,7 +40,7 @@ const attributeFCP = (metric: FCPMetricWithAttribution): void => {
     }
   } else {
     // There are no entries when restored from bfcache.
-    metric.attribution = {
+    (metric as FCPMetricWithAttribution).attribution = {
       timeToFirstByte: 0,
       firstByteToFCP: metric.value,
       loadState: getLoadState(getBFCacheRestoreTime()),

--- a/src/attribution/onFID.ts
+++ b/src/attribution/onFID.ts
@@ -17,18 +17,18 @@
 import {getLoadState} from '../lib/getLoadState.js';
 import {getSelector} from '../lib/getSelector.js';
 import {onFID as unattributedOnFID} from '../onFID.js';
-import {FIDAttribution, FIDMetricWithAttribution, FIDReportCallback, FIDReportCallbackWithAttribution, ReportOpts} from '../types.js';
+import {FIDMetric, FIDMetricWithAttribution, FIDReportCallback, FIDReportCallbackWithAttribution, ReportOpts} from '../types.js';
 
 
-const attributeFID = (metric: FIDMetricWithAttribution): void => {
+const attributeFID = (metric: FIDMetric): void => {
   const fidEntry = metric.entries[0];
-  metric.attribution = {
+  (metric as FIDMetricWithAttribution).attribution = {
     eventTarget: getSelector(fidEntry.target),
     eventType: fidEntry.name,
     eventTime: fidEntry.startTime,
     eventEntry: fidEntry,
     loadState: getLoadState(fidEntry.startTime),
-  } as FIDAttribution;
+  };
 };
 
 /**

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -17,10 +17,10 @@
 import {getLoadState} from '../lib/getLoadState.js';
 import {getSelector} from '../lib/getSelector.js';
 import {onINP as unattributedOnINP} from '../onINP.js';
-import {INPMetricWithAttribution, INPReportCallback, INPReportCallbackWithAttribution, ReportOpts} from '../types.js';
+import {INPMetric, INPMetricWithAttribution, INPReportCallback, INPReportCallbackWithAttribution, ReportOpts} from '../types.js';
 
 
-const attributeINP = (metric: INPMetricWithAttribution): void => {
+const attributeINP = (metric: INPMetric): void => {
   if (metric.entries.length) {
     const longestEntry = metric.entries.sort((a, b) => {
       // Sort by: 1) duration (DESC), then 2) processing time (DESC)
@@ -28,7 +28,7 @@ const attributeINP = (metric: INPMetricWithAttribution): void => {
       (a.processingEnd - a.processingStart);
     })[0];
 
-    metric.attribution = {
+    (metric as INPMetricWithAttribution).attribution = {
       eventTarget: getSelector(longestEntry.target),
       eventType: longestEntry.name,
       eventTime: longestEntry.startTime,
@@ -36,7 +36,7 @@ const attributeINP = (metric: INPMetricWithAttribution): void => {
       loadState: getLoadState(longestEntry.startTime),
     };
   } else {
-    metric.attribution = {};
+    (metric as INPMetricWithAttribution).attribution = {};
   }
 };
 

--- a/src/attribution/onTTFB.ts
+++ b/src/attribution/onTTFB.ts
@@ -15,10 +15,10 @@
  */
 
 import {onTTFB as unattributedOnTTFB} from '../onTTFB.js';
-import {TTFBMetricWithAttribution, TTFBReportCallback, TTFBReportCallbackWithAttribution, ReportOpts} from '../types.js';
+import {TTFBMetric, TTFBMetricWithAttribution, TTFBReportCallback, TTFBReportCallbackWithAttribution, ReportOpts} from '../types.js';
 
 
-const attributeTTFB = (metric: TTFBMetricWithAttribution): void => {
+const attributeTTFB = (metric: TTFBMetric): void => {
   if (metric.entries.length) {
     const navigationEntry = metric.entries[0];
     const activationStart = navigationEntry.activationStart || 0;
@@ -30,7 +30,7 @@ const attributeTTFB = (metric: TTFBMetricWithAttribution): void => {
     const requestStart = Math.max(
         navigationEntry.requestStart - activationStart, 0);
 
-    metric.attribution = {
+    (metric as TTFBMetricWithAttribution).attribution = {
       waitingTime: dnsStart,
       dnsTime: connectStart - dnsStart,
       connectionTime: requestStart - connectStart,
@@ -38,7 +38,7 @@ const attributeTTFB = (metric: TTFBMetricWithAttribution): void => {
       navigationEntry: navigationEntry,
     };
   } else {
-    metric.attribution = {
+    (metric as TTFBMetricWithAttribution).attribution = {
       waitingTime: 0,
       dnsTime: 0,
       connectionTime: 0,

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -37,6 +37,11 @@ export interface LCPAttribution {
    */
   element?: string,
   /**
+   * The URL (if applicable) of the LCP image resource. If the LCP element
+   * is a text node, this value will not be set.
+   */
+  url?: string,
+  /**
    * The time from when the user initiates loading the page until when the
    * browser receives the first byte of the response (a.k.a. TTFB). See
    * [Optimize LCP](https://web.dev/optimize-lcp/) for details.

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -372,6 +372,7 @@ describe('onLCP()', async function() {
       const [lcp] = await getBeacons();
       assertStandardReportsAreCorrect([lcp]);
 
+      assert(lcp.attribution.url.endsWith('/test/img/square.png?delay=500'));
       assert.equal(lcp.attribution.element, 'html>body>main>p>img');
       assert.equal(lcp.attribution.timeToFirstByte +
           lcp.attribution.resourceLoadDelay +
@@ -414,6 +415,7 @@ describe('onLCP()', async function() {
 
       assertStandardReportsAreCorrect([lcp]);
 
+      assert(lcp.attribution.url.endsWith('/test/img/square.png?delay=500'));
       assert.equal(lcp.attribution.element, 'html>body>main>p>img');
 
       // Specifically check that resourceLoadDelay falls back to `startTime`.
@@ -459,7 +461,8 @@ describe('onLCP()', async function() {
 
       const [lcp] = await getBeacons();
 
-      assert.strictEqual(lcp.navigationType, 'prerender');
+      assert(lcp.attribution.url.endsWith('/test/img/square.png?delay=500'));
+      assert.equal(lcp.navigationType, 'prerender');
       assert.equal(lcp.attribution.element, 'html>body>main>p>img');
 
       // Assert each individual LCP sub-part accounts for `activationStart`
@@ -508,6 +511,7 @@ describe('onLCP()', async function() {
 
       const [lcp] = await getBeacons();
 
+      assert.equal(lcp.attribution.url, undefined);
       assert.equal(lcp.attribution.element, 'html>body>main>h1');
       assert.equal(lcp.attribution.resourceLoadDelay, 0);
       assert.equal(lcp.attribution.resourceLoadTime, 0);


### PR DESCRIPTION
This PR builds builds on top of the work already done in https://github.com/GoogleChrome/web-vitals/pull/237 by adding a `url` property to the `LCPAttribution` object.

The `url` property is the same as the `url` property of the [LCP entry](https://www.w3.org/TR/largest-contentful-paint/#sec-largest-contentful-paint-interface), but since it's one of the most important diagnostic values, it makes sense to expose it directly on the attribution object. If there is no `url` property on the LCP entry, then this property will not be set on the attribution object.