### PR TITLE
Fix test flakiness in Firefox

### DIFF
--- a/test/e2e/onCLS-test.js
+++ b/test/e2e/onCLS-test.js
@@ -19,7 +19,7 @@ import {beaconCountIs, clearBeacons, getBeacons} from '../utils/beacons.js';
 import {browserSupportsEntry} from '../utils/browserSupportsEntry.js';
 import {firstContentfulPaint} from '../utils/firstContentfulPaint.js';
 import {imagesPainted} from '../utils/imagesPainted.js';
-import {navigateWithStrategy} from '../utils/navigateWithStrategy.js';
+import {navigateTo} from '../utils/navigateTo.js';
 import {nextFrame} from '../utils/nextFrame.js';
 import {stubForwardBack} from '../utils/stubForwardBack.js';
 import {stubVisibilityChange} from '../utils/stubVisibilityChange.js';
@@ -34,14 +34,14 @@ describe('onCLS()', async function () {
   });
 
   beforeEach(async function () {
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
     await clearBeacons();
   });
 
   it('reports the correct value on visibility hidden after shifts (reportAllChanges === false)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url('/test/cls');
+    await navigateTo('/test/cls');
 
     // Wait until all images are loaded and rendered, then change to hidden.
     await imagesPainted();
@@ -62,11 +62,11 @@ describe('onCLS()', async function () {
   it('reports the correct value on page unload after shifts (reportAllChanges === false)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url('/test/cls');
+    await navigateTo('/test/cls');
 
     // Wait until all images are loaded and rendered, then change to hidden.
     await imagesPainted();
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(1);
 
@@ -83,7 +83,7 @@ describe('onCLS()', async function () {
   it('reports the correct value even if loaded late (reportAllChanges === false)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await navigateWithStrategy(`/test/cls?lazyLoad=1`, 'complete');
+    await navigateTo(`/test/cls?lazyLoad=1`, {readyState: 'complete'});
 
     // Wait until all images are loaded and rendered, then change to hidden.
     await imagesPainted();
@@ -104,10 +104,9 @@ describe('onCLS()', async function () {
   it('reports the correct value even if loaded late (reportAllChanges === true)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await navigateWithStrategy(
-      `/test/cls?lazyLoad=1&reportAllChanges=1`,
-      'complete',
-    );
+    await navigateTo(`/test/cls?lazyLoad=1&reportAllChanges=1`, {
+      readyState: 'complete',
+    });
 
     // Wait until all images are loaded and rendered, then change to hidden.
     await imagesPainted();
@@ -130,7 +129,7 @@ describe('onCLS()', async function () {
   it('resets the session after timeout or gap elapses', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url('/test/cls');
+    await navigateTo('/test/cls');
 
     // Wait until all images are loaded and rendered.
     await imagesPainted();
@@ -233,7 +232,7 @@ describe('onCLS()', async function () {
   it('does not report if the browser does not support CLS', async function () {
     if (browserSupportsCLS) this.skip();
 
-    await browser.url('/test/cls');
+    await navigateTo('/test/cls');
 
     // Wait until all images are loaded and rendered, then change to hidden.
     await imagesPainted();
@@ -242,7 +241,7 @@ describe('onCLS()', async function () {
     // Wait a bit to ensure no beacons were sent.
     await browser.pause(1000);
 
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     // Wait a bit to ensure no beacons were sent.
     await browser.pause(1000);
@@ -254,7 +253,7 @@ describe('onCLS()', async function () {
   it('reports no new values on visibility hidden after shifts (reportAllChanges === true)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url('/test/cls?reportAllChanges=1');
+    await navigateTo('/test/cls?reportAllChanges=1');
 
     // Beacons should be sent as soon as layout shifts occur, wait for them.
     await beaconCountIs(3);
@@ -298,7 +297,7 @@ describe('onCLS()', async function () {
   it('does not report if the value has not changed (reportAllChanges === true)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url('/test/cls?reportAllChanges=1');
+    await navigateTo('/test/cls?reportAllChanges=1');
 
     // Beacons should be sent as soon as layout shifts occur, wait for them.
     await beaconCountIs(3);
@@ -331,7 +330,7 @@ describe('onCLS()', async function () {
 
     // Unload the page after no new shifts have occurred.
     await clearBeacons();
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     // Wait a bit to ensure no beacons were sent.
     await browser.pause(1000);
@@ -343,7 +342,7 @@ describe('onCLS()', async function () {
   it('continues reporting after visibilitychange (reportAllChanges === false)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url(`/test/cls`);
+    await navigateTo(`/test/cls`);
 
     // Wait until all images are loaded and rendered, then change to hidden.
     await imagesPainted();
@@ -387,7 +386,7 @@ describe('onCLS()', async function () {
   it('continues reporting after visibilitychange (reportAllChanges === true)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url(`/test/cls?reportAllChanges=1`);
+    await navigateTo(`/test/cls?reportAllChanges=1`);
     await beaconCountIs(3);
 
     const [cls1, cls2, cls3] = await getBeacons();
@@ -441,7 +440,7 @@ describe('onCLS()', async function () {
   it('continues reporting after bfcache restore (reportAllChanges === false)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url(`/test/cls`);
+    await navigateTo(`/test/cls`);
 
     // Wait until all images are loaded and rendered, then go forward & back.
     await imagesPainted();
@@ -500,7 +499,7 @@ describe('onCLS()', async function () {
   it('continues reporting after bfcache restore (reportAllChanges === true)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url(`/test/cls?reportAllChanges=1`);
+    await navigateTo(`/test/cls?reportAllChanges=1`);
     await beaconCountIs(3);
 
     const [cls1, cls2, cls3] = await getBeacons();
@@ -561,7 +560,7 @@ describe('onCLS()', async function () {
   it('reports zero if no layout shifts occurred on first visibility hidden (reportAllChanges === false)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await navigateWithStrategy(`/test/cls?noLayoutShifts=1`, 'complete');
+    await navigateTo(`/test/cls?noLayoutShifts=1`, {readyState: 'complete'});
 
     // Wait until the page is loaded and content is visible before hiding.
     await firstContentfulPaint();
@@ -580,10 +579,9 @@ describe('onCLS()', async function () {
   it('reports zero if no layout shifts occurred on first visibility hidden (reportAllChanges === true)', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await navigateWithStrategy(
-      `/test/cls?reportAllChanges=1&noLayoutShifts=1`,
-      'complete',
-    );
+    await navigateTo(`/test/cls?reportAllChanges=1&noLayoutShifts=1`, {
+      readyState: 'complete',
+    });
 
     // Wait until the page is loaded and content is visible before hiding.
     await firstContentfulPaint();
@@ -605,9 +603,9 @@ describe('onCLS()', async function () {
     if (!browserSupportsCLS) this.skip();
 
     // Wait until the page is loaded before navigating away.
-    await navigateWithStrategy(`/test/cls?noLayoutShifts=1`, 'complete');
+    await navigateTo(`/test/cls?noLayoutShifts=1`, {readyState: 'complete'});
 
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(1);
 
@@ -625,14 +623,13 @@ describe('onCLS()', async function () {
     if (!browserSupportsCLS) this.skip();
 
     // Wait until the page is loaded before navigating away.
-    await navigateWithStrategy(
-      `/test/cls?noLayoutShifts=1&reportAllChanges=1`,
-      'complete',
-    );
+    await navigateTo(`/test/cls?noLayoutShifts=1&reportAllChanges=1`, {
+      readyState: 'complete',
+    });
 
     // Wait until the page is loaded and content is visible before leaving.
     await firstContentfulPaint();
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(1);
 
@@ -647,7 +644,7 @@ describe('onCLS()', async function () {
   });
 
   it('does not report if the document was hidden at page load time', async function () {
-    await browser.url('/test/cls?hidden=1');
+    await navigateTo('/test/cls?hidden=1');
 
     await stubVisibilityChange('visible');
 
@@ -661,7 +658,7 @@ describe('onCLS()', async function () {
   it('reports if the page is restored from bfcache even when the document was hidden at page load time', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url('/test/cls?hidden=1');
+    await navigateTo('/test/cls?hidden=1');
 
     await stubForwardBack();
 
@@ -687,7 +684,7 @@ describe('onCLS()', async function () {
   it('reports prerender as nav type for prerender', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url('/test/cls?prerender=1');
+    await navigateTo('/test/cls?prerender=1');
 
     // Wait until all images are loaded and rendered, then change to hidden.
     await imagesPainted();
@@ -708,7 +705,7 @@ describe('onCLS()', async function () {
   it('reports restore as nav type for wasDiscarded', async function () {
     if (!browserSupportsCLS) this.skip();
 
-    await browser.url('/test/cls?wasDiscarded=1');
+    await navigateTo('/test/cls?wasDiscarded=1');
 
     // Wait until all images are loaded and rendered, then change to hidden.
     await imagesPainted();
@@ -730,7 +727,7 @@ describe('onCLS()', async function () {
     it('includes attribution data on the metric object', async function () {
       if (!browserSupportsCLS) this.skip();
 
-      await browser.url('/test/cls?attribution=1&delayDCL=2000');
+      await navigateTo('/test/cls?attribution=1&delayDCL=2000');
 
       // Wait until all images are loaded and rendered, then change to hidden.
       await imagesPainted();
@@ -771,10 +768,9 @@ describe('onCLS()', async function () {
     it('reports whether the largest shift was before or after load', async function () {
       if (!browserSupportsCLS) this.skip();
 
-      await navigateWithStrategy(
-        '/test/cls?attribution=1&noLayoutShifts=1',
-        'complete',
-      );
+      await navigateTo(`/test/cls?attribution=1&noLayoutShifts=1`, {
+        readyState: 'complete',
+      });
 
       // Wait until the page is loaded and content is visible before triggering
       // a layout shift.
@@ -815,10 +811,9 @@ describe('onCLS()', async function () {
     it('reports an empty object when no shifts', async function () {
       if (!browserSupportsCLS) this.skip();
 
-      await navigateWithStrategy(
-        '/test/cls?attribution=1&noLayoutShifts=1',
-        'complete',
-      );
+      await navigateTo(`/test/cls?attribution=1&noLayoutShifts=1`, {
+        readyState: 'complete',
+      });
 
       // Wait until the page is loaded and content is visible hiding.
       await firstContentfulPaint();

--- a/test/e2e/onFCP-test.js
+++ b/test/e2e/onFCP-test.js
@@ -17,7 +17,7 @@
 import assert from 'assert';
 import {beaconCountIs, clearBeacons, getBeacons} from '../utils/beacons.js';
 import {browserSupportsEntry} from '../utils/browserSupportsEntry.js';
-import {navigateWithStrategy} from '../utils/navigateWithStrategy.js';
+import {navigateTo} from '../utils/navigateTo.js';
 import {stubForwardBack} from '../utils/stubForwardBack.js';
 import {stubVisibilityChange} from '../utils/stubVisibilityChange.js';
 
@@ -31,14 +31,14 @@ describe('onFCP()', async function () {
   });
 
   beforeEach(async function () {
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
     await clearBeacons();
   });
 
   it('reports the correct value after the first paint', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await browser.url('/test/fcp');
+    await navigateTo('/test/fcp');
 
     await beaconCountIs(1);
 
@@ -55,7 +55,7 @@ describe('onFCP()', async function () {
   it('reports the correct value when loaded late', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await browser.url('/test/fcp?lazyLoad=1');
+    await navigateTo('/test/fcp?lazyLoad=1');
 
     await beaconCountIs(1);
 
@@ -72,7 +72,7 @@ describe('onFCP()', async function () {
   it('accounts for time prerendering the page', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await browser.url('/test/fcp?prerender=1');
+    await navigateTo('/test/fcp?prerender=1');
 
     await beaconCountIs(1);
 
@@ -95,7 +95,7 @@ describe('onFCP()', async function () {
   it('does not report if the browser does not support FCP (including bfcache restores)', async function () {
     if (browserSupportsFCP) this.skip();
 
-    await browser.url('/test/fcp');
+    await navigateTo('/test/fcp');
 
     // Wait a bit to ensure no beacons were sent.
     await browser.pause(1000);
@@ -116,7 +116,7 @@ describe('onFCP()', async function () {
   it('does not report if the document was hidden at page load time', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await navigateWithStrategy('/test/fcp?hidden=1', 'interactive');
+    await navigateTo('/test/fcp?hidden=1', {readyState: 'interactive'});
 
     await stubVisibilityChange('visible');
 
@@ -130,7 +130,7 @@ describe('onFCP()', async function () {
   it('does not report if the document changes to hidden before the first entry', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await navigateWithStrategy('/test/fcp?invisible=1', 'interactive');
+    await navigateTo('/test/fcp?invisible=1', {readyState: 'interactive'});
 
     await stubVisibilityChange('hidden');
     await stubVisibilityChange('visible');
@@ -145,7 +145,7 @@ describe('onFCP()', async function () {
   it('reports after a render delay before the page changes to hidden', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await browser.url('/test/fcp?renderBlocking=2000');
+    await navigateTo('/test/fcp?renderBlocking=2000');
 
     // Change to hidden after the first render.
     await browser.pause(2500);
@@ -164,7 +164,7 @@ describe('onFCP()', async function () {
   it('reports if the page is restored from bfcache', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await browser.url('/test/fcp');
+    await navigateTo('/test/fcp');
 
     await beaconCountIs(1);
 
@@ -211,7 +211,7 @@ describe('onFCP()', async function () {
   it('reports if the page is restored from bfcache even when the document was hidden at page load time', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await navigateWithStrategy('/test/fcp?hidden=1', 'interactive');
+    await navigateTo('/test/fcp?hidden=1', {readyState: 'interactive'});
 
     await stubVisibilityChange('visible');
 
@@ -253,7 +253,7 @@ describe('onFCP()', async function () {
   it('reports restore as nav type for wasDiscarded', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await browser.url('/test/fcp?wasDiscarded=1');
+    await navigateTo('/test/fcp?wasDiscarded=1');
 
     await beaconCountIs(1);
 
@@ -271,7 +271,7 @@ describe('onFCP()', async function () {
     it('includes attribution data on the metric object', async function () {
       if (!browserSupportsFCP) this.skip();
 
-      await navigateWithStrategy('/test/fcp?attribution=1', 'complete');
+      await navigateTo('/test/fcp?attribution=1', {readyState: 'complete'});
 
       await beaconCountIs(1);
 
@@ -318,10 +318,9 @@ describe('onFCP()', async function () {
     it('accounts for time prerendering the page', async function () {
       if (!browserSupportsFCP) this.skip();
 
-      await navigateWithStrategy(
-        '/test/fcp?attribution=1&prerender=1',
-        'complete',
-      );
+      await navigateTo(`/test/fcp?attribution=1&prerender=1`, {
+        readyState: 'complete',
+      });
 
       await beaconCountIs(1);
 
@@ -371,7 +370,7 @@ describe('onFCP()', async function () {
     it('reports after a bfcache restore', async function () {
       if (!browserSupportsFCP) this.skip();
 
-      await navigateWithStrategy('/test/fcp?attribution=1', 'complete');
+      await navigateTo('/test/fcp?attribution=1', {readyState: 'complete'});
 
       await beaconCountIs(1);
 

--- a/test/e2e/onFID-test.js
+++ b/test/e2e/onFID-test.js
@@ -17,7 +17,7 @@
 import assert from 'assert';
 import {beaconCountIs, clearBeacons, getBeacons} from '../utils/beacons.js';
 import {browserSupportsEntry} from '../utils/browserSupportsEntry.js';
-import {navigateWithStrategy} from '../utils/navigateWithStrategy.js';
+import {navigateTo} from '../utils/navigateTo.js';
 import {stubForwardBack} from '../utils/stubForwardBack.js';
 import {stubVisibilityChange} from '../utils/stubVisibilityChange.js';
 
@@ -31,14 +31,14 @@ describe('onFID()', async function () {
   });
 
   beforeEach(async function () {
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
     await clearBeacons();
   });
 
   it('reports the correct value after input', async function () {
     if (!browserSupportsFID) this.skip();
 
-    await browser.url('/test/fid');
+    await navigateTo('/test/fid');
 
     // Click on the <h1>.
     const h1 = await $('h1');
@@ -59,7 +59,7 @@ describe('onFID()', async function () {
   it('reports the correct value after input when script is loaded late', async function () {
     if (!browserSupportsFID) this.skip();
 
-    await browser.url('/test/fid?loadAfterInput=1');
+    await navigateTo('/test/fid?loadAfterInput=1');
 
     // Click on the <h1>.
     const h1 = await $('h1');
@@ -80,7 +80,7 @@ describe('onFID()', async function () {
   it('does not report if the browser does not support FID and the polyfill is not used', async function () {
     if (browserSupportsFID) this.skip();
 
-    await browser.url('/test/fid');
+    await navigateTo('/test/fid');
 
     // Click on the <h1>.
     const h1 = await $('h1');
@@ -110,7 +110,7 @@ describe('onFID()', async function () {
     // https://bugs.webkit.org/show_bug.cgi?id=211101
     if (browser.capabilities.browserName === 'Safari') this.skip();
 
-    await browser.url('/test/fid?polyfill=1');
+    await navigateTo('/test/fid?polyfill=1');
 
     // Click on the <h1>.
     const h1 = await $('h1');
@@ -139,7 +139,7 @@ describe('onFID()', async function () {
     // https://bugs.webkit.org/show_bug.cgi?id=211101
     if (browser.capabilities.browserName === 'Safari') this.skip();
 
-    await navigateWithStrategy('/test/fid?hidden=1', 'complete');
+    await navigateTo('/test/fid?hidden=1', {readyState: 'complete'});
 
     await stubVisibilityChange('visible');
 
@@ -159,7 +159,7 @@ describe('onFID()', async function () {
     // https://bugs.webkit.org/show_bug.cgi?id=211101
     if (browser.capabilities.browserName === 'Safari') this.skip();
 
-    await navigateWithStrategy('/test/fid', 'complete');
+    await navigateTo('/test/fid', {readyState: 'complete'});
 
     await stubVisibilityChange('hidden');
 
@@ -180,7 +180,7 @@ describe('onFID()', async function () {
   it('reports the first input delay after bfcache restores', async function () {
     if (!browserSupportsFID) this.skip();
 
-    await browser.url('/test/fid');
+    await navigateTo('/test/fid');
 
     // Click on the <h1>.
     const h1 = await $('h1');
@@ -219,7 +219,7 @@ describe('onFID()', async function () {
   it('reports prerender as nav type for prerender', async function () {
     if (!browserSupportsFID) this.skip();
 
-    await browser.url('/test/fid?prerender=1');
+    await navigateTo('/test/fid?prerender=1');
 
     // Click on the <h1>.
     const h1 = await $('h1');
@@ -240,7 +240,7 @@ describe('onFID()', async function () {
   it('reports restore as nav type for wasDiscarded', async function () {
     if (!browserSupportsFID) this.skip();
 
-    await browser.url('/test/fid?wasDiscarded=1');
+    await navigateTo('/test/fid?wasDiscarded=1');
 
     // Click on the <h1>.
     const h1 = await $('h1');
@@ -262,7 +262,7 @@ describe('onFID()', async function () {
     it('includes attribution data on the metric object', async function () {
       if (!browserSupportsFID) this.skip();
 
-      await browser.url('/test/fid?attribution=1');
+      await navigateTo('/test/fid?attribution=1');
 
       // Click on the <h1>.
       const h1 = await $('h1');
@@ -291,7 +291,7 @@ describe('onFID()', async function () {
     it('reports the domReadyState when input occurred', async function () {
       if (!browserSupportsFID) this.skip();
 
-      await browser.url('/test/fid?attribution=1&delayDCL=1000');
+      await navigateTo('/test/fid?attribution=1&delayDCL=1000');
 
       // Click on the <h1>.
       const h1 = await $('h1');
@@ -304,7 +304,7 @@ describe('onFID()', async function () {
 
       await clearBeacons();
 
-      await browser.url('/test/fid?attribution=1&delayResponse=1000');
+      await navigateTo('/test/fid?attribution=1&delayResponse=1000');
 
       // Click on the <h1>.
       const p = await $('p');

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -17,6 +17,7 @@
 import assert from 'assert';
 import {beaconCountIs, clearBeacons, getBeacons} from '../utils/beacons.js';
 import {browserSupportsEntry} from '../utils/browserSupportsEntry.js';
+import {navigateTo} from '../utils/navigateTo.js';
 import {nextFrame} from '../utils/nextFrame.js';
 import {stubForwardBack} from '../utils/stubForwardBack.js';
 import {stubVisibilityChange} from '../utils/stubVisibilityChange.js';
@@ -33,14 +34,14 @@ describe('onINP()', async function () {
   });
 
   beforeEach(async function () {
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
     await clearBeacons();
   });
 
   it('reports the correct value on visibility hidden after interactions (reportAllChanges === false)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp?click=100');
+    await navigateTo('/test/inp?click=100');
 
     const h1 = await $('h1');
     await h1.click();
@@ -64,7 +65,7 @@ describe('onINP()', async function () {
   it('reports the correct value on visibility hidden after interactions (reportAllChanges === true)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp?click=100&reportAllChanges=1');
+    await navigateTo('/test/inp?click=100&reportAllChanges=1');
 
     const h1 = await $('h1');
     await h1.click();
@@ -86,7 +87,7 @@ describe('onINP()', async function () {
   it('reports the correct value when script is loaded late (reportAllChanges === false)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp?click=100&loadAfterInput=1');
+    await navigateTo('/test/inp?click=100&loadAfterInput=1');
 
     const h1 = await $('h1');
     await h1.click();
@@ -110,9 +111,7 @@ describe('onINP()', async function () {
   it('reports the correct value when loaded late (reportAllChanges === true)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url(
-      '/test/inp?click=100&reportAllChanges=1&loadAfterInput=1',
-    );
+    await navigateTo('/test/inp?click=100&reportAllChanges=1&loadAfterInput=1');
 
     const h1 = await $('h1');
     await h1.click();
@@ -134,12 +133,12 @@ describe('onINP()', async function () {
   it('reports the correct value on page unload after interactions (reportAllChanges === false)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp?click=100');
+    await navigateTo('/test/inp?click=100');
 
     const h1 = await $('h1');
     await h1.click();
 
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(1);
 
@@ -158,12 +157,12 @@ describe('onINP()', async function () {
   it('reports the correct value on page unload after interactions (reportAllChanges === true)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp?click=100&reportAllChanges=1');
+    await navigateTo('/test/inp?click=100&reportAllChanges=1');
 
     const h1 = await $('h1');
     await h1.click();
 
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(1);
 
@@ -182,7 +181,7 @@ describe('onINP()', async function () {
   it('reports approx p98 interaction when 50+ interactions (reportAllChanges === false)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp?click=60&pointerdown=600');
+    await navigateTo('/test/inp?click=60&pointerdown=600');
 
     const h1 = await $('h1');
     await h1.click();
@@ -239,7 +238,7 @@ describe('onINP()', async function () {
   it('reports approx p98 interaction when 50+ interactions (reportAllChanges === true)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp?click=60&pointerdown=600&reportAllChanges=1');
+    await navigateTo('/test/inp?click=60&pointerdown=600&reportAllChanges=1');
 
     const h1 = await $('h1');
     await h1.click();
@@ -275,7 +274,7 @@ describe('onINP()', async function () {
   it('reports a new interaction after bfcache restore', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp');
+    await navigateTo('/test/inp');
 
     await setBlockingTime('click', 100);
 
@@ -353,7 +352,7 @@ describe('onINP()', async function () {
   it('does not report if there were no interactions', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp');
+    await navigateTo('/test/inp');
 
     await stubVisibilityChange('hidden');
 
@@ -367,7 +366,7 @@ describe('onINP()', async function () {
   it('reports prerender as nav type for prerender', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp?click=100&prerender=1');
+    await navigateTo('/test/inp?click=100&prerender=1');
 
     const h1 = await $('h1');
     await h1.click();
@@ -391,7 +390,7 @@ describe('onINP()', async function () {
   it('reports restore as nav type for wasDiscarded', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await browser.url('/test/inp?click=100&wasDiscarded=1');
+    await navigateTo('/test/inp?click=100&wasDiscarded=1');
 
     const h1 = await $('h1');
     await h1.click();
@@ -416,7 +415,7 @@ describe('onINP()', async function () {
     it('includes attribution data on the metric object', async function () {
       if (!browserSupportsINP) this.skip();
 
-      await browser.url('/test/inp?click=100&attribution=1');
+      await navigateTo('/test/inp?click=100&attribution=1');
 
       const h1 = await $('h1');
       await h1.click();
@@ -498,7 +497,7 @@ describe('onINP()', async function () {
     it('reports the domReadyState when input occurred', async function () {
       if (!browserSupportsINP) this.skip();
 
-      await browser.url(
+      await navigateTo(
         '/test/inp?' +
           'attribution=1&reportAllChanges=1&click=100&delayDCL=1000',
       );
@@ -515,7 +514,7 @@ describe('onINP()', async function () {
 
       await clearBeacons();
 
-      await browser.url(
+      await navigateTo(
         '/test/inp?' +
           'attribution=1&reportAllChanges=1&click=100&delayResponse=1000',
       );
@@ -535,7 +534,7 @@ describe('onINP()', async function () {
     it('reports the event target from any entry where target is defined', async function () {
       if (!browserSupportsINP) this.skip();
 
-      await browser.url('/test/inp?attribution=1&mousedown=100&click=50');
+      await navigateTo('/test/inp?attribution=1&mousedown=100&click=50');
 
       const h1 = await $('h1');
 

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -18,7 +18,7 @@ import assert from 'assert';
 import {beaconCountIs, clearBeacons, getBeacons} from '../utils/beacons.js';
 import {browserSupportsEntry} from '../utils/browserSupportsEntry.js';
 import {imagesPainted} from '../utils/imagesPainted.js';
-import {navigateWithStrategy} from '../utils/navigateWithStrategy.js';
+import {navigateTo} from '../utils/navigateTo.js';
 import {stubForwardBack} from '../utils/stubForwardBack.js';
 import {stubVisibilityChange} from '../utils/stubVisibilityChange.js';
 
@@ -32,20 +32,20 @@ describe('onLCP()', async function () {
   });
 
   beforeEach(async function () {
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
     await clearBeacons();
   });
 
   it('reports the correct value on hidden (reportAllChanges === false)', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp');
+    await navigateTo('/test/lcp');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
 
     // Load a new page to trigger the hidden state.
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(1);
     assertStandardReportsAreCorrect(await getBeacons());
@@ -54,13 +54,13 @@ describe('onLCP()', async function () {
   it('reports the correct value on hidden (reportAllChanges === true)', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?reportAllChanges=1');
+    await navigateTo('/test/lcp?reportAllChanges=1');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
 
     // Load a new page to trigger the hidden state.
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(2);
     assertFullReportsAreCorrect(await getBeacons());
@@ -69,7 +69,7 @@ describe('onLCP()', async function () {
   it('reports the correct value on input (reportAllChanges === false)', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp');
+    await navigateTo('/test/lcp');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
@@ -85,7 +85,7 @@ describe('onLCP()', async function () {
   it('reports the correct value on input (reportAllChanges === true)', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?reportAllChanges=1');
+    await navigateTo('/test/lcp?reportAllChanges=1');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
@@ -101,13 +101,13 @@ describe('onLCP()', async function () {
   it('reports the correct value when loaded late (reportAllChanges === false)', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?lazyLoad=1');
+    await navigateTo('/test/lcp?lazyLoad=1');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
 
     // Load a new page to trigger the hidden state.
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(1);
     assertStandardReportsAreCorrect(await getBeacons());
@@ -116,13 +116,13 @@ describe('onLCP()', async function () {
   it('reports the correct value when loaded late (reportAllChanges === true)', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?lazyLoad=1&reportAllChanges=1');
+    await navigateTo('/test/lcp?lazyLoad=1&reportAllChanges=1');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
 
     // Load a new page to trigger the hidden state.
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     // Even though the test sets `reportAllChanges` to true, since the library
     // is lazy loaded after all elements have been rendered, only a single
@@ -134,7 +134,7 @@ describe('onLCP()', async function () {
   it('accounts for time prerendering the page', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?prerender=1');
+    await navigateTo('/test/lcp?prerender=1');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
@@ -144,7 +144,7 @@ describe('onLCP()', async function () {
     });
 
     // Load a new page to trigger the hidden state.
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(1);
 
@@ -157,7 +157,7 @@ describe('onLCP()', async function () {
   it('does not report if the browser does not support LCP (including bfcache restores)', async function () {
     if (browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp');
+    await navigateTo('/test/lcp');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
@@ -192,7 +192,7 @@ describe('onLCP()', async function () {
   it('does not report if the document was hidden at page load time', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await navigateWithStrategy('/test/lcp?hidden=1', 'interactive');
+    await navigateTo('/test/lcp?hidden=1', {readyState: 'interactive'});
 
     await stubVisibilityChange('visible');
 
@@ -210,7 +210,7 @@ describe('onLCP()', async function () {
   it('does not report if the document changes to hidden before the first render', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?renderBlocking=1000');
+    await navigateTo('/test/lcp?renderBlocking=1000');
 
     await stubVisibilityChange('hidden');
     await stubVisibilityChange('visible');
@@ -229,7 +229,7 @@ describe('onLCP()', async function () {
   it('reports after a render delay before the page changes to hidden', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?renderBlocking=3000');
+    await navigateTo('/test/lcp?renderBlocking=3000');
 
     // Change to hidden after the first render.
     await browser.pause(3500);
@@ -249,7 +249,7 @@ describe('onLCP()', async function () {
   it('stops reporting after the document changes to hidden (reportAllChanges === false)', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?imgDelay=0&imgHidden=1');
+    await navigateTo('/test/lcp?imgDelay=0&imgHidden=1');
 
     // Wait for a frame to be painted.
     await browser.executeAsync((done) => requestAnimationFrame(done));
@@ -284,7 +284,7 @@ describe('onLCP()', async function () {
   it('stops reporting after the document changes to hidden (reportAllChanges === true)', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?reportAllChanges=1&imgDelay=0&imgHidden=1');
+    await navigateTo('/test/lcp?reportAllChanges=1&imgDelay=0&imgHidden=1');
 
     await beaconCountIs(1);
     const [lcp] = await getBeacons();
@@ -315,7 +315,7 @@ describe('onLCP()', async function () {
   it('reports if the page is restored from bfcache', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp');
+    await navigateTo('/test/lcp');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
@@ -358,7 +358,7 @@ describe('onLCP()', async function () {
   it('reports if the page is restored from bfcache even when the document was hidden at page load time', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await navigateWithStrategy('/test/lcp?hidden=1', 'interactive');
+    await navigateTo('/test/lcp?hidden=1', {readyState: 'interactive'});
 
     await stubVisibilityChange('visible');
 
@@ -403,13 +403,13 @@ describe('onLCP()', async function () {
   it('reports restore as nav type for wasDiscarded', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await browser.url('/test/lcp?wasDiscarded=1');
+    await navigateTo('/test/lcp?wasDiscarded=1');
 
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
 
     // Load a new page to trigger the hidden state.
-    await browser.url('about:blank');
+    await navigateTo('about:blank');
 
     await beaconCountIs(1);
 
@@ -428,7 +428,7 @@ describe('onLCP()', async function () {
     it('includes attribution data on the metric object', async function () {
       if (!browserSupportsLCP) this.skip();
 
-      await browser.url('/test/lcp?attribution=1');
+      await navigateTo('/test/lcp?attribution=1');
 
       // Wait until all images are loaded and fully rendered.
       await imagesPainted();
@@ -445,7 +445,7 @@ describe('onLCP()', async function () {
       });
 
       // Load a new page to trigger the hidden state.
-      await browser.url('about:blank');
+      await navigateTo('about:blank');
 
       await beaconCountIs(1);
 
@@ -470,7 +470,7 @@ describe('onLCP()', async function () {
     it('handles image resources with incomplete timing data', async function () {
       if (!browserSupportsLCP) this.skip();
 
-      await browser.url('/test/lcp?attribution=1');
+      await navigateTo('/test/lcp?attribution=1');
 
       // Wait until all images are loaded and fully rendered.
       await imagesPainted();
@@ -491,7 +491,7 @@ describe('onLCP()', async function () {
       });
 
       // Load a new page to trigger the hidden state.
-      await browser.url('about:blank');
+      await navigateTo('about:blank');
 
       await beaconCountIs(1);
 
@@ -524,7 +524,7 @@ describe('onLCP()', async function () {
     it('accounts for time prerendering the page', async function () {
       if (!browserSupportsLCP) this.skip();
 
-      await browser.url('/test/lcp?attribution=1&prerender=1');
+      await navigateTo('/test/lcp?attribution=1&prerender=1');
 
       // Wait until all images are loaded and fully rendered.
       await imagesPainted();
@@ -546,7 +546,7 @@ describe('onLCP()', async function () {
       });
 
       // Load a new page to trigger the hidden state.
-      await browser.url('about:blank');
+      await navigateTo('about:blank');
 
       await beaconCountIs(1);
 
@@ -597,17 +597,16 @@ describe('onLCP()', async function () {
     it('handles cases where there is no LCP resource', async function () {
       if (!browserSupportsLCP) this.skip();
 
-      await navigateWithStrategy(
-        '/test/lcp?attribution=1&imgHidden=1',
-        'complete',
-      );
+      await navigateTo('/test/lcp?attribution=1&imgHidden=1', {
+        readyState: 'complete',
+      });
 
       const navEntry = await browser.execute(() => {
         return performance.getEntriesByType('navigation')[0].toJSON();
       });
 
       // Load a new page to trigger the hidden state.
-      await browser.url('about:blank');
+      await navigateTo('about:blank');
 
       await beaconCountIs(1);
 
@@ -639,7 +638,7 @@ describe('onLCP()', async function () {
     it('reports after a bfcache restore', async function () {
       if (!browserSupportsLCP) this.skip();
 
-      await browser.url('/test/lcp?attribution=1');
+      await navigateTo('/test/lcp?attribution=1');
 
       // Wait until all images are loaded and fully rendered.
       await imagesPainted();

--- a/test/e2e/onTTFB-test.js
+++ b/test/e2e/onTTFB-test.js
@@ -16,7 +16,7 @@
 
 import assert from 'assert';
 import {beaconCountIs, clearBeacons, getBeacons} from '../utils/beacons.js';
-import {navigateWithStrategy} from '../utils/navigateWithStrategy.js';
+import {navigateTo} from '../utils/navigateTo.js';
 import {stubForwardBack} from '../utils/stubForwardBack.js';
 
 /**
@@ -62,13 +62,13 @@ describe('onTTFB()', async function () {
     // In Safari when navigating to 'about:blank' between tests the
     // Navigation Timing data is consistently negative, so the tests fail.
     if (browser.capabilities.browserName !== 'Safari') {
-      await browser.url('about:blank');
+      await navigateTo('about:blank');
     }
     await clearBeacons();
   });
 
   it('reports the correct value when run during page load', async function () {
-    await browser.url('/test/ttfb');
+    await navigateTo('/test/ttfb');
 
     const ttfb = await getTTFBBeacon();
 
@@ -86,7 +86,7 @@ describe('onTTFB()', async function () {
   });
 
   it('reports the correct value event when loaded late', async function () {
-    await browser.url('/test/ttfb?lazyLoad=1');
+    await navigateTo('/test/ttfb?lazyLoad=1');
 
     const ttfb = await getTTFBBeacon();
 
@@ -104,7 +104,7 @@ describe('onTTFB()', async function () {
   });
 
   it('reports the correct value when the response is delayed', async function () {
-    await browser.url('/test/ttfb?delay=1000');
+    await navigateTo('/test/ttfb?delay=1000');
 
     const ttfb = await getTTFBBeacon();
 
@@ -122,7 +122,7 @@ describe('onTTFB()', async function () {
   });
 
   it('accounts for time prerendering the page', async function () {
-    await browser.url('/test/ttfb?prerender=1');
+    await navigateTo('/test/ttfb?prerender=1');
 
     const ttfb = await getTTFBBeacon();
 
@@ -144,7 +144,7 @@ describe('onTTFB()', async function () {
 
   it('reports the correct value when run while prerendering', async function () {
     // Use 500 so prerendering finishes before load but after the module runs.
-    await browser.url('/test/ttfb?prerender=500&imgDelay=1000');
+    await navigateTo('/test/ttfb?prerender=500&imgDelay=1000');
 
     const ttfb = await getTTFBBeacon();
 
@@ -169,7 +169,7 @@ describe('onTTFB()', async function () {
   });
 
   it('reports after a bfcache restore', async function () {
-    await browser.url('/test/ttfb');
+    await navigateTo('/test/ttfb');
 
     const ttfb1 = await getTTFBBeacon();
 
@@ -201,7 +201,9 @@ describe('onTTFB()', async function () {
 
   it('ignores navigations with invalid responseStart timestamps', async function () {
     for (const rs of [-1, 0, 1e12]) {
-      await navigateWithStrategy(`/test/ttfb?responseStart=${rs}`, 'complete');
+      await navigateTo(`/test/ttfb?responseStart=${rs}`, {
+        readyState: 'complete',
+      });
 
       // Wait a bit to ensure no beacons were sent.
       await browser.pause(1000);
@@ -222,7 +224,7 @@ describe('onTTFB()', async function () {
   });
 
   it('reports restore as nav type for wasDiscarded', async function () {
-    await browser.url('/test/ttfb?wasDiscarded=1');
+    await navigateTo('/test/ttfb?wasDiscarded=1');
 
     const ttfb = await getTTFBBeacon();
 
@@ -241,7 +243,7 @@ describe('onTTFB()', async function () {
 
   describe('attribution', function () {
     it('includes attribution data on the metric object', async function () {
-      await browser.url('/test/ttfb?attribution=1');
+      await navigateTo('/test/ttfb?attribution=1');
 
       const ttfb = await getTTFBBeacon();
 
@@ -279,7 +281,7 @@ describe('onTTFB()', async function () {
     });
 
     it('accounts for time prerendering the page', async function () {
-      await browser.url('/test/ttfb?attribution=1&prerender=1');
+      await navigateTo('/test/ttfb?attribution=1&prerender=1');
 
       const ttfb = await getTTFBBeacon();
 
@@ -326,7 +328,7 @@ describe('onTTFB()', async function () {
     });
 
     it('reports after a bfcache restore', async function () {
-      await browser.url('/test/ttfb?attribution=1');
+      await navigateTo('/test/ttfb?attribution=1');
 
       await getTTFBBeacon();
 

--- a/test/utils/domReadyState.js
+++ b/test/utils/domReadyState.js
@@ -27,7 +27,10 @@ export function domReadyState(state) {
         resolve();
       } else {
         document.addEventListener('readystatechange', () => {
-          if (document.readyState === state) {
+          if (
+            document.readyState === state ||
+            document.readyState === 'complete'
+          ) {
             resolve();
           }
         });

--- a/test/utils/imagesPainted.js
+++ b/test/utils/imagesPainted.js
@@ -30,6 +30,7 @@ export function imagesPainted() {
       }
     });
 
+    // Use element timing if available, otherwise fall back to load+raf.
     if (PerformanceObserver.supportedEntryTypes.includes('element')) {
       const nodes = new Set([
         ...document.querySelectorAll('[elementtiming]:not([hidden])'),
@@ -47,7 +48,18 @@ export function imagesPainted() {
         }
       }).observe({type: 'element', buffered: true});
     } else {
-      done();
+      await new Promise((resolve) => {
+        if (document.readyState !== 'complete') {
+          addEventListener('load', resolve);
+        } else {
+          resolve();
+        }
+      });
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          done();
+        });
+      });
     }
   });
 }

--- a/test/utils/navigateTo.js
+++ b/test/utils/navigateTo.js
@@ -17,12 +17,11 @@
 import {domReadyState} from './domReadyState.js';
 
 /**
- * Returns a promise that resolves once the browser window has loaded, all
- * load callbacks have finished executing, and any pending `__readyPromises`
- * have settled.
+ * Returns a promise that resolves once the browser has navigated to the
+ * passed URL path, optionally waiting until a specific DOM ready state.
  * @return {Promise<void>}
  */
-export async function navigateWithStrategy(urlPath, readyState) {
+export async function navigateTo(urlPath, opts) {
   await browser.url(urlPath);
 
   // In Firefox, if the global PageLoadStrategy is set to "none", then
@@ -36,5 +35,7 @@ export async function navigateWithStrategy(urlPath, readyState) {
     });
   }
 
-  await domReadyState(readyState);
+  if (opts?.readyState) {
+    await domReadyState(opts.readyState);
+  }
 }


### PR DESCRIPTION
Fixes #436.

Geckodriver has a bug where, if the webdriver `PageLoadStrategy` option is set to "none" then calls to `browser.url()` can resolve before the browser has actually navigated to the page.

This library needs to set the `PageLoadStrategy` to "none" for many tests, so the only good way to fix this is to wrap the `browser.url()` function (the `navigateTo()` function in thie PR) and manually verify that the correct URL is loaded before resolving. As a convenience this wrapped function also exposes an option to conditionally wait for a given document`readyState` value.

In addition, since Firefox added support for LCP but does NOT support Element Timing, this PR adds a workaround for LCP tests to wait for `load` + `rAF` as a proxy for ensuring all images are loaded and painted.


