### PR TITLE
Fix onINP() attribution error due to empty entries

### DIFF
--- a/src/lib/interactions.ts
+++ b/src/lib/interactions.ts
@@ -46,7 +46,7 @@ let prevInteractionCount = 0;
  * Returns the interaction count since the last bfcache restore (or for the
  * full page lifecycle if there were no bfcache restores).
  */
-export const getInteractionCountForNavigation = () => {
+const getInteractionCountForNavigation = () => {
   return getInteractionCount() - prevInteractionCount;
 };
 

--- a/src/lib/whenIdle.ts
+++ b/src/lib/whenIdle.ts
@@ -15,9 +15,9 @@
  */
 
 import {onHidden} from './onHidden.js';
+import {runOnce} from './runOnce.js';
 
 const rIC = self.requestIdleCallback || self.setTimeout;
-const cIC = self.cancelIdleCallback || self.clearTimeout;
 
 /**
  * Runs the passed callback during the next idle period, or immediately
@@ -25,14 +25,14 @@ const cIC = self.cancelIdleCallback || self.clearTimeout;
  */
 export const whenIdle = (cb: () => void): number => {
   let handle = -1;
+  cb = runOnce(cb);
+  // If the document is hidden, run the callback immediately, otherwise
+  // race an idle callback with the next `visibilitychange` event.
   if (document.visibilityState === 'hidden') {
     cb();
   } else {
     handle = rIC(cb);
-    onHidden(() => {
-      cIC(handle);
-      cb();
-    });
+    onHidden(cb);
   }
   return handle;
 };

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -607,10 +607,15 @@ describe('onINP()', async function () {
       const [inp1] = await getBeacons();
       assert.equal(inp1.attribution.loadState, 'dom-interactive');
 
+      await clearBeacons();
+
       await navigateTo(
         '/test/inp' +
-          '?attribution=1&reportAllChanges=1&click=100&delayResponse=1000',
+          '?attribution=1&reportAllChanges=1&click=100&delayResponse=2000',
       );
+
+      // Wait a bit to ensure the page elements are available.
+      await browser.pause(1000);
 
       // Click on the <button>.
       const reset = await $('#reset');


### PR DESCRIPTION
This PR fixes #451 by removing the [logic](https://github.com/GoogleChrome/web-vitals/blob/e526abf45a64088cc96498b7d0a10682f3d9eceb/src/onINP.ts#L137-L142)) that would report `0` INP value with an empty `entries` array if the code detected that at least one interaction did happen but wasn't reported.

This logic is no longer necessary (given that we observe `first-input` entries), so as long as we always include `first-input` entries, there should never be an empty `entries` array (which is what was causing the `TypeError` in #451).

Note that code prior this PR assumed that any time a `first-input` entry was dispatched with a `duration` value above the `durationThreshold` of the `event` observer, then there would always be a correspondoing `event` entry (and thus the `first-input` entry was redundant). This turns out to not be true in cases where the first interaction occurs before the `DOMContentLoaded` event fires, so the fix is to just always include `first-input` entries (without trying to dedupe). (Note: this may be a Chrome bug that needs addressing, cc: @mmocny.)

/cc: @ErwinHofmanRV