### PR TITLE
Fix unit tests broken in v4

### DIFF
--- a/src/lib/whenIdle.ts
+++ b/src/lib/whenIdle.ts
@@ -17,7 +17,9 @@
 import {onHidden} from './onHidden.js';
 import {runOnce} from './runOnce.js';
 
-const rIC = self.requestIdleCallback || self.setTimeout;
+// Used by unit test so expose via globalThis with fallback for unsupporting browsers
+const rIC =
+  globalThis.requestIdleCallback || globalThis.setTimeout || self.setTimeout;
 
 /**
  * Runs the passed callback during the next idle period, or immediately

--- a/src/lib/whenIdle.ts
+++ b/src/lib/whenIdle.ts
@@ -18,8 +18,9 @@ import {onHidden} from './onHidden.js';
 import {runOnce} from './runOnce.js';
 
 // Used by unit test so expose via globalThis with fallback for unsupporting browsers
-const rIC =
-  globalThis.requestIdleCallback || globalThis.setTimeout || self.setTimeout;
+const rIC = globalThis
+  ? globalThis.requestIdleCallback || globalThis.setTimeout
+  : self.setTimeout;
 
 /**
  * Runs the passed callback during the next idle period, or immediately

--- a/src/lib/whenIdle.ts
+++ b/src/lib/whenIdle.ts
@@ -22,7 +22,6 @@ import {runOnce} from './runOnce.js';
  * if the browser's visibility state is (or becomes) hidden.
  */
 export const whenIdle = (cb: () => void): number => {
-  // Used by unit test so expose via globalThis with fallback for unsupporting browsers
   const rIC = self.requestIdleCallback || self.setTimeout;
 
   let handle = -1;

--- a/src/lib/whenIdle.ts
+++ b/src/lib/whenIdle.ts
@@ -17,16 +17,14 @@
 import {onHidden} from './onHidden.js';
 import {runOnce} from './runOnce.js';
 
-// Used by unit test so expose via globalThis with fallback for unsupporting browsers
-const rIC = globalThis
-  ? globalThis.requestIdleCallback || globalThis.setTimeout
-  : self.setTimeout;
-
 /**
  * Runs the passed callback during the next idle period, or immediately
  * if the browser's visibility state is (or becomes) hidden.
  */
 export const whenIdle = (cb: () => void): number => {
+  // Used by unit test so expose via globalThis with fallback for unsupporting browsers
+  const rIC = self.requestIdleCallback || self.setTimeout;
+
   let handle = -1;
   cb = runOnce(cb);
   // If the document is hidden, run the callback immediately, otherwise


### PR DESCRIPTION
Unit tests in v4 are broken since merging #442 as it exports a function using `self` which doesn't exist in node contexts.