### PR TITLE
Add eventListener to reset CLS & INP metrics

### DIFF
--- a/src/lib/manualSoftNavigation.ts
+++ b/src/lib/manualSoftNavigation.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const onManualSoftNavigation = (cb: () => void) => {
+  document.addEventListener('reset-web-vital-metrics', cb);
+};

--- a/src/onCLS.ts
+++ b/src/onCLS.ts
@@ -115,9 +115,7 @@ export const onCLS = (onReport: CLSReportCallback, opts?: ReportOpts) => {
           report(true);
         });
 
-        // Only report after a bfcache restore if the `PerformanceObserver`
-        // successfully registered.
-        onBFCacheRestore(() => {
+        const resetCLSMetric = () => {
           sessionValue = 0;
           metric = initMetric('CLS', 0);
           report = bindReporter(
@@ -126,8 +124,18 @@ export const onCLS = (onReport: CLSReportCallback, opts?: ReportOpts) => {
             CLSThresholds,
             opts!.reportAllChanges,
           );
+        };
 
+        // Only report after a bfcache restore if the `PerformanceObserver`
+        // successfully registered.
+        onBFCacheRestore(() => {
+          resetCLSMetric();
           doubleRAF(() => report());
+        });
+
+        document.addEventListener('reset-web-vital-metrics', () => {
+          report(true);
+          resetCLSMetric();
         });
 
         // Queue a task to report (if nothing else triggers a report first).

--- a/src/onCLS.ts
+++ b/src/onCLS.ts
@@ -28,6 +28,7 @@ import {
   MetricRatingThresholds,
   ReportOpts,
 } from './types.js';
+import {onManualSoftNavigation} from './lib/manualSoftNavigation.js';
 
 /** Thresholds for CLS. See https://web.dev/articles/cls#what_is_a_good_cls_score */
 export const CLSThresholds: MetricRatingThresholds = [0.1, 0.25];
@@ -133,7 +134,7 @@ export const onCLS = (onReport: CLSReportCallback, opts?: ReportOpts) => {
           doubleRAF(() => report());
         });
 
-        document.addEventListener('reset-web-vital-metrics', () => {
+        onManualSoftNavigation(() => {
           report(true);
           resetCLSMetric();
         });

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -240,21 +240,28 @@ export const onINP = (onReport: INPReportCallback, opts?: ReportOpts) => {
         report(true);
       });
 
-      // Only report after a bfcache restore if the `PerformanceObserver`
-      // successfully registered.
-      onBFCacheRestore(() => {
+      const resetINPMetric = () => {
         longestInteractionList = [];
-        // Important, we want the count for the full page here,
-        // not just for the current navigation.
         prevInteractionCount = getInteractionCount();
-
         metric = initMetric('INP');
+
         report = bindReporter(
           onReport,
           metric,
           INPThresholds,
           opts!.reportAllChanges,
         );
+      };
+
+      // Only report after a bfcache restore if the `PerformanceObserver`
+      // successfully registered.
+      onBFCacheRestore(() => {
+        resetINPMetric();
+      });
+
+      document.addEventListener('reset-web-vital-metrics', () => {
+        report(true);
+        resetINPMetric();
       });
     }
   });

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -17,6 +17,7 @@
 import {onBFCacheRestore} from './lib/bfcache.js';
 import {bindReporter} from './lib/bindReporter.js';
 import {initMetric} from './lib/initMetric.js';
+import {onManualSoftNavigation} from './lib/manualSoftNavigation.js';
 import {observe} from './lib/observe.js';
 import {onHidden} from './lib/onHidden.js';
 import {
@@ -259,7 +260,7 @@ export const onINP = (onReport: INPReportCallback, opts?: ReportOpts) => {
         resetINPMetric();
       });
 
-      document.addEventListener('reset-web-vital-metrics', () => {
+      onManualSoftNavigation(() => {
         report(true);
         resetINPMetric();
       });


### PR DESCRIPTION
This PR enables manual resetting of CLS & INP metrics through dispatching a `reset-web-vital-metrics` event. It allows single-page applications to trigger this event during page transitions and measure these long-running metric measurement for each page. While it differs from Google's use of the metrics, it greatly enhances the ability of SPAs to assess the performance of individual pages. 

Currently, as a fallback, we've enabled `reportAllChanges` for these metrics, buffer the measurements and report the latest before a page transition. However, this approach skews the results of later pages in a user journey because the metric is only reported again when it's worse than before. This PR aims to provide a more accurate understanding of page performance in the context of SPA pages.

This is similar to the `soft-navigate` branch but can be used today already. It could also serve as a fallback method in case the `soft-navigate` heuristics don't work particularly well with certain applications.

Relevant issue: #119 


