### PR TITLE
make bindReporter generic over metric type

### DIFF
--- a/src/lib/bindReporter.ts
+++ b/src/lib/bindReporter.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {Metric, MetricRatingThresholds} from '../types.js';
+import {MetricType, MetricRatingThresholds} from '../types.js';
 
 const getRating = (
   value: number,
   thresholds: MetricRatingThresholds
-): Metric['rating'] => {
+): MetricType['rating'] => {
   if (value > thresholds[1]) {
     return 'poor';
   }
@@ -29,9 +29,9 @@ const getRating = (
   return 'good';
 };
 
-export const bindReporter = <MetricName extends Metric['name']>(
-  callback: (metric: Extract<Metric, {name: MetricName}>) => void,
-  metric: Extract<Metric, {name: MetricName}>,
+export const bindReporter = <MetricName extends MetricType['name']>(
+  callback: (metric: Extract<MetricType, {name: MetricName}>) => void,
+  metric: Extract<MetricType, {name: MetricName}>,
   thresholds: MetricRatingThresholds,
   reportAllChanges?: boolean
 ) => {

--- a/src/lib/bindReporter.ts
+++ b/src/lib/bindReporter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Metric, MetricRatingThresholds, ReportCallback} from '../types.js';
+import {Metric, MetricRatingThresholds} from '../types.js';
 
 const getRating = (
   value: number,
@@ -29,9 +29,9 @@ const getRating = (
   return 'good';
 };
 
-export const bindReporter = (
-  callback: ReportCallback,
-  metric: Metric,
+export const bindReporter = <MetricName extends Metric['name']>(
+  callback: (metric: Extract<Metric, {name: MetricName}>) => void,
+  metric: Extract<Metric, {name: MetricName}>,
   thresholds: MetricRatingThresholds,
   reportAllChanges?: boolean
 ) => {

--- a/src/lib/initMetric.ts
+++ b/src/lib/initMetric.ts
@@ -20,7 +20,10 @@ import {getActivationStart} from './getActivationStart.js';
 import {getNavigationEntry} from './getNavigationEntry.js';
 import {Metric} from '../types.js';
 
-export const initMetric = (name: Metric['name'], value?: number): Metric => {
+export const initMetric = <MetricName extends Metric['name']>(
+  name: MetricName,
+  value?: number
+) => {
   const navEntry = getNavigationEntry();
   let navigationType: Metric['navigationType'] = 'navigate';
 
@@ -39,12 +42,15 @@ export const initMetric = (name: Metric['name'], value?: number): Metric => {
     }
   }
 
+  // Use `entries` type specific for the metric.
+  const entries: Extract<Metric, {name: MetricName}>['entries'] = [];
+
   return {
     name,
     value: typeof value === 'undefined' ? -1 : value,
-    rating: 'good', // Will be updated if the value changes.
+    rating: 'good' as const, // If needed, will be updated when reported. `const` to keep the type from widening to `string`.
     delta: 0,
-    entries: [],
+    entries,
     id: generateUniqueID(),
     navigationType,
   };

--- a/src/lib/initMetric.ts
+++ b/src/lib/initMetric.ts
@@ -18,14 +18,14 @@ import {getBFCacheRestoreTime} from './bfcache.js';
 import {generateUniqueID} from './generateUniqueID.js';
 import {getActivationStart} from './getActivationStart.js';
 import {getNavigationEntry} from './getNavigationEntry.js';
-import {Metric} from '../types.js';
+import {MetricType} from '../types.js';
 
-export const initMetric = <MetricName extends Metric['name']>(
+export const initMetric = <MetricName extends MetricType['name']>(
   name: MetricName,
   value?: number
 ) => {
   const navEntry = getNavigationEntry();
-  let navigationType: Metric['navigationType'] = 'navigate';
+  let navigationType: MetricType['navigationType'] = 'navigate';
 
   if (getBFCacheRestoreTime() >= 0) {
     navigationType = 'back-forward-cache';
@@ -38,12 +38,12 @@ export const initMetric = <MetricName extends Metric['name']>(
       navigationType = navEntry.type.replace(
         /_/g,
         '-'
-      ) as Metric['navigationType'];
+      ) as MetricType['navigationType'];
     }
   }
 
   // Use `entries` type specific for the metric.
-  const entries: Extract<Metric, {name: MetricName}>['entries'] = [];
+  const entries: Extract<MetricType, {name: MetricName}>['entries'] = [];
 
   return {
     name,

--- a/src/lib/polyfills/interactionCountPolyfill.ts
+++ b/src/lib/polyfills/interactionCountPolyfill.ts
@@ -15,7 +15,6 @@
  */
 
 import {observe} from '../observe.js';
-import {Metric} from '../../types.js';
 
 declare global {
   interface Performance {
@@ -27,8 +26,8 @@ let interactionCountEstimate = 0;
 let minKnownInteractionId = Infinity;
 let maxKnownInteractionId = 0;
 
-const updateEstimate = (entries: Metric['entries']) => {
-  (entries as PerformanceEventTiming[]).forEach((e) => {
+const updateEstimate = (entries: PerformanceEventTiming[]) => {
+  entries.forEach((e) => {
     if (e.interactionId) {
       minKnownInteractionId = Math.min(minKnownInteractionId, e.interactionId);
       maxKnownInteractionId = Math.max(maxKnownInteractionId, e.interactionId);

--- a/src/onCLS.ts
+++ b/src/onCLS.ts
@@ -26,7 +26,6 @@ import {
   CLSMetric,
   CLSReportCallback,
   MetricRatingThresholds,
-  ReportCallback,
   ReportOpts,
 } from './types.js';
 
@@ -66,9 +65,8 @@ export const onCLS = (onReport: CLSReportCallback, opts?: ReportOpts) => {
       let report: ReturnType<typeof bindReporter>;
 
       let sessionValue = 0;
-      let sessionEntries: PerformanceEntry[] = [];
+      let sessionEntries: LayoutShift[] = [];
 
-      // const handleEntries = (entries: Metric['entries']) => {
       const handleEntries = (entries: LayoutShift[]) => {
         entries.forEach((entry) => {
           // Only count layout shifts without recent user input.
@@ -106,7 +104,7 @@ export const onCLS = (onReport: CLSReportCallback, opts?: ReportOpts) => {
       const po = observe('layout-shift', handleEntries);
       if (po) {
         report = bindReporter(
-          onReport as ReportCallback,
+          onReport,
           metric,
           CLSThresholds,
           opts!.reportAllChanges
@@ -123,7 +121,7 @@ export const onCLS = (onReport: CLSReportCallback, opts?: ReportOpts) => {
           sessionValue = 0;
           metric = initMetric('CLS', 0);
           report = bindReporter(
-            onReport as ReportCallback,
+            onReport,
             metric,
             CLSThresholds,
             opts!.reportAllChanges

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -26,7 +26,6 @@ import {
   FCPMetric,
   FCPReportCallback,
   MetricRatingThresholds,
-  ReportCallback,
   ReportOpts,
 } from './types.js';
 
@@ -71,7 +70,7 @@ export const onFCP = (onReport: FCPReportCallback, opts?: ReportOpts) => {
 
     if (po) {
       report = bindReporter(
-        onReport as ReportCallback,
+        onReport,
         metric,
         FCPThresholds,
         opts!.reportAllChanges
@@ -82,7 +81,7 @@ export const onFCP = (onReport: FCPReportCallback, opts?: ReportOpts) => {
       onBFCacheRestore((event) => {
         metric = initMetric('FCP');
         report = bindReporter(
-          onReport as ReportCallback,
+          onReport,
           metric,
           FCPThresholds,
           opts!.reportAllChanges

--- a/src/onFID.ts
+++ b/src/onFID.ts
@@ -31,7 +31,6 @@ import {
   FIDReportCallback,
   FirstInputPolyfillCallback,
   MetricRatingThresholds,
-  ReportCallback,
   ReportOpts,
 } from './types.js';
 
@@ -71,7 +70,7 @@ export const onFID = (onReport: FIDReportCallback, opts?: ReportOpts) => {
 
     const po = observe('first-input', handleEntries);
     report = bindReporter(
-      onReport as ReportCallback,
+      onReport,
       metric,
       FIDThresholds,
       opts!.reportAllChanges
@@ -100,7 +99,7 @@ export const onFID = (onReport: FIDReportCallback, opts?: ReportOpts) => {
       onBFCacheRestore(() => {
         metric = initMetric('FID');
         report = bindReporter(
-          onReport as ReportCallback,
+          onReport,
           metric,
           FIDThresholds,
           opts!.reportAllChanges
@@ -117,7 +116,7 @@ export const onFID = (onReport: FIDReportCallback, opts?: ReportOpts) => {
         onBFCacheRestore(() => {
           metric = initMetric('FID');
           report = bindReporter(
-            onReport as ReportCallback,
+            onReport,
             metric,
             FIDThresholds,
             opts!.reportAllChanges

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -28,7 +28,6 @@ import {
   INPMetric,
   INPReportCallback,
   MetricRatingThresholds,
-  ReportCallback,
   ReportOpts,
 } from './types.js';
 
@@ -212,7 +211,7 @@ export const onINP = (onReport: INPReportCallback, opts?: ReportOpts) => {
     } as PerformanceObserverInit);
 
     report = bindReporter(
-      onReport as ReportCallback,
+      onReport,
       metric,
       INPThresholds,
       opts!.reportAllChanges
@@ -246,7 +245,7 @@ export const onINP = (onReport: INPReportCallback, opts?: ReportOpts) => {
 
         metric = initMetric('INP');
         report = bindReporter(
-          onReport as ReportCallback,
+          onReport,
           metric,
           INPThresholds,
           opts!.reportAllChanges

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -28,7 +28,6 @@ import {
   LCPMetric,
   MetricRatingThresholds,
   LCPReportCallback,
-  ReportCallback,
   ReportOpts,
 } from './types.js';
 
@@ -82,7 +81,7 @@ export const onLCP = (onReport: LCPReportCallback, opts?: ReportOpts) => {
 
     if (po) {
       report = bindReporter(
-        onReport as ReportCallback,
+        onReport,
         metric,
         LCPThresholds,
         opts!.reportAllChanges
@@ -111,7 +110,7 @@ export const onLCP = (onReport: LCPReportCallback, opts?: ReportOpts) => {
       onBFCacheRestore((event) => {
         metric = initMetric('LCP');
         report = bindReporter(
-          onReport as ReportCallback,
+          onReport,
           metric,
           LCPThresholds,
           opts!.reportAllChanges

--- a/src/onTTFB.ts
+++ b/src/onTTFB.ts
@@ -20,7 +20,6 @@ import {onBFCacheRestore} from './lib/bfcache.js';
 import {getNavigationEntry} from './lib/getNavigationEntry.js';
 import {
   MetricRatingThresholds,
-  ReportCallback,
   ReportOpts,
   TTFBReportCallback,
 } from './types.js';
@@ -66,7 +65,7 @@ export const onTTFB = (onReport: TTFBReportCallback, opts?: ReportOpts) => {
 
   let metric = initMetric('TTFB');
   let report = bindReporter(
-    onReport as ReportCallback,
+    onReport,
     metric,
     TTFBThresholds,
     opts.reportAllChanges
@@ -100,7 +99,7 @@ export const onTTFB = (onReport: TTFBReportCallback, opts?: ReportOpts) => {
       onBFCacheRestore(() => {
         metric = initMetric('TTFB', 0);
         report = bindReporter(
-          onReport as ReportCallback,
+          onReport,
           metric,
           TTFBThresholds,
           opts!.reportAllChanges

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -18,8 +18,14 @@ import {
   FirstInputPolyfillEntry,
   NavigationTimingPolyfillEntry,
 } from './polyfills.js';
+import type {CLSMetric} from './cls.js';
+import type {FCPMetric} from './fcp.js';
+import type {FIDMetric} from './fid.js';
+import type {INPMetric} from './inp.js';
+import type {LCPMetric} from './lcp.js';
+import type {TTFBMetric} from './ttfb.js';
 
-export interface Metric {
+export interface MetricBase {
   /**
    * The name of the metric (in acronym form).
    */
@@ -85,17 +91,14 @@ export interface Metric {
     | 'restore';
 }
 
-/**
- * A version of the `Metric` that is used with the attribution build.
- */
-export interface MetricWithAttribution extends Metric {
-  /**
-   * An object containing potentially-helpful debugging information that
-   * can be sent along with the metric value for the current page visit in
-   * order to help identify issues happening to real-users in the field.
-   */
-  attribution: {[key: string]: unknown};
-}
+/** The union of supported metric types. */
+export type Metric =
+  | CLSMetric
+  | FCPMetric
+  | FIDMetric
+  | INPMetric
+  | LCPMetric
+  | TTFBMetric;
 
 /**
  * The thresholds of metric's "good", "needs improvement", and "poor" ratings.

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -25,7 +25,7 @@ import type {INPMetric} from './inp.js';
 import type {LCPMetric} from './lcp.js';
 import type {TTFBMetric} from './ttfb.js';
 
-export interface MetricBase {
+export interface Metric {
   /**
    * The name of the metric (in acronym form).
    */
@@ -92,13 +92,25 @@ export interface MetricBase {
 }
 
 /** The union of supported metric types. */
-export type Metric =
+export type MetricType =
   | CLSMetric
   | FCPMetric
   | FIDMetric
   | INPMetric
   | LCPMetric
   | TTFBMetric;
+
+/**
+ * A version of the `Metric` that is used with the attribution build.
+ */
+export interface MetricWithAttribution extends Metric {
+  /**
+   * An object containing potentially-helpful debugging information that
+   * can be sent along with the metric value for the current page visit in
+   * order to help identify issues happening to real-users in the field.
+   */
+  attribution: {[key: string]: unknown};
+}
 
 /**
  * The thresholds of metric's "good", "needs improvement", and "poor" ratings.
@@ -116,7 +128,7 @@ export type Metric =
 export type MetricRatingThresholds = [number, number];
 
 export interface ReportCallback {
-  (metric: Metric): void;
+  (metric: MetricType): void;
 }
 
 export interface ReportOpts {

--- a/src/types/cls.ts
+++ b/src/types/cls.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import type {LoadState, MetricBase} from './base.js';
+import type {LoadState, Metric} from './base.js';
 
 /**
  * A CLS-specific version of the Metric object.
  */
-export interface CLSMetric extends MetricBase {
+export interface CLSMetric extends Metric {
   name: 'CLS';
   entries: LayoutShift[];
 }

--- a/src/types/cls.ts
+++ b/src/types/cls.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {LoadState, Metric} from './base.js';
+import type {LoadState, MetricBase} from './base.js';
 
 /**
  * A CLS-specific version of the Metric object.
  */
-export interface CLSMetric extends Metric {
+export interface CLSMetric extends MetricBase {
   name: 'CLS';
   entries: LayoutShift[];
 }

--- a/src/types/fcp.ts
+++ b/src/types/fcp.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {LoadState, Metric} from './base.js';
+import type {LoadState, MetricBase} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 /**
  * An FCP-specific version of the Metric object.
  */
-export interface FCPMetric extends Metric {
+export interface FCPMetric extends MetricBase {
   name: 'FCP';
   entries: PerformancePaintTiming[];
 }

--- a/src/types/fcp.ts
+++ b/src/types/fcp.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import type {LoadState, MetricBase} from './base.js';
+import type {LoadState, Metric} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 /**
  * An FCP-specific version of the Metric object.
  */
-export interface FCPMetric extends MetricBase {
+export interface FCPMetric extends Metric {
   name: 'FCP';
   entries: PerformancePaintTiming[];
 }

--- a/src/types/fid.ts
+++ b/src/types/fid.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {LoadState, Metric} from './base.js';
+import type {LoadState, MetricBase} from './base.js';
 import {FirstInputPolyfillEntry} from './polyfills.js';
 
 /**
  * An FID-specific version of the Metric object.
  */
-export interface FIDMetric extends Metric {
+export interface FIDMetric extends MetricBase {
   name: 'FID';
   entries: (PerformanceEventTiming | FirstInputPolyfillEntry)[];
 }

--- a/src/types/fid.ts
+++ b/src/types/fid.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import type {LoadState, MetricBase} from './base.js';
+import type {LoadState, Metric} from './base.js';
 import {FirstInputPolyfillEntry} from './polyfills.js';
 
 /**
  * An FID-specific version of the Metric object.
  */
-export interface FIDMetric extends MetricBase {
+export interface FIDMetric extends Metric {
   name: 'FID';
   entries: (PerformanceEventTiming | FirstInputPolyfillEntry)[];
 }

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import type {LoadState, MetricBase} from './base.js';
+import type {LoadState, Metric} from './base.js';
 
 /**
  * An INP-specific version of the Metric object.
  */
-export interface INPMetric extends MetricBase {
+export interface INPMetric extends Metric {
   name: 'INP';
   entries: PerformanceEventTiming[];
 }

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {LoadState, Metric} from './base.js';
+import type {LoadState, MetricBase} from './base.js';
 
 /**
  * An INP-specific version of the Metric object.
  */
-export interface INPMetric extends Metric {
+export interface INPMetric extends MetricBase {
   name: 'INP';
   entries: PerformanceEventTiming[];
 }

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import type {MetricBase} from './base.js';
+import type {Metric} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 /**
  * An LCP-specific version of the Metric object.
  */
-export interface LCPMetric extends MetricBase {
+export interface LCPMetric extends Metric {
   name: 'LCP';
   entries: LargestContentfulPaint[];
 }

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {Metric} from './base.js';
+import type {MetricBase} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 /**
  * An LCP-specific version of the Metric object.
  */
-export interface LCPMetric extends Metric {
+export interface LCPMetric extends MetricBase {
   name: 'LCP';
   entries: LargestContentfulPaint[];
 }

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import type {MetricBase} from './base.js';
+import type {Metric} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 /**
  * A TTFB-specific version of the Metric object.
  */
-export interface TTFBMetric extends MetricBase {
+export interface TTFBMetric extends Metric {
   name: 'TTFB';
   entries: PerformanceNavigationTiming[] | NavigationTimingPolyfillEntry[];
 }

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {Metric} from './base.js';
+import type {MetricBase} from './base.js';
 import {NavigationTimingPolyfillEntry} from './polyfills.js';
 
 /**
  * A TTFB-specific version of the Metric object.
  */
-export interface TTFBMetric extends Metric {
+export interface TTFBMetric extends MetricBase {
   name: 'TTFB';
   entries: PerformanceNavigationTiming[] | NavigationTimingPolyfillEntry[];
 }


### PR DESCRIPTION
Can land after #356

Parameterizes the `bindReporter` type on the `metric` passed in so that the `callback` can now be typed specifically for that metric (e.g. a result for `CLSMetric` must be using a `CLSReportCallback`).

This required `initMetric` to be parameterized similarly, so the returned metric type is now based on the metric `name` passed in.

```ts
let metric = initMetric('FCP');
//  ^ FCPMetric
```

---

The main change required was using a union of the metric types wherever the base `Metric` interface is currently used. This leaves most uses of it unchanged, but allows narrowing to which specific metric is being used based on the `name` property.

I renamed the existing `Metric` to be `MetricBase` and named the union `Metric` to keep the uses of it unchanged, but if someone has better naming suggestions, changing is no problem :)