### PR TITLE
Report initial CLS value when reportAllChanges is true

### DIFF
--- a/src/lib/doubleRAF.ts
+++ b/src/lib/doubleRAF.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const doubleRAF = (cb: () => unknown) => {
+  requestAnimationFrame(() => requestAnimationFrame(() => cb()));
+};

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -16,6 +16,7 @@
 
 import {onBFCacheRestore} from './lib/bfcache.js';
 import {bindReporter} from './lib/bindReporter.js';
+import {doubleRAF} from './lib/doubleRAF.js';
 import {getActivationStart} from './lib/getActivationStart.js';
 import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
 import {initMetric} from './lib/initMetric.js';
@@ -73,11 +74,9 @@ export const onFCP = (onReport: FCPReportCallback, opts?: ReportOpts) => {
         report = bindReporter(
             onReport, metric, thresholds, opts!.reportAllChanges);
 
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            metric.value = performance.now() - event.timeStamp;
-            report(true);
-          });
+        doubleRAF(() => {
+          metric.value = performance.now() - event.timeStamp;
+          report(true);
         });
       });
     }

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -16,6 +16,7 @@
 
 import {onBFCacheRestore} from './lib/bfcache.js';
 import {bindReporter} from './lib/bindReporter.js';
+import {doubleRAF} from './lib/doubleRAF.js';
 import {getActivationStart} from './lib/getActivationStart.js';
 import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
 import {initMetric} from './lib/initMetric.js';
@@ -101,12 +102,10 @@ export const onLCP = (onReport: ReportCallback, opts?: ReportOpts) => {
         report = bindReporter(
             onReport, metric, thresholds, opts!.reportAllChanges);
 
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            metric.value = performance.now() - event.timeStamp;
-            reportedMetricIDs[metric.id] = true;
-            report(true);
-          });
+        doubleRAF(() => {
+          metric.value = performance.now() - event.timeStamp;
+          reportedMetricIDs[metric.id] = true;
+          report(true);
         });
       });
     }

