### PR TITLE
Metric type fixes

### DIFF
--- a/src/onCLS.ts
+++ b/src/onCLS.ts
@@ -26,6 +26,7 @@ import {
   CLSMetric,
   CLSReportCallback,
   MetricRatingThresholds,
+  ReportCallback,
   ReportOpts,
 } from './types.js';
 
@@ -105,7 +106,7 @@ export const onCLS = (onReport: CLSReportCallback, opts?: ReportOpts) => {
       const po = observe('layout-shift', handleEntries);
       if (po) {
         report = bindReporter(
-          onReport,
+          onReport as ReportCallback,
           metric,
           CLSThresholds,
           opts!.reportAllChanges
@@ -122,7 +123,7 @@ export const onCLS = (onReport: CLSReportCallback, opts?: ReportOpts) => {
           sessionValue = 0;
           metric = initMetric('CLS', 0);
           report = bindReporter(
-            onReport,
+            onReport as ReportCallback,
             metric,
             CLSThresholds,
             opts!.reportAllChanges

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -26,6 +26,7 @@ import {
   FCPMetric,
   FCPReportCallback,
   MetricRatingThresholds,
+  ReportCallback,
   ReportOpts,
 } from './types.js';
 
@@ -70,7 +71,7 @@ export const onFCP = (onReport: FCPReportCallback, opts?: ReportOpts) => {
 
     if (po) {
       report = bindReporter(
-        onReport,
+        onReport as ReportCallback,
         metric,
         FCPThresholds,
         opts!.reportAllChanges
@@ -81,7 +82,7 @@ export const onFCP = (onReport: FCPReportCallback, opts?: ReportOpts) => {
       onBFCacheRestore((event) => {
         metric = initMetric('FCP');
         report = bindReporter(
-          onReport,
+          onReport as ReportCallback,
           metric,
           FCPThresholds,
           opts!.reportAllChanges

--- a/src/onFID.ts
+++ b/src/onFID.ts
@@ -28,6 +28,7 @@ import {runOnce} from './lib/runOnce.js';
 import {whenActivated} from './lib/whenActivated.js';
 import {
   FIDMetric,
+  FIDReportCallback,
   FirstInputPolyfillCallback,
   MetricRatingThresholds,
   ReportCallback,
@@ -46,7 +47,7 @@ export const FIDThresholds: MetricRatingThresholds = [100, 300];
  * _**Important:** since FID is only reported after the user interacts with the
  * page, it's possible that it will not be reported for some page loads._
  */
-export const onFID = (onReport: ReportCallback, opts?: ReportOpts) => {
+export const onFID = (onReport: FIDReportCallback, opts?: ReportOpts) => {
   // Set defaults
   opts = opts || {};
 
@@ -70,7 +71,7 @@ export const onFID = (onReport: ReportCallback, opts?: ReportOpts) => {
 
     const po = observe('first-input', handleEntries);
     report = bindReporter(
-      onReport,
+      onReport as ReportCallback,
       metric,
       FIDThresholds,
       opts!.reportAllChanges
@@ -99,7 +100,7 @@ export const onFID = (onReport: ReportCallback, opts?: ReportOpts) => {
       onBFCacheRestore(() => {
         metric = initMetric('FID');
         report = bindReporter(
-          onReport,
+          onReport as ReportCallback,
           metric,
           FIDThresholds,
           opts!.reportAllChanges
@@ -116,7 +117,7 @@ export const onFID = (onReport: ReportCallback, opts?: ReportOpts) => {
         onBFCacheRestore(() => {
           metric = initMetric('FID');
           report = bindReporter(
-            onReport,
+            onReport as ReportCallback,
             metric,
             FIDThresholds,
             opts!.reportAllChanges

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -26,6 +26,7 @@ import {
 import {whenActivated} from './lib/whenActivated.js';
 import {
   INPMetric,
+  INPReportCallback,
   MetricRatingThresholds,
   ReportCallback,
   ReportOpts,
@@ -149,7 +150,7 @@ const estimateP98LongestInteraction = () => {
  * hidden. As a result, the `callback` function might be called multiple times
  * during the same page load._
  */
-export const onINP = (onReport: ReportCallback, opts?: ReportOpts) => {
+export const onINP = (onReport: INPReportCallback, opts?: ReportOpts) => {
   // Set defaults
   opts = opts || {};
 
@@ -211,7 +212,7 @@ export const onINP = (onReport: ReportCallback, opts?: ReportOpts) => {
     } as PerformanceObserverInit);
 
     report = bindReporter(
-      onReport,
+      onReport as ReportCallback,
       metric,
       INPThresholds,
       opts!.reportAllChanges
@@ -245,7 +246,7 @@ export const onINP = (onReport: ReportCallback, opts?: ReportOpts) => {
 
         metric = initMetric('INP');
         report = bindReporter(
-          onReport,
+          onReport as ReportCallback,
           metric,
           INPThresholds,
           opts!.reportAllChanges

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -27,6 +27,7 @@ import {whenActivated} from './lib/whenActivated.js';
 import {
   LCPMetric,
   MetricRatingThresholds,
+  LCPReportCallback,
   ReportCallback,
   ReportOpts,
 } from './types.js';
@@ -47,7 +48,7 @@ const reportedMetricIDs: Record<string, boolean> = {};
  * performance entry is dispatched, or once the final value of the metric has
  * been determined.
  */
-export const onLCP = (onReport: ReportCallback, opts?: ReportOpts) => {
+export const onLCP = (onReport: LCPReportCallback, opts?: ReportOpts) => {
   // Set defaults
   opts = opts || {};
 
@@ -81,7 +82,7 @@ export const onLCP = (onReport: ReportCallback, opts?: ReportOpts) => {
 
     if (po) {
       report = bindReporter(
-        onReport,
+        onReport as ReportCallback,
         metric,
         LCPThresholds,
         opts!.reportAllChanges
@@ -110,7 +111,7 @@ export const onLCP = (onReport: ReportCallback, opts?: ReportOpts) => {
       onBFCacheRestore((event) => {
         metric = initMetric('LCP');
         report = bindReporter(
-          onReport,
+          onReport as ReportCallback,
           metric,
           LCPThresholds,
           opts!.reportAllChanges

--- a/src/onTTFB.ts
+++ b/src/onTTFB.ts
@@ -18,7 +18,12 @@ import {bindReporter} from './lib/bindReporter.js';
 import {initMetric} from './lib/initMetric.js';
 import {onBFCacheRestore} from './lib/bfcache.js';
 import {getNavigationEntry} from './lib/getNavigationEntry.js';
-import {MetricRatingThresholds, ReportCallback, ReportOpts} from './types.js';
+import {
+  MetricRatingThresholds,
+  ReportCallback,
+  ReportOpts,
+  TTFBReportCallback,
+} from './types.js';
 import {getActivationStart} from './lib/getActivationStart.js';
 import {whenActivated} from './lib/whenActivated.js';
 
@@ -55,13 +60,13 @@ const whenReady = (callback: () => void) => {
  * includes time spent on DNS lookup, connection negotiation, network latency,
  * and server processing time.
  */
-export const onTTFB = (onReport: ReportCallback, opts?: ReportOpts) => {
+export const onTTFB = (onReport: TTFBReportCallback, opts?: ReportOpts) => {
   // Set defaults
   opts = opts || {};
 
   let metric = initMetric('TTFB');
   let report = bindReporter(
-    onReport,
+    onReport as ReportCallback,
     metric,
     TTFBThresholds,
     opts.reportAllChanges
@@ -95,7 +100,7 @@ export const onTTFB = (onReport: ReportCallback, opts?: ReportOpts) => {
       onBFCacheRestore(() => {
         metric = initMetric('TTFB', 0);
         report = bindReporter(
-          onReport,
+          onReport as ReportCallback,
           metric,
           TTFBThresholds,
           opts!.reportAllChanges

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -116,10 +116,6 @@ export interface ReportCallback {
   (metric: Metric): void;
 }
 
-export interface ReportCallbackWithAttribution {
-  (metric: MetricWithAttribution): void;
-}
-
 export interface ReportOpts {
   reportAllChanges?: boolean;
   durationThreshold?: number;

--- a/src/types/cls.ts
+++ b/src/types/cls.ts
@@ -81,7 +81,7 @@ export interface CLSMetricWithAttribution extends CLSMetric {
 /**
  * A CLS-specific version of the ReportCallback function.
  */
-export interface CLSReportCallback extends ReportCallback {
+export interface CLSReportCallback extends Omit<ReportCallback, 'metric'> {
   (metric: CLSMetric): void;
 }
 
@@ -89,6 +89,6 @@ export interface CLSReportCallback extends ReportCallback {
  * A CLS-specific version of the ReportCallback function with attribution.
  */
 export interface CLSReportCallbackWithAttribution
-  extends ReportCallbackWithAttribution {
+  extends Omit<ReportCallbackWithAttribution, 'metric'> {
   (metric: CLSMetricWithAttribution): void;
 }

--- a/src/types/cls.ts
+++ b/src/types/cls.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  LoadState,
-  Metric,
-  ReportCallback,
-  ReportCallbackWithAttribution,
-} from './base.js';
+import {LoadState, Metric} from './base.js';
 
 /**
  * A CLS-specific version of the Metric object.
@@ -81,14 +76,13 @@ export interface CLSMetricWithAttribution extends CLSMetric {
 /**
  * A CLS-specific version of the ReportCallback function.
  */
-export interface CLSReportCallback extends Omit<ReportCallback, 'metric'> {
+export interface CLSReportCallback {
   (metric: CLSMetric): void;
 }
 
 /**
  * A CLS-specific version of the ReportCallback function with attribution.
  */
-export interface CLSReportCallbackWithAttribution
-  extends Omit<ReportCallbackWithAttribution, 'metric'> {
+export interface CLSReportCallbackWithAttribution {
   (metric: CLSMetricWithAttribution): void;
 }

--- a/src/types/fcp.ts
+++ b/src/types/fcp.ts
@@ -73,7 +73,7 @@ export interface FCPMetricWithAttribution extends FCPMetric {
 /**
  * An FCP-specific version of the ReportCallback function.
  */
-export interface FCPReportCallback extends ReportCallback {
+export interface FCPReportCallback extends Omit<ReportCallback, 'metric'> {
   (metric: FCPMetric): void;
 }
 
@@ -81,6 +81,6 @@ export interface FCPReportCallback extends ReportCallback {
  * An FCP-specific version of the ReportCallback function with attribution.
  */
 export interface FCPReportCallbackWithAttribution
-  extends ReportCallbackWithAttribution {
+  extends Omit<ReportCallbackWithAttribution, 'metric'> {
   (metric: FCPMetricWithAttribution): void;
 }

--- a/src/types/fcp.ts
+++ b/src/types/fcp.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  LoadState,
-  Metric,
-  ReportCallback,
-  ReportCallbackWithAttribution,
-} from './base.js';
+import {LoadState, Metric} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 /**
@@ -73,14 +68,13 @@ export interface FCPMetricWithAttribution extends FCPMetric {
 /**
  * An FCP-specific version of the ReportCallback function.
  */
-export interface FCPReportCallback extends Omit<ReportCallback, 'metric'> {
+export interface FCPReportCallback {
   (metric: FCPMetric): void;
 }
 
 /**
  * An FCP-specific version of the ReportCallback function with attribution.
  */
-export interface FCPReportCallbackWithAttribution
-  extends Omit<ReportCallbackWithAttribution, 'metric'> {
+export interface FCPReportCallbackWithAttribution {
   (metric: FCPMetricWithAttribution): void;
 }

--- a/src/types/fid.ts
+++ b/src/types/fid.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  LoadState,
-  Metric,
-  ReportCallback,
-  ReportCallbackWithAttribution,
-} from './base.js';
+import {LoadState, Metric} from './base.js';
 import {FirstInputPolyfillEntry} from './polyfills.js';
 
 /**
@@ -74,14 +69,13 @@ export interface FIDMetricWithAttribution extends FIDMetric {
 /**
  * An FID-specific version of the ReportCallback function.
  */
-export interface FIDReportCallback extends Omit<ReportCallback, 'metric'> {
+export interface FIDReportCallback {
   (metric: FIDMetric): void;
 }
 
 /**
  * An FID-specific version of the ReportCallback function with attribution.
  */
-export interface FIDReportCallbackWithAttribution
-  extends Omit<ReportCallbackWithAttribution, 'metric'> {
+export interface FIDReportCallbackWithAttribution {
   (metric: FIDMetricWithAttribution): void;
 }

--- a/src/types/fid.ts
+++ b/src/types/fid.ts
@@ -74,7 +74,7 @@ export interface FIDMetricWithAttribution extends FIDMetric {
 /**
  * An FID-specific version of the ReportCallback function.
  */
-export interface FIDReportCallback extends ReportCallback {
+export interface FIDReportCallback extends Omit<ReportCallback, 'metric'> {
   (metric: FIDMetric): void;
 }
 
@@ -82,6 +82,6 @@ export interface FIDReportCallback extends ReportCallback {
  * An FID-specific version of the ReportCallback function with attribution.
  */
 export interface FIDReportCallbackWithAttribution
-  extends ReportCallbackWithAttribution {
+  extends Omit<ReportCallbackWithAttribution, 'metric'> {
   (metric: FIDMetricWithAttribution): void;
 }

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  LoadState,
-  Metric,
-  ReportCallback,
-  ReportCallbackWithAttribution,
-} from './base.js';
+import {LoadState, Metric} from './base.js';
 
 /**
  * An INP-specific version of the Metric object.
@@ -73,14 +68,13 @@ export interface INPMetricWithAttribution extends INPMetric {
 /**
  * An INP-specific version of the ReportCallback function.
  */
-export interface INPReportCallback extends Omit<ReportCallback, 'metric'> {
+export interface INPReportCallback {
   (metric: INPMetric): void;
 }
 
 /**
  * An INP-specific version of the ReportCallback function with attribution.
  */
-export interface INPReportCallbackWithAttribution
-  extends Omit<ReportCallbackWithAttribution, 'metric'> {
+export interface INPReportCallbackWithAttribution {
   (metric: INPMetricWithAttribution): void;
 }

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -73,7 +73,7 @@ export interface INPMetricWithAttribution extends INPMetric {
 /**
  * An INP-specific version of the ReportCallback function.
  */
-export interface INPReportCallback extends ReportCallback {
+export interface INPReportCallback extends Omit<ReportCallback, 'metric'> {
   (metric: INPMetric): void;
 }
 
@@ -81,6 +81,6 @@ export interface INPReportCallback extends ReportCallback {
  * An INP-specific version of the ReportCallback function with attribution.
  */
 export interface INPReportCallbackWithAttribution
-  extends ReportCallbackWithAttribution {
+  extends Omit<ReportCallbackWithAttribution, 'metric'> {
   (metric: INPMetricWithAttribution): void;
 }

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -91,7 +91,7 @@ export interface LCPMetricWithAttribution extends LCPMetric {
 /**
  * An LCP-specific version of the ReportCallback function.
  */
-export interface LCPReportCallback extends ReportCallback {
+export interface LCPReportCallback extends Omit<ReportCallback, 'metric'> {
   (metric: LCPMetric): void;
 }
 
@@ -99,6 +99,6 @@ export interface LCPReportCallback extends ReportCallback {
  * An LCP-specific version of the ReportCallback function with attribution.
  */
 export interface LCPReportCallbackWithAttribution
-  extends ReportCallbackWithAttribution {
+  extends Omit<ReportCallbackWithAttribution, 'metric'> {
   (metric: LCPMetricWithAttribution): void;
 }

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Metric, ReportCallback, ReportCallbackWithAttribution} from './base.js';
+import {Metric} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 /**
@@ -91,14 +91,13 @@ export interface LCPMetricWithAttribution extends LCPMetric {
 /**
  * An LCP-specific version of the ReportCallback function.
  */
-export interface LCPReportCallback extends Omit<ReportCallback, 'metric'> {
+export interface LCPReportCallback {
   (metric: LCPMetric): void;
 }
 
 /**
  * An LCP-specific version of the ReportCallback function with attribution.
  */
-export interface LCPReportCallbackWithAttribution
-  extends Omit<ReportCallbackWithAttribution, 'metric'> {
+export interface LCPReportCallbackWithAttribution {
   (metric: LCPMetricWithAttribution): void;
 }

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -69,7 +69,7 @@ export interface TTFBMetricWithAttribution extends TTFBMetric {
 /**
  * A TTFB-specific version of the ReportCallback function.
  */
-export interface TTFBReportCallback extends ReportCallback {
+export interface TTFBReportCallback extends Omit<ReportCallback, 'metric'> {
   (metric: TTFBMetric): void;
 }
 
@@ -77,6 +77,6 @@ export interface TTFBReportCallback extends ReportCallback {
  * A TTFB-specific version of the ReportCallback function with attribution.
  */
 export interface TTFBReportCallbackWithAttribution
-  extends ReportCallbackWithAttribution {
+  extends Omit<ReportCallbackWithAttribution, 'metric'> {
   (metric: TTFBMetricWithAttribution): void;
 }

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Metric, ReportCallback, ReportCallbackWithAttribution} from './base.js';
+import {Metric} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 /**
@@ -69,14 +69,13 @@ export interface TTFBMetricWithAttribution extends TTFBMetric {
 /**
  * A TTFB-specific version of the ReportCallback function.
  */
-export interface TTFBReportCallback extends Omit<ReportCallback, 'metric'> {
+export interface TTFBReportCallback {
   (metric: TTFBMetric): void;
 }
 
 /**
  * A TTFB-specific version of the ReportCallback function with attribution.
  */
-export interface TTFBReportCallbackWithAttribution
-  extends Omit<ReportCallbackWithAttribution, 'metric'> {
+export interface TTFBReportCallbackWithAttribution {
   (metric: TTFBMetricWithAttribution): void;
 }


### PR DESCRIPTION
Fixes #351 
Fixes #358

It appears [you can't just change a type of an interface in Typescript by repeating it](https://stackoverflow.com/questions/41285211/overriding-interface-property-type-defined-in-typescript-d-ts-file).

This PR uses `Omit` to completely replace the `metric` value, but then has to do an assertion for `ReportCall` of the more specific metric `XXXReportCall` type to the generic `ReportCall` type.