### PR TITLE
Move the Navigation Timing API polyfill to the base+polyfill build

### DIFF
--- a/src/lib/getNavigationEntry.ts
+++ b/src/lib/getNavigationEntry.ts
@@ -38,7 +38,12 @@ const getNavigationEntryFromPerformanceTiming = (): NavigationTimingPolyfillEntr
 };
 
 export const getNavigationEntry = (): PerformanceNavigationTiming | NavigationTimingPolyfillEntry | undefined => {
-  return window.performance && (performance.getEntriesByType &&
-      performance.getEntriesByType('navigation')[0] ||
-          getNavigationEntryFromPerformanceTiming());
+  if (window.__WEB_VITALS_POLYFILL__) {
+    return window.performance && (performance.getEntriesByType &&
+        performance.getEntriesByType('navigation')[0] ||
+            getNavigationEntryFromPerformanceTiming());
+  } else {
+    return window.performance && (performance.getEntriesByType &&
+        performance.getEntriesByType('navigation')[0]);
+  }
 };


### PR DESCRIPTION
This PR removes the Navigation Timing polyfill from the "standard" build and adds it to the "base+polyfill" build. This reduces the total size of the "standard" build by about 5% (brotli'd).

When this library was first released, Safari didn't support the Navigation Timing API (Level 2), so this was a lightweight and easy way to get the TTFB metric in all modern browsers. But Safari has now supported this API since version 15, which has been out for almost a year.

I think this library should aim to support the latest stable version(s) of all modern browsers when reasonable, but given that this is a measurement library and not a feature library, I don't think full browser support should be a goal.

Also, this change primarily affects the TTFB metric, which is largely a measure of network/device capabilities rather than browser capabilities, so supporting only the latest versions of Safari seems reasonable for optimization purposes.