### PR TITLE
Use the cjs extension for all UMD builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ The following table lists all the builds distributed with the `web-vitals` packa
     </td>
   </tr>
   <tr>
-    <td><code>web-vitals.umd.js</code></td>
+    <td><code>web-vitals.umd.cjs</code></td>
     <td><code>pgk.main</code></td>
     <td>
       A UMD version of the <code>web-vitals.js</code> bundle (exposed on the <code>window.webVitals.*</code> namespace).
@@ -574,7 +574,7 @@ The following table lists all the builds distributed with the `web-vitals` packa
     </td>
   </tr>
     <tr>
-    <td><code>web-vitals.attribution.umd.js</code></td>
+    <td><code>web-vitals.attribution.umd.cjs</code></td>
     <td>--</td>
     <td>
       A UMD version of the <code>web-vitals.attribution.js</code> build (exposed on the <code>window.webVitals.*</code> namespace).
@@ -598,7 +598,7 @@ The following table lists all the builds distributed with the `web-vitals` packa
     </td>
   </tr>
     <tr>
-    <td><code>web-vitals.base.umd.js</code></td>
+    <td><code>web-vitals.base.umd.cjs</code></td>
     <td>--</td>
     <td>
       <p><strong>This build has been <a href="https://github.com/GoogleChrome/web-vitals/issues/238">deprecated</a>.</strong></p>
@@ -619,7 +619,7 @@ The following table lists all the builds distributed with the `web-vitals` packa
     <td>--</td>
     <td>
       <p><strong>This build has been <a href="https://github.com/GoogleChrome/web-vitals/issues/238">deprecated</a>.</strong></p>
-      <p>The "polyfill" part of the "base+polyfill" version. This script should be used with either <code>web-vitals.base.js</code>, <code>web-vitals.base.umd.js</code>, or <code>web-vitals.base.iife.js</code> (it will not work with any script that doesn't have "base" in the filename).</p>
+      <p>The "polyfill" part of the "base+polyfill" version. This script should be used with either <code>web-vitals.base.js</code>, <code>web-vitals.base.umd.cjs</code>, or <code>web-vitals.base.iife.js</code> (it will not work with any script that doesn't have "base" in the filename).</p>
       See <a href="#how-to-use-the-polyfill">how to use the polyfill</a> for more details.
     </td>
   </tr>

--- a/package.json
+++ b/package.json
@@ -4,32 +4,32 @@
   "description": "Easily measure performance metrics in JavaScript",
   "type": "module",
   "typings": "dist/modules/index.d.ts",
-  "main": "dist/web-vitals.umd.js",
+  "main": "dist/web-vitals.umd.cjs",
   "module": "dist/web-vitals.js",
   "exports": {
     ".": {
       "types": "./dist/modules/index.d.ts",
-      "require": "./dist/web-vitals.umd.js",
+      "require": "./dist/web-vitals.umd.cjs",
       "default": "./dist/web-vitals.js"
     },
     "./base": {
       "types": "./base.d.ts",
-      "require": "./dist/web-vitals.base.umd.js",
+      "require": "./dist/web-vitals.base.umd.cjs",
       "default": "./dist/web-vitals.base.js"
     },
     "./base.js": {
       "types": "./base.d.ts",
-      "require": "./dist/web-vitals.base.umd.js",
+      "require": "./dist/web-vitals.base.umd.cjs",
       "default": "./dist/web-vitals.base.js"
     },
     "./attribution": {
       "types": "./dist/modules/attribution.d.ts",
-      "require": "./dist/web-vitals.attribution.umd.js",
+      "require": "./dist/web-vitals.attribution.umd.cjs",
       "default": "./dist/web-vitals.attribution.js"
     },
     "./attribution.js": {
       "types": "./dist/modules/attribution.d.ts",
-      "require": "./dist/web-vitals.attribution.umd.js",
+      "require": "./dist/web-vitals.attribution.umd.cjs",
       "default": "./dist/web-vitals.attribution.js"
     },
     "./onCLS.js": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,7 +53,7 @@ const configs = [
     input: 'dist/modules/index.js',
     output: {
       format: 'umd',
-      file: `./dist/web-vitals.umd.js`,
+      file: `./dist/web-vitals.umd.cjs`,
       name: 'webVitals',
     },
     plugins: configurePlugins({module: false, polyfill: false}),
@@ -79,7 +79,7 @@ const configs = [
     input: 'dist/modules/index.js',
     output: {
       format: 'umd',
-      file: `./dist/web-vitals.base.umd.js`,
+      file: `./dist/web-vitals.base.umd.cjs`,
       name: 'webVitals',
       extend: true,
     },
@@ -117,7 +117,7 @@ const configs = [
     input: 'dist/modules/attribution.js',
     output: {
       format: 'umd',
-      file: `./dist/web-vitals.attribution.umd.js`,
+      file: `./dist/web-vitals.attribution.umd.cjs`,
       name: 'webVitals',
     },
     plugins: configurePlugins({module: false, polyfill: false}),


### PR DESCRIPTION
This PR fixes #256 by ensuring all UMD builds have the `.cjs` extension.

I do not believe this requires a breaking change because none of the UMD files in `dist` were directly referenced in the documentation examples, and technically the names of these files should be an implementation detail.

It's possible some sites were hard-coding these file named in their HTML, but presumably those references include specific versions (also we document that HTML pages should reference the IIFE builds rather than the UMD builds, so in theory this change will only affect node consumers).

If we get reports of any breakage we can always publish both versions, but I'd prefer to see if this will be an issue before adding that for all future v3 builds.