### PR TITLE
Set an explicit unpkg dist file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "typings": "dist/modules/index.d.ts",
   "main": "dist/web-vitals.umd.cjs",
   "module": "dist/web-vitals.js",
+  "unpkg": "dist/web-vitals.iife.js",
   "exports": {
     ".": {
       "types": "./dist/modules/index.d.ts",


### PR DESCRIPTION
This PR fixes #259 by adding an explicit `unpkg` field in `package.json` that points to the IIFE version of the library. By pointing to a `.js` file, this should work around the fact that unpkg.com currently doesn't support `.cjs` extensions.