### PR TITLE
Fix INP `durationThreshold` bug when set to 0

### DIFF
--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -206,7 +206,7 @@ export const onINP = (onReport: INPReportCallback, opts?: ReportOpts) => {
       // and performance. Running this callback for any interaction that spans
       // just one or two frames is likely not worth the insight that could be
       // gained.
-      durationThreshold: opts!.durationThreshold || 40,
+      durationThreshold: opts!.durationThreshold ?? 40,
     } as PerformanceObserverInit);
 
     report = bindReporter(


### PR DESCRIPTION
When INP's `durationThreshold` was set to a value of `0`, it would actually ignore all values under 40 ms because the logical OR (||) operator was used and `0` is falsey.

Use nullish coalescing operator instead to prevent this from happening.