### PR TITLE
Rename `TTFBAttribution` fields from `*Time` to `*Duration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,21 +1028,21 @@ interface TTFBAttribution {
    * DNS lookup begins. This includes redirects, service worker startup, and
    * HTTP cache lookup times.
    */
-  waitingTime: number;
+  waitingDuration: number;
   /**
    * The total time to resolve the DNS for the current request.
    */
-  dnsTime: number;
+  dnsDuration: number;
   /**
    * The total time to create the connection to the requested domain.
    */
-  connectionTime: number;
+  connectionDuration: number;
   /**
    * The time time from when the request was sent until the first byte of the
    * response was received. This includes network time as well as server
    * processing time.
    */
-  requestTime: number;
+  requestDuration: number;
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
    * general page load issues. This can be used to access `serverTiming` for example:

--- a/src/attribution/onTTFB.ts
+++ b/src/attribution/onTTFB.ts
@@ -42,20 +42,20 @@ const attributeTTFB = (metric: TTFBMetric): void => {
     );
 
     (metric as TTFBMetricWithAttribution).attribution = {
-      waitingTime: dnsStart,
-      dnsTime: connectStart - dnsStart,
-      connectionTime: requestStart - connectStart,
-      requestTime: metric.value - requestStart,
+      waitingDuration: dnsStart,
+      dnsDuration: connectStart - dnsStart,
+      connectionDuration: requestStart - connectStart,
+      requestDuration: metric.value - requestStart,
       navigationEntry: navigationEntry,
     };
     return;
   }
   // Set an empty object if no other attribution has been set.
   (metric as TTFBMetricWithAttribution).attribution = {
-    waitingTime: 0,
-    dnsTime: 0,
-    connectionTime: 0,
-    requestTime: 0,
+    waitingDuration: 0,
+    dnsDuration: 0,
+    connectionDuration: 0,
+    requestDuration: 0,
   };
 };
 

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -35,21 +35,21 @@ export interface TTFBAttribution {
    * DNS lookup begins. This includes redirects, service worker startup, and
    * HTTP cache lookup times.
    */
-  waitingTime: number;
+  waitingDuration: number;
   /**
    * The total time to resolve the DNS for the current request.
    */
-  dnsTime: number;
+  dnsDuration: number;
   /**
    * The total time to create the connection to the requested domain.
    */
-  connectionTime: number;
+  connectionDuration: number;
   /**
    * The time time from when the request was sent until the first byte of the
    * response was received. This includes network time as well as server
    * processing time.
    */
-  requestTime: number;
+  requestDuration: number;
   /**
    * The `navigation` entry of the current page, which is useful for diagnosing
    * general page load issues. This can be used to access `serverTiming` for example:

--- a/src/types/ttfb.ts
+++ b/src/types/ttfb.ts
@@ -45,7 +45,7 @@ export interface TTFBAttribution {
    */
   connectionDuration: number;
   /**
-   * The time time from when the request was sent until the first byte of the
+   * The total time from when the request was sent until the first byte of the
    * response was received. This includes network time as well as server
    * processing time.
    */

--- a/test/e2e/onTTFB-test.js
+++ b/test/e2e/onTTFB-test.js
@@ -261,19 +261,19 @@ describe('onTTFB()', async function () {
 
       const navEntry = ttfb.entries[0];
       assert.strictEqual(
-        ttfb.attribution.waitingTime,
+        ttfb.attribution.waitingDuration,
         navEntry.domainLookupStart,
       );
       assert.strictEqual(
-        ttfb.attribution.dnsTime,
+        ttfb.attribution.dnsDuration,
         navEntry.connectStart - navEntry.domainLookupStart,
       );
       assert.strictEqual(
-        ttfb.attribution.connectionTime,
+        ttfb.attribution.connectionDuration,
         navEntry.requestStart - navEntry.connectStart,
       );
       assert.strictEqual(
-        ttfb.attribution.requestTime,
+        ttfb.attribution.requestDuration,
         navEntry.responseStart - navEntry.requestStart,
       );
 
@@ -303,22 +303,22 @@ describe('onTTFB()', async function () {
 
       const navEntry = ttfb.entries[0];
       assert.strictEqual(
-        ttfb.attribution.waitingTime,
+        ttfb.attribution.waitingDuration,
         Math.max(0, navEntry.domainLookupStart - activationStart),
       );
       assert.strictEqual(
-        ttfb.attribution.dnsTime,
+        ttfb.attribution.dnsDuration,
         Math.max(0, navEntry.connectStart - activationStart) -
           Math.max(0, navEntry.domainLookupStart - activationStart),
       );
       assert.strictEqual(
-        ttfb.attribution.connectionTime,
+        ttfb.attribution.connectionDuration,
         Math.max(0, navEntry.requestStart - activationStart) -
           Math.max(0, navEntry.connectStart - activationStart),
       );
 
       assert.strictEqual(
-        ttfb.attribution.requestTime,
+        ttfb.attribution.requestDuration,
         Math.max(0, navEntry.responseStart - activationStart) -
           Math.max(0, navEntry.requestStart - activationStart),
       );
@@ -346,10 +346,10 @@ describe('onTTFB()', async function () {
       assert.strictEqual(ttfb.navigationType, 'back-forward-cache');
       assert.strictEqual(ttfb.entries.length, 0);
 
-      assert.strictEqual(ttfb.attribution.waitingTime, 0);
-      assert.strictEqual(ttfb.attribution.dnsTime, 0);
-      assert.strictEqual(ttfb.attribution.connectionTime, 0);
-      assert.strictEqual(ttfb.attribution.requestTime, 0);
+      assert.strictEqual(ttfb.attribution.waitingDuration, 0);
+      assert.strictEqual(ttfb.attribution.dnsDuration, 0);
+      assert.strictEqual(ttfb.attribution.connectionDuration, 0);
+      assert.strictEqual(ttfb.attribution.requestDuration, 0);
       assert.strictEqual(ttfb.attribution.navigationEntry, undefined);
     });
   });


### PR DESCRIPTION
This PR continues the renaming work from #450 and updates the `TTFBAttribution` interface with the same changes—all properties whose name ended in `*Time` have been renamed to `*Duration`, in order to make it more clear that these are durations of time rather than timestamps.

```diff
interface TTFBAttribution {
-  waitingTime: number;
+  waitingDuration: number;

-  dnsTime: number;
+  dnsDuration: number;

-  connectionTime: number;
+  connectionDuration: number;

-  requestTime: number;
+  requestDuration: number;
}
```

**⚠️ Important:** this is a breaking change for anyone using the attribution build.