### PR TITLE
Rename resourceLoadTime to resourceLoadDuration in LCP attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ interface LCPAttribution {
    * otherwise 0). See [Optimize LCP](https://web.dev/articles/optimize-lcp) for
    * details.
    */
-  resourceLoadTime: number;
+  resourceLoadDuration: number;
   /**
    * The delta between when the LCP resource finishes loading until the LCP
    * element is fully rendered. See [Optimize

--- a/src/attribution/onLCP.ts
+++ b/src/attribution/onLCP.ts
@@ -62,7 +62,7 @@ const attributeLCP = (metric: LCPMetric) => {
         element: getSelector(lcpEntry.element),
         timeToFirstByte: ttfb,
         resourceLoadDelay: lcpRequestStart - ttfb,
-        resourceLoadTime: lcpResponseEnd - lcpRequestStart,
+        resourceLoadDuration: lcpResponseEnd - lcpRequestStart,
         elementRenderDelay: lcpRenderTime - lcpResponseEnd,
         navigationEntry,
         lcpEntry,
@@ -84,7 +84,7 @@ const attributeLCP = (metric: LCPMetric) => {
   (metric as LCPMetricWithAttribution).attribution = {
     timeToFirstByte: 0,
     resourceLoadDelay: 0,
-    resourceLoadTime: 0,
+    resourceLoadDuration: 0,
     elementRenderDelay: metric.value,
   };
 };

--- a/src/types/lcp.ts
+++ b/src/types/lcp.ts
@@ -56,7 +56,7 @@ export interface LCPAttribution {
    * otherwise 0). See [Optimize LCP](https://web.dev/articles/optimize-lcp) for
    * details.
    */
-  resourceLoadTime: number;
+  resourceLoadDuration: number;
   /**
    * The delta between when the LCP resource finishes loading until the LCP
    * element is fully rendered. See [Optimize

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -457,7 +457,7 @@ describe('onLCP()', async function () {
       assert.equal(
         lcp.attribution.timeToFirstByte +
           lcp.attribution.resourceLoadDelay +
-          lcp.attribution.resourceLoadTime +
+          lcp.attribution.resourceLoadDuration +
           lcp.attribution.elementRenderDelay,
         lcp.value,
       );
@@ -514,7 +514,7 @@ describe('onLCP()', async function () {
       assert.equal(
         lcp.attribution.timeToFirstByte +
           lcp.attribution.resourceLoadDelay +
-          lcp.attribution.resourceLoadTime +
+          lcp.attribution.resourceLoadDuration +
           lcp.attribution.elementRenderDelay,
         lcp.value,
       );
@@ -568,7 +568,7 @@ describe('onLCP()', async function () {
       );
 
       assert.equal(
-        lcp.attribution.resourceLoadTime,
+        lcp.attribution.resourceLoadDuration,
         Math.max(0, lcpResEntry.responseEnd - navEntry.activationStart) -
           Math.max(0, lcpResEntry.requestStart - navEntry.activationStart),
       );
@@ -583,7 +583,7 @@ describe('onLCP()', async function () {
       assert.equal(
         lcp.attribution.timeToFirstByte +
           lcp.attribution.resourceLoadDelay +
-          lcp.attribution.resourceLoadTime +
+          lcp.attribution.resourceLoadDuration +
           lcp.attribution.elementRenderDelay,
         lcp.value,
       );
@@ -614,11 +614,11 @@ describe('onLCP()', async function () {
       assert.equal(lcp.attribution.url, undefined);
       assert.equal(lcp.attribution.element, 'html>body>main>h1');
       assert.equal(lcp.attribution.resourceLoadDelay, 0);
-      assert.equal(lcp.attribution.resourceLoadTime, 0);
+      assert.equal(lcp.attribution.resourceLoadDuration, 0);
       assert.equal(
         lcp.attribution.timeToFirstByte +
           lcp.attribution.resourceLoadDelay +
-          lcp.attribution.resourceLoadTime +
+          lcp.attribution.resourceLoadDuration +
           lcp.attribution.elementRenderDelay,
         lcp.value,
       );
@@ -664,7 +664,7 @@ describe('onLCP()', async function () {
       assert.equal(lcp2.attribution.element, undefined);
       assert.equal(lcp2.attribution.timeToFirstByte, 0);
       assert.equal(lcp2.attribution.resourceLoadDelay, 0);
-      assert.equal(lcp2.attribution.resourceLoadTime, 0);
+      assert.equal(lcp2.attribution.resourceLoadDuration, 0);
       assert.equal(lcp2.attribution.elementRenderDelay, lcp2.value);
       assert.equal(lcp2.attribution.navigationEntry, undefined);
       assert.equal(lcp2.attribution.lcpResourceEntry, undefined);


### PR DESCRIPTION
This PR renames `resourceLoadTime` to `resourceLoadDuration` in the `LCPAttribution` object to make it more clear that this is a duration value rather than a timestamp.

Note: this is a breaking change for anyone using the attribution build.