### PR TITLE
Defer execution of observer callbacks

### DIFF
--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -43,7 +43,12 @@ export const observe = <K extends keyof PerformanceEntryMap>(
   try {
     if (PerformanceObserver.supportedEntryTypes.includes(type)) {
       const po = new PerformanceObserver((list) => {
-        callback(list.getEntries() as PerformanceEntryMap[K]);
+        // Delay by a microtask to workaround a bug in Safari where the
+        // callback is invoked immediately, rather than in a separate task.
+        // See: https://github.com/GoogleChrome/web-vitals/issues/271
+        Promise.resolve().then(() => {
+          callback(list.getEntries() as PerformanceEntryMap[K]);
+        });
       });
       po.observe(Object.assign({
         type,

--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -45,7 +45,7 @@ export const observe = <K extends keyof PerformanceEntryMap>(
       const po = new PerformanceObserver((list) => {
         // Delay by a microtask to workaround a bug in Safari where the
         // callback is invoked immediately, rather than in a separate task.
-        // See: https://github.com/GoogleChrome/web-vitals/issues/271
+        // See: https://github.com/GoogleChrome/web-vitals/issues/277
         Promise.resolve().then(() => {
           callback(list.getEntries() as PerformanceEntryMap[K]);
         });


### PR DESCRIPTION
This PR fixes #277 by deferring execution of all Performance Observer callbacks by a microtask, which will allow the current call stack to complete and ensure all module-scoped variables are available within the callback itself. This is needed to address an interop issue with Safari.

This PR also removes some related logic that was only needed to address compat issues in older versions of Safari. Since this logic is not needed in the last two major versions of Safari, it's safe to remove from this library.