--- a/test/e2e/onCLS-test.js
+++ b/test/e2e/onCLS-test.js
@@ -209,25 +209,33 @@ describe('onCLS()', async function() {
     await browser.url('/test/cls?reportAllChanges=1');
 
     // Beacons should be sent as soon as layout shifts occur, wait for them.
-    await beaconCountIs(2);
+    await beaconCountIs(3);
 
-    const [cls1, cls2] = await getBeacons();
+    const [cls1, cls2, cls3] = await getBeacons();
 
-    assert(cls1.value >= 0);
+    assert.strictEqual(cls1.value, 0);
     assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.rating, 'good');
-    assert.strictEqual(cls1.entries.length, 1);
+    assert.strictEqual(cls1.entries.length, 0);
     assert.match(cls1.navigationType, /navigate|reload/);
 
-    assert(cls2.value >= cls1.value);
+    assert(cls2.value >= 0);
     assert.strictEqual(cls2.name, 'CLS');
     assert.strictEqual(cls2.id, cls1.id);
-    assert.strictEqual(cls2.value, cls1.value + cls2.delta);
+    assert.strictEqual(cls2.value, cls1.delta + cls2.delta);
     assert.strictEqual(cls2.rating, 'good');
-    assert.strictEqual(cls2.entries.length, 2);
+    assert.strictEqual(cls2.entries.length, 1);
     assert.match(cls2.navigationType, /navigate|reload/);
+
+    assert(cls3.value >= cls2.value);
+    assert.strictEqual(cls3.name, 'CLS');
+    assert.strictEqual(cls3.id, cls2.id);
+    assert.strictEqual(cls3.value, cls2.value + cls3.delta);
+    assert.strictEqual(cls3.rating, 'good');
+    assert.strictEqual(cls3.entries.length, 2);
+    assert.match(cls3.navigationType, /navigate|reload/);
 
     await clearBeacons();
     await stubVisibilityChange('hidden');
@@ -245,24 +253,33 @@ describe('onCLS()', async function() {
     await browser.url('/test/cls?reportAllChanges=1');
 
     // Beacons should be sent as soon as layout shifts occur, wait for them.
-    await beaconCountIs(2);
+    await beaconCountIs(3);
 
-    const [cls1, cls2] = await getBeacons();
+    const [cls1, cls2, cls3] = await getBeacons();
 
-    assert(cls1.value >= 0);
+    assert.strictEqual(cls1.value, 0);
     assert(cls1.id.match(/^v3-\d+-\d+$/));
+    assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
     assert.strictEqual(cls1.rating, 'good');
-    assert.strictEqual(cls1.entries.length, 1);
+    assert.strictEqual(cls1.entries.length, 0);
     assert.match(cls1.navigationType, /navigate|reload/);
 
-    assert(cls2.value >= cls1.value);
+    assert(cls2.value >= 0);
     assert.strictEqual(cls2.name, 'CLS');
     assert.strictEqual(cls2.id, cls1.id);
-    assert.strictEqual(cls2.value, cls1.value + cls2.delta);
+    assert.strictEqual(cls2.value, cls1.delta + cls2.delta);
     assert.strictEqual(cls2.rating, 'good');
-    assert.strictEqual(cls2.entries.length, 2);
+    assert.strictEqual(cls2.entries.length, 1);
     assert.match(cls2.navigationType, /navigate|reload/);
+
+    assert(cls3.value >= cls2.value);
+    assert.strictEqual(cls3.name, 'CLS');
+    assert.strictEqual(cls3.id, cls2.id);
+    assert.strictEqual(cls3.value, cls2.value + cls3.delta);
+    assert.strictEqual(cls3.rating, 'good');
+    assert.strictEqual(cls3.entries.length, 2);
+    assert.match(cls3.navigationType, /navigate|reload/);
 
     // Unload the page after no new shifts have occurred.
     await clearBeacons();
@@ -323,23 +340,33 @@ describe('onCLS()', async function() {
     if (!browserSupportsCLS) this.skip();
 
     await browser.url(`/test/cls?reportAllChanges=1`);
-    await beaconCountIs(2);
+    await beaconCountIs(3);
 
-    const [cls1, cls2] = await getBeacons();
+    const [cls1, cls2, cls3] = await getBeacons();
 
-    assert(cls1.value > 0);
+    assert.strictEqual(cls1.value, 0);
     assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
-    assert.strictEqual(cls1.entries.length, 1);
+    assert.strictEqual(cls1.rating, 'good');
+    assert.strictEqual(cls1.entries.length, 0);
+    assert.match(cls1.navigationType, /navigate|reload/);
 
-    assert(cls2.value > cls1.value);
+    assert(cls2.value >= 0);
     assert.strictEqual(cls2.name, 'CLS');
     assert.strictEqual(cls2.id, cls1.id);
-    assert.strictEqual(cls2.value, cls1.value + cls2.delta);
+    assert.strictEqual(cls2.value, cls1.delta + cls2.delta);
     assert.strictEqual(cls2.rating, 'good');
-    assert.strictEqual(cls2.entries.length, 2);
+    assert.strictEqual(cls2.entries.length, 1);
     assert.match(cls2.navigationType, /navigate|reload/);
+
+    assert(cls3.value >= cls2.value);
+    assert.strictEqual(cls3.name, 'CLS');
+    assert.strictEqual(cls3.id, cls2.id);
+    assert.strictEqual(cls3.value, cls2.value + cls3.delta);
+    assert.strictEqual(cls3.rating, 'good');
+    assert.strictEqual(cls3.entries.length, 2);
+    assert.match(cls3.navigationType, /navigate|reload/);
 
     // Unload the page after no new shifts have occurred.
     await clearBeacons();
@@ -352,15 +379,15 @@ describe('onCLS()', async function() {
     await triggerLayoutShift();
 
     await beaconCountIs(1);
-    const [cls3] = await getBeacons();
+    const [cls4] = await getBeacons();
 
-    assert(cls3.value > cls2.value);
-    assert.strictEqual(cls3.name, 'CLS');
-    assert.strictEqual(cls3.id, cls2.id);
-    assert.strictEqual(cls3.value, cls2.value + cls3.delta);
-    assert.strictEqual(cls3.rating, 'good');
-    assert.strictEqual(cls3.entries.length, 3);
-    assert.match(cls3.navigationType, /navigate|reload/);
+    assert(cls4.value > cls3.value);
+    assert.strictEqual(cls4.name, 'CLS');
+    assert.strictEqual(cls4.id, cls3.id);
+    assert.strictEqual(cls4.value, cls3.value + cls4.delta);
+    assert.strictEqual(cls4.rating, 'good');
+    assert.strictEqual(cls4.entries.length, 3);
+    assert.match(cls4.navigationType, /navigate|reload/);
   });
 
   it('continues reporting after bfcache restore (reportAllChanges === false)', async function() {
@@ -426,24 +453,33 @@ describe('onCLS()', async function() {
     if (!browserSupportsCLS) this.skip();
 
     await browser.url(`/test/cls?reportAllChanges=1`);
-    await beaconCountIs(2);
+    await beaconCountIs(3);
 
-    const [cls1, cls2] = await getBeacons();
+    const [cls1, cls2, cls3] = await getBeacons();
 
-    assert(cls1.value > 0);
+    assert.strictEqual(cls1.value, 0);
     assert(cls1.id.match(/^v3-\d+-\d+$/));
     assert.strictEqual(cls1.name, 'CLS');
     assert.strictEqual(cls1.value, cls1.delta);
-    assert.strictEqual(cls1.entries.length, 1);
+    assert.strictEqual(cls1.rating, 'good');
+    assert.strictEqual(cls1.entries.length, 0);
     assert.match(cls1.navigationType, /navigate|reload/);
 
-    assert(cls2.value > cls1.value);
+    assert(cls2.value >= 0);
     assert.strictEqual(cls2.name, 'CLS');
     assert.strictEqual(cls2.id, cls1.id);
-    assert.strictEqual(cls2.value, cls1.value + cls2.delta);
+    assert.strictEqual(cls2.value, cls1.delta + cls2.delta);
     assert.strictEqual(cls2.rating, 'good');
-    assert.strictEqual(cls2.entries.length, 2);
+    assert.strictEqual(cls2.entries.length, 1);
     assert.match(cls2.navigationType, /navigate|reload/);
+
+    assert(cls3.value >= cls2.value);
+    assert.strictEqual(cls3.name, 'CLS');
+    assert.strictEqual(cls3.id, cls2.id);
+    assert.strictEqual(cls3.value, cls2.value + cls3.delta);
+    assert.strictEqual(cls3.rating, 'good');
+    assert.strictEqual(cls3.entries.length, 2);
+    assert.match(cls3.navigationType, /navigate|reload/);
 
     await clearBeacons();
     await stubForwardBack();
@@ -453,17 +489,25 @@ describe('onCLS()', async function() {
 
     await triggerLayoutShift();
 
-    await beaconCountIs(1);
-    const [cls3] = await getBeacons();
+    await beaconCountIs(2);
+    const [cls4, cls5] = await getBeacons();
 
-    assert(cls3.value > 0);
-    assert(cls3.id.match(/^v3-\d+-\d+$/));
-    assert(cls3.id !== cls2.id);
-    assert.strictEqual(cls3.name, 'CLS');
-    assert.strictEqual(cls3.value, cls3.delta);
-    assert.strictEqual(cls3.rating, 'good');
-    assert.strictEqual(cls3.entries.length, 1);
-    assert.strictEqual(cls3.navigationType, 'back-forward-cache');
+    assert.strictEqual(cls4.value, 0);
+    assert(cls4.id.match(/^v3-\d+-\d+$/));
+    assert(cls4.id !== cls3.id);
+    assert.strictEqual(cls4.name, 'CLS');
+    assert.strictEqual(cls4.value, cls4.delta);
+    assert.strictEqual(cls4.rating, 'good');
+    assert.strictEqual(cls4.entries.length, 0);
+    assert.strictEqual(cls4.navigationType, 'back-forward-cache');
+
+    assert(cls5.value > 0);
+    assert.strictEqual(cls5.id, cls4.id);
+    assert.strictEqual(cls5.name, 'CLS');
+    assert.strictEqual(cls5.value, cls4.delta + cls5.delta);
+    assert.strictEqual(cls5.rating, 'good');
+    assert.strictEqual(cls5.entries.length, 1);
+    assert.strictEqual(cls5.navigationType, 'back-forward-cache');
   });
 
   it('reports zero if no layout shifts occurred on first visibility hidden (reportAllChanges === false)', async function() {

--- a/test/views/cls.njk
+++ b/test/views/cls.njk
@@ -50,7 +50,7 @@
 
     onCLS((cls) => {
       // Log for easier manual testing.
-      console.log(window.cls = cls);
+      console.log(cls);
 
       // Sources is verbose to serialize, so remove first.
       cls = {


### PR DESCRIPTION
This PR fixes #279 by ensuring that an initial CLS value of 0 is reported as soon as the page reaches FCP. For pages that don't set `reportAllChanges` to true, they shouldn't notice any change; however, for pages that do set `reportAllChanges` to true, they may see additional reports come in.

Note, I do not think this qualifies as a breaking change, because developers should not have been assuming a certain number of reports will be triggered on any particular page. It is possible this breaks some people's test pages, but it should not break anyone's real-world applications.