### PR TITLE
Prevent FID entries being emitted as INP for non-supporting browsers

### DIFF
--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -218,9 +218,12 @@ export const onINP = (onReport: INPReportCallback, opts?: ReportOpts) => {
     );
 
     if (po) {
-      // Also observe entries of type `first-input`. This is useful in cases
+      // If browser supports interactionId (and so supports INP), also
+      // observe entries of type `first-input`. This is useful in cases
       // where the first interaction is less than the `durationThreshold`.
-      po.observe({type: 'first-input', buffered: true});
+      if ('interactionId' in PerformanceEventTiming?.prototype) {
+        po.observe({type: 'first-input', buffered: true});
+      }
 
       onHidden(() => {
         handleEntries(po.takeRecords() as INPMetric['entries']);

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -220,7 +220,7 @@ export const onINP = (onReport: INPReportCallback, opts?: ReportOpts) => {
       // If browser supports interactionId (and so supports INP), also
       // observe entries of type `first-input`. This is useful in cases
       // where the first interaction is less than the `durationThreshold`.
-      if ('interactionId' in PerformanceEventTiming?.prototype) {
+      if ('interactionId' in PerformanceEventTiming.prototype) {
         po.observe({type: 'first-input', buffered: true});
       }
 

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -170,9 +170,8 @@ export const onINP = (onReport: INPReportCallback, opts?: ReportOpts) => {
         // so to consider them in INP we have to first check that an existing
         // entry doesn't match the `duration` and `startTime`.
         // Note that this logic assumes that `event` entries are dispatched
-        // before `first-input` entries. This is true in Chrome but it is not
-        // true in Firefox; however, Firefox doesn't support interactionId, so
-        // it's not an issue at the moment.
+        // before `first-input` entries. This is true in Chrome (the only browser
+        // that currently supports INP).
         // TODO(philipwalton): remove once crbug.com/1325826 is fixed.
         if (entry.entryType === 'first-input') {
           const noMatchingEntry = !longestInteractionList.some(


### PR DESCRIPTION
Fixes #367 