### PR TITLE
Pick the first non-null target for INP attribution

### DIFF
--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -37,8 +37,10 @@ const attributeINP = (metric: INPMetric): void => {
       );
     })[0];
 
+    const targetEntry = metric.entries.find(entry => entry.target);
+
     (metric as INPMetricWithAttribution).attribution = {
-      eventTarget: getSelector(longestEntry.target),
+      eventTarget: getSelector(targetEntry?.target),
       eventType: longestEntry.name,
       eventTime: longestEntry.startTime,
       eventEntry: longestEntry,


### PR DESCRIPTION
Some pointer entries have a known [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1367329) causing them to have null event targets. In cases where there are mouse or click entries in the same interaction that do have non-null event targets, always prefer those.

This PR works around the bug by changing the `eventTarget` in INP attribution to use the first entry in the list having a non-null target, rather than always using the longest entry in the list, which may sometimes be a pointer entry.