### PR TITLE
Add an Upgrading to v4 doc

### DIFF
--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -1,52 +1,59 @@
 # Upgrading to v4
 
-This document lists the full set of breaking changes that need to be addressed when upgrading from version 3.x to 4.x, across both the "standard" and "attribution" builds (see [build options](/#build-options) for details). For a list of all changes see the [CHANGELOG](/CHANGELOG.md).
+This document lists the full set of changes between version 3 and version 4 that are relevant to anyone wanting to upgrade to the new version. This document groups changes into "breaking changes" and "new features" across both the "standard" and "attribution" builds (see [build options](/#build-options) for details).
 
-Version 4 is currently in beta, you can install it via the `next` tag on npm:
+Note: version 4 is currently in beta, you can install it via the `next` tag on npm:
 
 ```sh
 npm install web-vitals@next
 ```
 
-## Standard build
+## ⚠️ Breaking changes
 
-### General
+### Standard build
 
-- The "base+polyfill" build has been removed (see [#435](https://github.com/GoogleChrome/web-vitals/pull/435))
-  - This includes the FID polyfill and the Navigation Timing polyfill supporting legacy Safari browsers.
-- Previously deprecated `getXXX()` functions have been removed (see [#435](https://github.com/GoogleChrome/web-vitals/pull/435))
+#### General
 
-### `INPMetric`
+- **Removed** the "base+polyfill" build, which includes the FID polyfill and the Navigation Timing polyfill supporting legacy Safari browsers (see [#435](https://github.com/GoogleChrome/web-vitals/pull/435)).
+- **Removed** all `getXXX()` functions that were deprecated in v3 (see [#435](https://github.com/GoogleChrome/web-vitals/pull/435)).
 
-- `entries`
-  - Updated to only include entries with matching `interactionId` and `duration` values (previously it was only matching `interactionId` values, see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+#### `INPMetric`
 
-## Attribution build
+- **Changed** `entries` to only include entries with matching `interactionId` that were processed within the same animation frame. Previously it included all entries with matching `interactionId` values, which could include entries not impacting INP (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
 
-### `INPAttribution`
+### Attribution build
 
-- `eventTarget`:
-  - Renamed to `interactionTarget` (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
-- `eventTime`:
-  - Renamed to `interactionTime` (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
-- `eventType`:
-  - Renamed to `interactionType` (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
-  - Also this property will now always be either "pointer" or "keyboard" (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
-- `eventEntry`:
-  - Removed in favor of an array of entries (`processedEventEntries`) processed during the interaction (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+#### `INPAttribution`
 
-### `LCPAttribution`
+- **Renamed** `eventTarget` to `interactionTarget` (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- **Renamed** `eventTime` to `interactionTime` (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- **Renamed** `eventType` to `interactionType`. Also this property will now always be either "pointer" or "keyboard" (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- **Removed** `eventEntry` in favor of the new `processedEventEntries` array (see below), which includes all `event` entries processed within the same animation frame as the INP candidate interaction (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
 
-- `resourceLoadTime`:
-  - Renamed to `resourceLoadDuration` (see [#450](https://github.com/GoogleChrome/web-vitals/pull/450)).
+#### `LCPAttribution`
 
-### `TTFBAttribution`
+- **Renamed** `resourceLoadTime` to `resourceLoadDuration` (see [#450](https://github.com/GoogleChrome/web-vitals/pull/450)).
 
-- `waitingTime`:
-  - Renamed to `waitingDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
-- `dnsTime`:
-  - Renamed to `dnsDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
-- `connectionTime`:
-  - Renamed to `connectionDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
-- `requestTime`:
-  - Renamed to `requestDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
+#### `TTFBAttribution`
+
+- **Renamed** `waitingTime` to `waitingDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
+- **Renamed** `dnsTime` to `dnsDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
+- **Renamed** `connectionTime` to `connectionDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
+- **Renamed** `requestTime` to `requestDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
+
+## 🚀 New features
+
+### Standard build
+
+No new features were introduced into the "standard" build, outside of the breaking changes mentioned above.
+
+### Attribution build
+
+#### `INPAttribution`
+
+- **Added** `nextPaintTime`, which marks the timestamp of the next paint after the interaction (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- **Added** `inputDelay`, which measures the time from when the user interacted with the page until when the browser was first able to start processing event listeners for that interaction. (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- **Added** `processingDuration`, which measures the time from when the first event listener started running in response to the user interaction until when all event listener processing has finished (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- **Added** `presentationDelay`, which measures the time from when the browser finished processing all event listeners for the user interaction until the next frame is presented on the screen and visible to the user. (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- **Added** `processedEventEntries`, an array of `event` entries that were processed within the same animation frame as the INP candidate interaction (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- **Added** `longAnimationFrameEntries`, which includes any `long-animation-frame` entries that overlap with the INP candidate interaction (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -1,0 +1,48 @@
+# Upgrading to v4
+
+This document lists the full set of breaking changes that need to be addressed when upgrading from version 3.x to 4.x, across both the "standard" and "attribution" builds (see [build options](/#build-options) for details).
+
+For a list of all changes see the [CHANGELOG](/CHANGELOG.md).
+
+## Standard build
+
+### General
+
+- The "base+polyfill" build has been removed (see [#435](https://github.com/GoogleChrome/web-vitals/pull/435))
+  - This includes the FID polyfill and the Navigation Timing polyfill supporting legacy Safari browsers.
+- Previously deprecated `getXXX()` functions have been removed (see [#435](https://github.com/GoogleChrome/web-vitals/pull/435))
+
+### `INPMetric`
+
+- `entries`
+  - Updated to only include entries with matching `interactionId` and `duration` values (previously it was only matching `interactionId` values, see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+
+## Attribution build
+
+### `INPAttribution`
+
+- `eventTarget`:
+  - Renamed to `interactionTarget` (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- `eventTime`:
+  - Renamed to `interactionTime` (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- `eventType`:
+  - Renamed to `interactionType` (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+  - Also this property will now always be either "pointer" or "keyboard" (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+- `eventEntry`:
+  - Removed in favor of an array of entries (`processedEventEntries`) processed during the interaction (see [#442](https://github.com/GoogleChrome/web-vitals/pull/442)).
+
+### `LCPAttribution`
+
+- `resourceLoadTime`:
+  - Renamed to `resourceLoadDuration` (see [#450](https://github.com/GoogleChrome/web-vitals/pull/450)).
+
+### `TTFBAttribution`
+
+- `waitingTime`:
+  - Renamed to `waitingDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
+- `dnsTime`:
+  - Renamed to `dnsDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
+- `connectionTime`:
+  - Renamed to `connectionDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).
+- `requestTime`:
+  - Renamed to `requestDuration` (see [#453](https://github.com/GoogleChrome/web-vitals/pull/453)).

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -1,8 +1,12 @@
 # Upgrading to v4
 
-This document lists the full set of breaking changes that need to be addressed when upgrading from version 3.x to 4.x, across both the "standard" and "attribution" builds (see [build options](/#build-options) for details).
+This document lists the full set of breaking changes that need to be addressed when upgrading from version 3.x to 4.x, across both the "standard" and "attribution" builds (see [build options](/#build-options) for details). For a list of all changes see the [CHANGELOG](/CHANGELOG.md).
 
-For a list of all changes see the [CHANGELOG](/CHANGELOG.md).
+Version 4 is currently in beta, you can install it via the `next` tag on npm:
+
+```sh
+npm install web-vitals@next
+```
 
 ## Standard build
 


### PR DESCRIPTION
This PR adds an "Upgrading to v4" doc that lists the full set of breaking changes from v3 in a single place, to make it easier for folks to upgrade.

Note: this is different from the CHANGELOG, which does list all changes but only lists them by PR title. The new upgrading doc makes it so folks can easily upgrade without needing to read through the PR descriptions/discussions.