### PR TITLE
Fix Types of Attribution

### DIFF
--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -55,10 +55,3 @@ export {
    */
   onTTFB as getTTFB,
 } from './onTTFB.js';
-
-export {
-  /**
-   * @deprecated Use `ReportCallback` instead.
-   */
-  ReportCallback as ReportHandler,
-} from './types.js';

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
+import { CLSAttribution } from './cls.js';
+import { FCPAttribution } from './fcp.js';
+import { FIDAttribution } from './fid.js';
+import { INPAttribution } from './inp.js';
+import { LCPAttribution } from './lcp.js';
 import {FirstInputPolyfillEntry, NavigationTimingPolyfillEntry} from './polyfills.js';
+import { TTFBAttribution } from './ttfb.js';
 
 
 export interface Metric {
@@ -77,11 +83,7 @@ export interface MetricWithAttribution extends Metric {
    * can be sent along with the metric value for the current page visit in
    * order to help identify issues happening to real-users in the field.
    */
-  attribution: {[key: string]: unknown};
-}
-
-export interface ReportCallback {
-  (metric: Metric): void;
+  attribution: CLSAttribution | FCPAttribution | FIDAttribution | INPAttribution | LCPAttribution | TTFBAttribution;
 }
 
 export interface ReportOpts {

--- a/src/types/cls.ts
+++ b/src/types/cls.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {LoadState, Metric, ReportCallback} from './base.js';
+import {LoadState, Metric, MetricWithAttribution} from './base.js';
 
 
 /**
@@ -23,6 +23,12 @@ import {LoadState, Metric, ReportCallback} from './base.js';
 export interface CLSMetric extends Metric {
   name: 'CLS';
   entries: LayoutShift[];
+}
+/**
+ * A CLS-specific version of the Metric object with attribution.
+ */
+export interface CLSMetricWithAttribution extends MetricWithAttribution {
+  attribution: CLSAttribution;
 }
 
 /**
@@ -68,22 +74,15 @@ export interface CLSMetric extends Metric {
 }
 
 /**
- * A CLS-specific version of the Metric object with attribution.
- */
-export interface CLSMetricWithAttribution extends CLSMetric {
-  attribution: CLSAttribution;
-}
-
-/**
  * A CLS-specific version of the ReportCallback function.
  */
-export interface CLSReportCallback extends ReportCallback {
+export interface CLSReportCallback {
   (metric: CLSMetric): void;
 }
 
 /**
  * A CLS-specific version of the ReportCallback function with attribution.
  */
-export interface CLSReportCallbackWithAttribution extends CLSReportCallback {
+export interface CLSReportCallbackWithAttribution {
   (metric: CLSMetricWithAttribution): void;
 }

--- a/src/types/fcp.ts
+++ b/src/types/fcp.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {LoadState, Metric, ReportCallback} from './base.js';
+import {LoadState, Metric, MetricWithAttribution} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 
@@ -24,6 +24,12 @@ import {NavigationTimingPolyfillEntry} from './polyfills.js';
 export interface FCPMetric extends Metric {
   name: 'FCP';
   entries: PerformancePaintTiming[];
+}
+/**
+ * An FCP-specific version of the Metric object with attribution.
+ */
+export interface FCPMetricWithAttribution extends MetricWithAttribution {
+  attribution: FCPAttribution;
 }
 
 /**
@@ -59,22 +65,15 @@ export interface FCPMetric extends Metric {
 }
 
 /**
- * An FCP-specific version of the Metric object with attribution.
- */
-export interface FCPMetricWithAttribution extends FCPMetric {
-  attribution: FCPAttribution;
-}
-
-/**
  * An FCP-specific version of the ReportCallback function.
  */
-export interface FCPReportCallback extends ReportCallback {
+export interface FCPReportCallback {
   (metric: FCPMetric): void;
 }
 
 /**
  * An FCP-specific version of the ReportCallback function with attribution.
  */
-export interface FCPReportCallbackWithAttribution extends FCPReportCallback {
+export interface FCPReportCallbackWithAttribution {
   (metric: FCPMetricWithAttribution): void;
 }

--- a/src/types/fid.ts
+++ b/src/types/fid.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {LoadState, Metric, ReportCallback} from './base.js';
+import {LoadState, Metric, MetricWithAttribution} from './base.js';
 import {FirstInputPolyfillEntry} from './polyfills.js';
 
 
@@ -24,6 +24,12 @@ import {FirstInputPolyfillEntry} from './polyfills.js';
 export interface FIDMetric extends Metric {
   name: 'FID';
   entries: (PerformanceEventTiming | FirstInputPolyfillEntry)[];
+}
+/**
+ * An FID-specific version of the Metric object with attribution.
+ */
+export interface FIDMetricWithAttribution extends MetricWithAttribution {
+  attribution: FIDAttribution;
 }
 
 /**
@@ -61,22 +67,15 @@ export interface FIDAttribution {
 }
 
 /**
- * An FID-specific version of the Metric object with attribution.
- */
-export interface FIDMetricWithAttribution extends FIDMetric {
-  attribution: FIDAttribution;
-}
-
-/**
  * An FID-specific version of the ReportCallback function.
  */
-export interface FIDReportCallback extends ReportCallback {
+export interface FIDReportCallback {
   (metric: FIDMetric): void;
 }
 
 /**
  * An FID-specific version of the ReportCallback function with attribution.
  */
-export interface FIDReportCallbackWithAttribution extends FIDReportCallback {
+export interface FIDReportCallbackWithAttribution {
   (metric: FIDMetricWithAttribution): void;
 }

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {LoadState, Metric, ReportCallback} from './base.js';
+import {LoadState, Metric, MetricWithAttribution} from './base.js';
 
 
 /**
@@ -23,6 +23,12 @@ import {LoadState, Metric, ReportCallback} from './base.js';
 export interface INPMetric extends Metric {
   name: 'INP';
   entries: PerformanceEventTiming[];
+}
+/**
+ * An INP-specific version of the Metric object with attribution.
+ */
+export interface INPMetricWithAttribution extends MetricWithAttribution {
+  attribution: INPAttribution;
 }
 
 /**
@@ -60,22 +66,15 @@ export interface INPAttribution {
 }
 
 /**
- * An INP-specific version of the Metric object with attribution.
- */
-export interface INPMetricWithAttribution extends INPMetric {
-  attribution: INPAttribution;
-}
-
-/**
  * An INP-specific version of the ReportCallback function.
  */
-export interface INPReportCallback extends ReportCallback {
+export interface INPReportCallback {
   (metric: INPMetric): void;
 }
 
 /**
  * An INP-specific version of the ReportCallback function with attribution.
  */
-export interface INPReportCallbackWithAttribution extends INPReportCallback {
+export interface INPReportCallbackWithAttribution {
   (metric: INPMetricWithAttribution): void;
 }

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Metric, ReportCallback} from './base.js';
+import {Metric, MetricWithAttribution} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 
@@ -24,6 +24,12 @@ import {NavigationTimingPolyfillEntry} from './polyfills.js';
 export interface LCPMetric extends Metric {
   name: 'LCP';
   entries: LargestContentfulPaint[];
+}
+/**
+ * An LCP-specific version of the Metric object with attribution.
+ */
+export interface LCPMetricWithAttribution extends MetricWithAttribution {
+  attribution: LCPAttribution;
 }
 
 /**
@@ -82,22 +88,15 @@ export interface LCPAttribution {
 }
 
 /**
- * An LCP-specific version of the Metric object with attribution.
- */
-export interface LCPMetricWithAttribution extends LCPMetric {
-  attribution: LCPAttribution;
-}
-
-/**
  * An LCP-specific version of the ReportCallback function.
  */
-export interface LCPReportCallback extends ReportCallback {
+export interface LCPReportCallback {
   (metric: LCPMetric): void;
 }
 
 /**
  * An LCP-specific version of the ReportCallback function with attribution.
  */
-export interface LCPReportCallbackWithAttribution extends LCPReportCallback {
+export interface LCPReportCallbackWithAttribution {
   (metric: LCPMetricWithAttribution): void;
 }

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Metric, ReportCallback} from './base.js';
+import {Metric, MetricWithAttribution} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 
@@ -24,6 +24,12 @@ import {NavigationTimingPolyfillEntry} from './polyfills.js';
 export interface TTFBMetric extends Metric {
   name: 'TTFB';
   entries: PerformanceNavigationTiming[] | NavigationTimingPolyfillEntry[];
+}
+/**
+ * A TTFB-specific version of the Metric object with attribution.
+ */
+export interface TTFBMetricWithAttribution extends MetricWithAttribution {
+  attribution: TTFBAttribution;
 }
 
 /**
@@ -60,22 +66,15 @@ export interface TTFBMetric extends Metric {
 }
 
 /**
- * A TTFB-specific version of the Metric object with attribution.
- */
-export interface TTFBMetricWithAttribution extends TTFBMetric {
-  attribution: TTFBAttribution;
-}
-
-/**
  * A TTFB-specific version of the ReportCallback function.
  */
-export interface TTFBReportCallback extends ReportCallback {
+export interface TTFBReportCallback {
   (metric: TTFBMetric): void;
 }
 
 /**
  * A TTFB-specific version of the ReportCallback function with attribution.
  */
-export interface TTFBReportCallbackWithAttribution extends TTFBReportCallback {
+export interface TTFBReportCallbackWithAttribution {
   (metric: TTFBMetricWithAttribution): void;
 }


### PR DESCRIPTION
Hello, There may be a problem with types of attributtion.

As an example, a type error occurs in the following code in call `onCLS`.
```ts
import { CLSMetricWithAttribution, MetricWithAttribution, onCLS } from 'web-vitals/attribution';

const sendCLSMetrics = (metric: CLSMetricWithAttribution) => {
    console.log(metric.attribution)
}

onCLS(sendCLSMetrics); // type error

const sendMetrics = (metric: MetricWithAttribution) => {
    console.log(metric.attribution)
}

onCLS(sendMetrics); // type error
```

I think there is a problem with extending callback function. Sorry if there is any problem with my usage.