### PR TITLE
Add Server Timing information to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,7 +1018,8 @@ interface FCPAttribution {
   fcpEntry?: PerformancePaintTiming;
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
-   * general page load issues.
+   * general page load issues. This can be used to access `serverTiming` for example:
+   * navigationEntry.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
 }
@@ -1129,7 +1130,8 @@ interface LCPAttribution {
   elementRenderDelay: number;
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
-   * general page load issues.
+   * general page load issues. This can be used to access `serverTiming` for example:
+   * navigationEntry.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
   /**
@@ -1169,8 +1171,9 @@ interface TTFBAttribution {
    */
   requestTime: number;
   /**
-   * The `PerformanceNavigationTiming` entry used to determine TTFB (or the
-   * polyfill entry in browsers that don't support Navigation Timing).
+   * The `navigation` entry of the current page, which is useful for diagnosing
+   * general page load issues. This can be used to access `serverTiming` for example:
+   * navigationEntry.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
 }

--- a/README.md
+++ b/README.md
@@ -1019,7 +1019,7 @@ interface FCPAttribution {
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
    * general page load issues. This can be used to access `serverTiming` for example:
-   * navigationEntry.serverTiming
+   * navigationEntry?.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
 }
@@ -1131,7 +1131,7 @@ interface LCPAttribution {
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
    * general page load issues. This can be used to access `serverTiming` for example:
-   * navigationEntry.serverTiming
+   * navigationEntry?.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
   /**
@@ -1173,7 +1173,7 @@ interface TTFBAttribution {
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
    * general page load issues. This can be used to access `serverTiming` for example:
-   * navigationEntry.serverTiming
+   * navigationEntry?.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
 }

--- a/src/types/fcp.ts
+++ b/src/types/fcp.ts
@@ -52,7 +52,8 @@ export interface FCPAttribution {
   fcpEntry?: PerformancePaintTiming;
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
-   * general page load issues.
+   * general page load issues. This can be used to access `serverTiming` for example:
+   * navigationEntry.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
 }

--- a/src/types/fcp.ts
+++ b/src/types/fcp.ts
@@ -53,7 +53,7 @@ export interface FCPAttribution {
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
    * general page load issues. This can be used to access `serverTiming` for example:
-   * navigationEntry.serverTiming
+   * navigationEntry?.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
 }

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -67,7 +67,7 @@ export interface LCPAttribution {
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
    * general page load issues. This can be used to access `serverTiming` for example:
-   * navigationEntry.serverTiming
+   * navigationEntry?.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
   /**

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -66,7 +66,8 @@ export interface LCPAttribution {
   elementRenderDelay: number;
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
-   * general page load issues.
+   * general page load issues. This can be used to access `serverTiming` for example:
+   * navigationEntry.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
   /**

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -52,8 +52,9 @@ export interface TTFBAttribution {
    */
   requestTime: number;
   /**
-   * The `PerformanceNavigationTiming` entry used to determine TTFB (or the
-   * polyfill entry in browsers that don't support Navigation Timing).
+   * The `navigation` entry of the current page, which is useful for diagnosing
+   * general page load issues. This can be used to access `serverTiming` for example:
+   * navigationEntry.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
 }

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -54,7 +54,7 @@ export interface TTFBAttribution {
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
    * general page load issues. This can be used to access `serverTiming` for example:
-   * navigationEntry.serverTiming
+   * navigationEntry?.serverTiming
    */
   navigationEntry?: PerformanceNavigationTiming | NavigationTimingPolyfillEntry;
 }


### PR DESCRIPTION
Fixes #302 

Decided against adding an explicit value for this as, unlike the others, there's no calculation needed, and want to keep the build small. So documented this as an example instead.