### PR TITLE
Remove Internet Explorer from list of supported browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,16 +1218,16 @@ interface TTFBAttribution {
 
 ## Browser Support
 
-The `web-vitals` code has been tested and will run without error in all major browsers as well as Internet Explorer back to version 9. However, some of the APIs required to capture these metrics are currently only available in Chromium-based browsers (e.g. Chrome, Edge, Opera, Samsung Internet).
+The `web-vitals` code has been tested and will run without error in all major browsers. However, some of the APIs required to capture these metrics are currently only available in Chromium-based browsers (e.g. Chrome, Edge, Opera, Samsung Internet).
 
 Browser support for each function is as follows:
 
 - `onCLS()`: Chromium
 - `onFCP()`: Chromium, Firefox, Safari 14.1+
-- `onFID()`: Chromium, Firefox _(with [polyfill](#how-to-use-the-polyfill): Safari, Internet Explorer)_
+- `onFID()`: Chromium, Firefox _(with [polyfill](#how-to-use-the-polyfill): Safari)_
 - `onINP()`: Chromium
 - `onLCP()`: Chromium
-- `onTTFB()`: Chromium, Firefox, Safari 15+ _(with [polyfill](#how-to-use-the-polyfill): Safari 8+, Internet Explorer)_
+- `onTTFB()`: Chromium, Firefox, Safari 15+ _(with [polyfill](#how-to-use-the-polyfill): Safari 8+)_
 
 ## Limitations
 


### PR DESCRIPTION
As noted in #350 web-vitals no longer works in IE9 as of version 2.1.2. It probably still works in IE10 and IE11 but is no longer tested in either and so is at risk of breaking in either soon.

With all versions of IE not officially unsupported I think it's best to remove any language of it's support from the README. Perhaps this should be a breaking change and saved for v4, but as noted v3 (and also the latest version of v3) already are not reflective of the actual situation so I'm tempted not to leave this for v4 and just merge this.