### PR TITLE
Clamp LCP and FCP to 0 for prerendered pages

### DIFF
--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -50,8 +50,9 @@ export const onFCP = (onReport: FCPReportCallback, opts?: ReportOpts) => {
         if (entry.startTime < visibilityWatcher.firstHiddenTime) {
           // The activationStart reference is used because FCP should be
           // relative to page activation rather than navigation start if the
-          // page was prerendered.
-          metric.value = entry.startTime - getActivationStart();
+          // page was prerendered. But in cases where `activationStart` occurs
+          // after the FCP, this time should be clamped at 0.
+          metric.value = Math.max(entry.startTime - getActivationStart(), 0);
           metric.entries.push(entry);
           report(true);
         }

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -54,8 +54,10 @@ export const onLCP = (onReport: ReportCallback, opts?: ReportOpts) => {
       // The startTime attribute returns the value of the renderTime if it is
       // not 0, and the value of the loadTime otherwise. The activationStart
       // reference is used because LCP should be relative to page activation
-      // rather than navigation start if the page was prerendered.
-      const value = lastEntry.startTime - getActivationStart();
+      // rather than navigation start if the page was prerendered. But in cases
+      // where `activationStart` occurs after the LCP, this time should be
+      // clamped at 0.
+      const value = Math.max(lastEntry.startTime - getActivationStart(), 0);
 
       // Only report if the page wasn't hidden prior to LCP.
       if (value < visibilityWatcher.firstHiddenTime) {


### PR DESCRIPTION
Fixes #268 

Not sure how to add a test for this, since the prerendered test (http://localhost:9090/test/lcp?prerender=1) is just a stub and not an actual preprendered page so LCP is not zero.