### PR TITLE
Update the metric ID prefix for v3

### DIFF
--- a/src/lib/generateUniqueID.ts
+++ b/src/lib/generateUniqueID.ts
@@ -20,5 +20,5 @@
  * @return {string}
  */
 export const generateUniqueID = () => {
-  return `v2-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
+  return `v3-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
 };

--- a/test/e2e/onCLS-test.js
+++ b/test/e2e/onCLS-test.js
@@ -50,7 +50,7 @@ describe('onCLS()', async function() {
 
     const [cls] = await getBeacons();
     assert(cls.value >= 0);
-    assert(cls.id.match(/^v2-\d+-\d+$/));
+    assert(cls.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, cls.delta);
     assert.strictEqual(cls.rating, 'good');
@@ -71,7 +71,7 @@ describe('onCLS()', async function() {
 
     const [cls] = await getBeacons();
     assert(cls.value >= 0);
-    assert(cls.id.match(/^v2-\d+-\d+$/));
+    assert(cls.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, cls.delta);
     assert.strictEqual(cls.rating, 'good');
@@ -94,7 +94,7 @@ describe('onCLS()', async function() {
     const [cls1] = await getBeacons();
 
     assert(cls1.value >= 0);
-    assert(cls1.id.match(/^v2-\d+-\d+$/));
+    assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.rating, 'good');
@@ -127,7 +127,7 @@ describe('onCLS()', async function() {
     assert.strictEqual(cls2.rating, 'poor');
     assert.strictEqual(cls2.entries.length, 2);
     assert.match(cls2.navigationType, /navigate|reload/);
-    assert.match(cls2.id, /^v2-\d+-\d+$/);
+    assert.match(cls2.id, /^v3-\d+-\d+$/);
 
     await browser.pause(1000);
     await stubVisibilityChange('visible');
@@ -160,7 +160,7 @@ describe('onCLS()', async function() {
     assert.strictEqual(cls3.rating, 'poor');
     assert.strictEqual(cls3.entries.length, 4);
     assert.match(cls3.navigationType, /navigate|reload/);
-    assert.match(cls3.id, /^v2-\d+-\d+$/);
+    assert.match(cls3.id, /^v3-\d+-\d+$/);
 
     await browser.pause(1000);
     await stubVisibilityChange('visible');
@@ -214,7 +214,7 @@ describe('onCLS()', async function() {
     const [cls1, cls2] = await getBeacons();
 
     assert(cls1.value >= 0);
-    assert(cls1.id.match(/^v2-\d+-\d+$/));
+    assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.rating, 'good');
@@ -250,7 +250,7 @@ describe('onCLS()', async function() {
     const [cls1, cls2] = await getBeacons();
 
     assert(cls1.value >= 0);
-    assert(cls1.id.match(/^v2-\d+-\d+$/));
+    assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.rating, 'good');
     assert.strictEqual(cls1.entries.length, 1);
@@ -290,7 +290,7 @@ describe('onCLS()', async function() {
 
     assert(cls1.value >= 0);
     assert(cls1.delta >= 0);
-    assert(cls1.id.match(/^v2-\d+-\d+$/));
+    assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.rating, 'good');
@@ -328,7 +328,7 @@ describe('onCLS()', async function() {
     const [cls1, cls2] = await getBeacons();
 
     assert(cls1.value > 0);
-    assert(cls1.id.match(/^v2-\d+-\d+$/));
+    assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.entries.length, 1);
@@ -377,7 +377,7 @@ describe('onCLS()', async function() {
     const [cls1] = await getBeacons();
 
     assert(cls1.value >= 0);
-    assert(cls1.id.match(/^v2-\d+-\d+$/));
+    assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.delta, cls1.value);
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
@@ -394,7 +394,7 @@ describe('onCLS()', async function() {
     const [cls2] = await getBeacons();
 
     assert(cls2.value >= 0);
-    assert(cls2.id.match(/^v2-\d+-\d+$/));
+    assert(cls2.id.match(/^v3-\d+-\d+$/));
     assert(cls2.id !== cls1.id);
 
     assert.strictEqual(cls2.name, 'CLS');
@@ -412,7 +412,7 @@ describe('onCLS()', async function() {
     const [cls3] = await getBeacons();
 
     assert(cls3.value >= 0);
-    assert(cls3.id.match(/^v2-\d+-\d+$/));
+    assert(cls3.id.match(/^v3-\d+-\d+$/));
     assert(cls3.id !== cls2.id);
 
     assert.strictEqual(cls3.name, 'CLS');
@@ -431,7 +431,7 @@ describe('onCLS()', async function() {
     const [cls1, cls2] = await getBeacons();
 
     assert(cls1.value > 0);
-    assert(cls1.id.match(/^v2-\d+-\d+$/));
+    assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.entries.length, 1);
@@ -457,7 +457,7 @@ describe('onCLS()', async function() {
     const [cls3] = await getBeacons();
 
     assert(cls3.value > 0);
-    assert(cls3.id.match(/^v2-\d+-\d+$/));
+    assert(cls3.id.match(/^v3-\d+-\d+$/));
     assert(cls3.id !== cls2.id);
     assert.strictEqual(cls3.name, 'CLS');
     assert.strictEqual(cls3.value, cls3.delta);
@@ -478,7 +478,7 @@ describe('onCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls] = await getBeacons();
-    assert(cls.id.match(/^v2-\d+-\d+$/));
+    assert(cls.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
@@ -499,7 +499,7 @@ describe('onCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls] = await getBeacons();
-    assert(cls.id.match(/^v2-\d+-\d+$/));
+    assert(cls.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
@@ -520,7 +520,7 @@ describe('onCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls] = await getBeacons();
-    assert(cls.id.match(/^v2-\d+-\d+$/));
+    assert(cls.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
@@ -541,7 +541,7 @@ describe('onCLS()', async function() {
     await beaconCountIs(1);
 
     const [cls] = await getBeacons();
-    assert(cls.id.match(/^v2-\d+-\d+$/));
+    assert(cls.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.value, 0);
     assert.strictEqual(cls.delta, 0);
@@ -580,7 +580,7 @@ describe('onCLS()', async function() {
     const [cls] = await getBeacons();
 
     assert(cls.value >= 0);
-    assert(cls.id.match(/^v2-\d+-\d+$/));
+    assert(cls.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls.name, 'CLS');
     assert.strictEqual(cls.delta, cls.value);
     assert.strictEqual(cls.rating, 'good');
@@ -602,7 +602,7 @@ describe('onCLS()', async function() {
 
       const [cls] = await getBeacons();
       assert(cls.value >= 0);
-      assert(cls.id.match(/^v2-\d+-\d+$/));
+      assert(cls.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(cls.name, 'CLS');
       assert.strictEqual(cls.value, cls.delta);
       assert.strictEqual(cls.rating, 'good');
@@ -640,7 +640,7 @@ describe('onCLS()', async function() {
       const [cls] = await getBeacons();
 
       assert(cls.value >= 0);
-      assert(cls.id.match(/^v2-\d+-\d+$/));
+      assert(cls.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(cls.name, 'CLS');
       assert.strictEqual(cls.value, cls.delta);
       assert.strictEqual(cls.rating, 'good');
@@ -677,7 +677,7 @@ describe('onCLS()', async function() {
       const [cls] = await getBeacons();
 
       assert(cls.value >= 0);
-      assert(cls.id.match(/^v2-\d+-\d+$/));
+      assert(cls.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(cls.name, 'CLS');
       assert.strictEqual(cls.value, cls.delta);
       assert.strictEqual(cls.rating, 'good');

--- a/test/e2e/onFCP-test.js
+++ b/test/e2e/onFCP-test.js
@@ -44,7 +44,7 @@ describe('onFCP()', async function() {
 
     const [fcp] = await getBeacons();
     assert(fcp.value >= 0);
-    assert(fcp.id.match(/^v2-\d+-\d+$/));
+    assert(fcp.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(fcp.name, 'FCP');
     assert.strictEqual(fcp.value, fcp.delta);
     assert.strictEqual(fcp.rating, 'good');
@@ -66,7 +66,7 @@ describe('onFCP()', async function() {
     });
 
     assert(fcp.value >= 0);
-    assert(fcp.id.match(/^v2-\d+-\d+$/));
+    assert(fcp.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(fcp.name, 'FCP');
     assert.strictEqual(fcp.value, fcp.delta);
     assert.strictEqual(fcp.rating, 'good');
@@ -137,7 +137,7 @@ describe('onFCP()', async function() {
 
     const [fcp] = await getBeacons();
     assert(fcp.value >= 0);
-    assert(fcp.id.match(/^v2-\d+-\d+$/));
+    assert(fcp.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(fcp.name, 'FCP');
     assert.strictEqual(fcp.value, fcp.delta);
     assert.strictEqual(fcp.rating, 'needs-improvement');
@@ -154,7 +154,7 @@ describe('onFCP()', async function() {
 
     const [fcp1] = await getBeacons();
     assert(fcp1.value >= 0);
-    assert(fcp1.id.match(/^v2-\d+-\d+$/));
+    assert(fcp1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(fcp1.name, 'FCP');
     assert.strictEqual(fcp1.value, fcp1.delta);
     assert.strictEqual(fcp1.rating, 'good');
@@ -168,7 +168,7 @@ describe('onFCP()', async function() {
 
     const [fcp2] = await getBeacons();
     assert(fcp2.value >= 0);
-    assert(fcp2.id.match(/^v2-\d+-\d+$/));
+    assert(fcp2.id.match(/^v3-\d+-\d+$/));
     assert(fcp2.id !== fcp1.id);
     assert.strictEqual(fcp2.name, 'FCP');
     assert.strictEqual(fcp2.value, fcp2.delta);
@@ -183,7 +183,7 @@ describe('onFCP()', async function() {
 
     const [fcp3] = await getBeacons();
     assert(fcp3.value >= 0);
-    assert(fcp3.id.match(/^v2-\d+-\d+$/));
+    assert(fcp3.id.match(/^v3-\d+-\d+$/));
     assert(fcp3.id !== fcp2.id);
     assert.strictEqual(fcp3.name, 'FCP');
     assert.strictEqual(fcp3.value, fcp3.delta);
@@ -212,7 +212,7 @@ describe('onFCP()', async function() {
 
     const [fcp1] = await getBeacons();
     assert(fcp1.value >= 0);
-    assert(fcp1.id.match(/^v2-\d+-\d+$/));
+    assert(fcp1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(fcp1.name, 'FCP');
     assert.strictEqual(fcp1.value, fcp1.delta);
     assert.strictEqual(fcp1.rating, 'good');
@@ -226,7 +226,7 @@ describe('onFCP()', async function() {
 
     const [fcp2] = await getBeacons();
     assert(fcp2.value >= 0);
-    assert(fcp2.id.match(/^v2-\d+-\d+$/));
+    assert(fcp2.id.match(/^v3-\d+-\d+$/));
     assert(fcp2.id !== fcp1.id);
     assert.strictEqual(fcp2.name, 'FCP');
     assert.strictEqual(fcp2.value, fcp2.delta);
@@ -255,7 +255,7 @@ describe('onFCP()', async function() {
       const [fcp] = await getBeacons();
 
       assert(fcp.value >= 0);
-      assert(fcp.id.match(/^v2-\d+-\d+$/));
+      assert(fcp.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(fcp.name, 'FCP');
       assert.strictEqual(fcp.value, fcp.delta);
       assert.strictEqual(fcp.rating, 'good');
@@ -302,7 +302,7 @@ describe('onFCP()', async function() {
 
       const [fcp] = await getBeacons();
       assert(fcp.value >= 0);
-      assert(fcp.id.match(/^v2-\d+-\d+$/));
+      assert(fcp.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(fcp.name, 'FCP');
       assert.strictEqual(fcp.value, fcp.delta);
       assert.strictEqual(fcp.rating, 'good');
@@ -341,7 +341,7 @@ describe('onFCP()', async function() {
 
       const [fcp] = await getBeacons();
       assert(fcp.value >= 0);
-      assert(fcp.id.match(/^v2-\d+-\d+$/));
+      assert(fcp.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(fcp.name, 'FCP');
       assert.strictEqual(fcp.value, fcp.delta);
       assert.strictEqual(fcp.rating, 'good');

--- a/test/e2e/onFID-test.js
+++ b/test/e2e/onFID-test.js
@@ -48,7 +48,7 @@ describe('onFID()', async function() {
 
     const [fid] = await getBeacons();
     assert(fid.value >= 0);
-    assert(fid.id.match(/^v2-\d+-\d+$/));
+    assert(fid.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.rating, 'good');
@@ -100,7 +100,7 @@ describe('onFID()', async function() {
     const [fid] = await getBeacons();
 
     assert(fid.value >= 0);
-    assert(fid.id.match(/^v2-\d+-\d+$/));
+    assert(fid.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(fid.name, 'FID');
     assert.strictEqual(fid.value, fid.delta);
     assert.strictEqual(fid.rating, 'good');
@@ -168,7 +168,7 @@ describe('onFID()', async function() {
 
     const [fid1] = await getBeacons();
     assert(fid1.value >= 0);
-    assert(fid1.id.match(/^v2-\d+-\d+$/));
+    assert(fid1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(fid1.name, 'FID');
     assert.strictEqual(fid1.value, fid1.delta);
     assert.strictEqual(fid1.rating, 'good');
@@ -185,7 +185,7 @@ describe('onFID()', async function() {
 
     const [fid2] = await getBeacons();
     assert(fid2.value >= 0);
-    assert(fid2.id.match(/^v2-\d+-\d+$/));
+    assert(fid2.id.match(/^v3-\d+-\d+$/));
     assert(fid1.id !== fid2.id);
     assert.strictEqual(fid2.name, 'FID');
     assert.strictEqual(fid2.rating, 'good');
@@ -208,7 +208,7 @@ describe('onFID()', async function() {
 
       const [fid] = await getBeacons();
       assert(fid.value >= 0);
-      assert(fid.id.match(/^v2-\d+-\d+$/));
+      assert(fid.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(fid.name, 'FID');
       assert.strictEqual(fid.value, fid.delta);
       assert.strictEqual(fid.rating, 'good');

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -52,7 +52,7 @@ describe('onINP()', async function() {
 
     const [inp] = await getBeacons();
     assert(inp.value >= 0);
-    assert(inp.id.match(/^v2-\d+-\d+$/));
+    assert(inp.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(inp.name, 'INP');
     assert.strictEqual(inp.value, inp.delta);
     assert.strictEqual(inp.rating, 'good');
@@ -76,7 +76,7 @@ describe('onINP()', async function() {
 
     const [inp] = await getBeacons();
     assert(inp.value >= 0);
-    assert(inp.id.match(/^v2-\d+-\d+$/));
+    assert(inp.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(inp.name, 'INP');
     assert.strictEqual(inp.value, inp.delta);
     assert.strictEqual(inp.rating, 'good');
@@ -100,7 +100,7 @@ describe('onINP()', async function() {
 
     const [inp] = await getBeacons();
     assert(inp.value >= 0);
-    assert(inp.id.match(/^v2-\d+-\d+$/));
+    assert(inp.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(inp.name, 'INP');
     assert.strictEqual(inp.value, inp.delta);
     assert.strictEqual(inp.rating, 'good');
@@ -124,7 +124,7 @@ describe('onINP()', async function() {
 
     const [inp] = await getBeacons();
     assert(inp.value >= 0);
-    assert(inp.id.match(/^v2-\d+-\d+$/));
+    assert(inp.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(inp.name, 'INP');
     assert.strictEqual(inp.value, inp.delta);
     assert.strictEqual(inp.rating, 'good');
@@ -242,7 +242,7 @@ describe('onINP()', async function() {
 
     const [inp1] = await getBeacons();
     assert(inp1.value >= 0);
-    assert(inp1.id.match(/^v2-\d+-\d+$/));
+    assert(inp1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(inp1.name, 'INP');
     assert.strictEqual(inp1.value, inp1.delta);
     assert.strictEqual(inp1.rating, 'good');
@@ -265,7 +265,7 @@ describe('onINP()', async function() {
 
     const [inp2] = await getBeacons();
     assert(inp2.value >= 0);
-    assert(inp2.id.match(/^v2-\d+-\d+$/));
+    assert(inp2.id.match(/^v3-\d+-\d+$/));
     assert(inp1.id !== inp2.id);
     assert.strictEqual(inp2.name, 'INP');
     assert.strictEqual(inp2.value, inp2.delta);
@@ -291,7 +291,7 @@ describe('onINP()', async function() {
 
     const [inp3] = await getBeacons();
     assert(inp3.value >= 0);
-    assert(inp3.id.match(/^v2-\d+-\d+$/));
+    assert(inp3.id.match(/^v3-\d+-\d+$/));
     assert(inp1.id !== inp3.id);
     assert.strictEqual(inp3.name, 'INP');
     assert.strictEqual(inp3.value, inp3.delta);
@@ -335,7 +335,7 @@ describe('onINP()', async function() {
       const [inp1] = await getBeacons();
 
       assert(inp1.value >= 100 - ROUNDING_ERROR);
-      assert(inp1.id.match(/^v2-\d+-\d+$/));
+      assert(inp1.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(inp1.name, 'INP');
       assert.strictEqual(inp1.value, inp1.delta);
       assert.strictEqual(inp1.rating, 'good');
@@ -374,7 +374,7 @@ describe('onINP()', async function() {
       const [inp2] = await getBeacons();
 
       assert(inp2.value >= 300 - ROUNDING_ERROR);
-      assert(inp2.id.match(/^v2-\d+-\d+$/));
+      assert(inp2.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(inp2.name, 'INP');
       assert.strictEqual(inp2.value, inp1.value + inp2.delta);
       assert.strictEqual(inp2.rating, 'needs-improvement');

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -305,7 +305,7 @@ describe('onLCP()', async function() {
     const [lcp1] = await getBeacons();
 
     assert(lcp1.value > 0); // Greater than the image load delay.
-    assert(lcp1.id.match(/^v2-\d+-\d+$/));
+    assert(lcp1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(lcp1.name, 'LCP');
     assert.strictEqual(lcp1.value, lcp1.delta);
     assert.strictEqual(lcp1.rating, 'good');
@@ -319,7 +319,7 @@ describe('onLCP()', async function() {
     const [lcp2] = await getBeacons();
 
     assert(lcp2.value > 0); // Greater than the image load delay.
-    assert(lcp2.id.match(/^v2-\d+-\d+$/));
+    assert(lcp2.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(lcp2.name, 'LCP');
     assert.strictEqual(lcp2.value, lcp2.delta);
     assert.strictEqual(lcp2.rating, 'good');
@@ -351,7 +351,7 @@ describe('onLCP()', async function() {
     const [lcp1] = await getBeacons();
 
     assert(lcp1.value > 0); // Greater than the image load delay.
-    assert(lcp1.id.match(/^v2-\d+-\d+$/));
+    assert(lcp1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(lcp1.name, 'LCP');
     assert.strictEqual(lcp1.value, lcp1.delta);
     assert.strictEqual(lcp1.rating, 'good');
@@ -365,7 +365,7 @@ describe('onLCP()', async function() {
     const [lcp2] = await getBeacons();
 
     assert(lcp2.value > 0); // Greater than the image load delay.
-    assert(lcp2.id.match(/^v2-\d+-\d+$/));
+    assert(lcp2.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(lcp2.name, 'LCP');
     assert.strictEqual(lcp2.value, lcp2.delta);
     assert.strictEqual(lcp2.rating, 'good');
@@ -579,7 +579,7 @@ describe('onLCP()', async function() {
       const [lcp2] = await getBeacons();
 
       assert(lcp2.value > 0); // Greater than the image load delay.
-      assert(lcp2.id.match(/^v2-\d+-\d+$/));
+      assert(lcp2.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(lcp2.name, 'LCP');
       assert.strictEqual(lcp2.value, lcp2.delta);
       assert.strictEqual(lcp2.entries.length, 0);
@@ -601,7 +601,7 @@ const assertStandardReportsAreCorrect = (beacons) => {
   const [lcp] = beacons;
 
   assert(lcp.value > 500); // Greater than the image load delay.
-  assert(lcp.id.match(/^v2-\d+-\d+$/));
+  assert(lcp.id.match(/^v3-\d+-\d+$/));
   assert.strictEqual(lcp.name, 'LCP');
   assert.strictEqual(lcp.value, lcp.delta);
   assert.strictEqual(lcp.rating, 'good');
@@ -613,7 +613,7 @@ const assertFullReportsAreCorrect = (beacons) => {
   const [lcp1, lcp2] = beacons;
 
   assert(lcp1.value < 500); // Less than the image load delay.
-  assert(lcp1.id.match(/^v2-\d+-\d+$/));
+  assert(lcp1.id.match(/^v3-\d+-\d+$/));
   assert.strictEqual(lcp1.name, 'LCP');
   assert.strictEqual(lcp1.value, lcp1.delta);
   assert.strictEqual(lcp1.rating, 'good');

--- a/test/e2e/onTTFB-test.js
+++ b/test/e2e/onTTFB-test.js
@@ -70,7 +70,7 @@ describe('onTTFB()', async function() {
     assert(ttfb.value >= 0);
     assert(ttfb.value >= ttfb.entries[0].requestStart);
     assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
-    assert(ttfb.id.match(/^v2-\d+-\d+$/));
+    assert(ttfb.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.rating, 'good');
@@ -88,7 +88,7 @@ describe('onTTFB()', async function() {
     assert(ttfb.value >= 0);
     assert(ttfb.value >= ttfb.entries[0].requestStart);
     assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
-    assert(ttfb.id.match(/^v2-\d+-\d+$/));
+    assert(ttfb.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.rating, 'good');
@@ -106,7 +106,7 @@ describe('onTTFB()', async function() {
     assert(ttfb.value >= 1000);
     assert(ttfb.value >= ttfb.entries[0].requestStart);
     assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
-    assert(ttfb.id.match(/^v2-\d+-\d+$/));
+    assert(ttfb.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(ttfb.name, 'TTFB');
     assert.strictEqual(ttfb.value, ttfb.delta);
     assert.strictEqual(ttfb.rating, 'needs-improvement');
@@ -161,7 +161,7 @@ describe('onTTFB()', async function() {
     assert(ttfb1.value >= 0);
     assert(ttfb1.value >= ttfb1.entries[0].requestStart);
     assert(ttfb1.value <= ttfb1.entries[0].loadEventEnd);
-    assert(ttfb1.id.match(/^v2-\d+-\d+$/));
+    assert(ttfb1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(ttfb1.name, 'TTFB');
     assert.strictEqual(ttfb1.rating, 'good');
     assert.strictEqual(ttfb1.value, ttfb1.delta);
@@ -176,7 +176,7 @@ describe('onTTFB()', async function() {
     const ttfb2 = await getTTFBBeacon();
 
     assert(ttfb2.value >= 0);
-    assert(ttfb2.id.match(/^v2-\d+-\d+$/));
+    assert(ttfb2.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(ttfb2.name, 'TTFB');
     assert.strictEqual(ttfb2.value, ttfb2.delta);
     assert.strictEqual(ttfb2.rating, 'good');
@@ -193,7 +193,7 @@ describe('onTTFB()', async function() {
       assert(ttfb.value >= 0);
       assert(ttfb.value >= ttfb.entries[0].requestStart);
       assert(ttfb.value <= ttfb.entries[0].loadEventEnd);
-      assert(ttfb.id.match(/^v2-\d+-\d+$/));
+      assert(ttfb.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(ttfb.name, 'TTFB');
       assert.strictEqual(ttfb.value, ttfb.delta);
       assert.strictEqual(ttfb.rating, 'good');
@@ -265,7 +265,7 @@ describe('onTTFB()', async function() {
       const ttfb = await getTTFBBeacon();
 
       assert(ttfb.value >= 0);
-      assert(ttfb.id.match(/^v2-\d+-\d+$/));
+      assert(ttfb.id.match(/^v3-\d+-\d+$/));
       assert.strictEqual(ttfb.name, 'TTFB');
       assert.strictEqual(ttfb.value, ttfb.delta);
       assert.strictEqual(ttfb.rating, 'good');


### PR DESCRIPTION
This PR updates the metric ID prefix from `v2` to `v3`. (Ideally this would have been done in the first v3 beta, but it was missed.)