### PR TITLE
fix: Memory leak caused by caching event objects

### DIFF
--- a/src/lib/polyfills/firstInputPolyfill.ts
+++ b/src/lib/polyfills/firstInputPolyfill.ts
@@ -86,6 +86,7 @@ const reportFirstInputDelayIfRecordedAndValid = () => {
       callback(entry);
     });
     callbacks = [];
+    firstInputEvent = null;
   }
 }
 


### PR DESCRIPTION
The event object is not cleared after reporting, causing the dom to be cached
