### PR TITLE
Add jsdelivr and cdnjs as an alternative CDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ _**Tip:** while it's certainly possible to inline the code in `dist/polyfill.js`
 
 ### From a CDN
 
-The recommended way to use the `web-vitals` package is to install it from npm and integrate it into your build process. However, if you're not using npm, it's still possible to use `web-vitals` by requesting it from a CDN that serves npm package files.
+The recommended way to use the `web-vitals` package is to install it from npm and integrate it into your build process.However, if you're not using npm, it's still possible to use `web-vitals` by requesting it from a CDN that serves npm package files.
 
 The following examples show how to load `web-vitals` from [unpkg.com](https://unpkg.com) (or [jsDelivr](https://www.jsdelivr.com/) in the comments):
 
-_**Important!** The [unpkg.com](https://unpkg.com) and [jsDelivr](https://www.jsdelivr.com/) CDNs are shown here for example purposes only. `unpkg.com` is not affiliated with Google, and there are no guarantees that the URLs shown in these examples will continue to work in the future._
+_**Important!** The [unpkg.com](https://unpkg.com) and [jsDelivr](https://www.jsdelivr.com/) CDNs are shown here for example purposes only. `unpkg.com` is not affiliated with Google, and there are no guarantees that the URLs shown in these examples will continue to work in the future. Self-hosting the built files rather than loading from the CDN is better for security, reliability, and performance reasons._
 
 **Load the "standard" build** _(using a module script)_
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ _**Tip:** while it's certainly possible to inline the code in `dist/polyfill.js`
 
 ### From a CDN
 
-The recommended way to use the `web-vitals` package is to install it from npm and integrate it into your build process.However, if you're not using npm, it's still possible to use `web-vitals` by requesting it from a CDN that serves npm package files.
+The recommended way to use the `web-vitals` package is to install it from npm and integrate it into your build process. However, if you're not using npm, it's still possible to use `web-vitals` by requesting it from a CDN that serves npm package files.
 
 The following examples show how to load `web-vitals` from [unpkg.com](https://unpkg.com/browse/web-vitals/). It is also possible to load this from [jsDelivr](https://www.jsdelivr.com/package/npm/web-vitals), and [cdnjs](https://cdnjs.com/libraries/web-vitals).
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can install this library from npm by running:
 npm install web-vitals
 ```
 
-_**Note:** If you're not using npm, you can still load `web-vitals` via `<script>` tags from a CDN like [unpkg.com](https://unpkg.com) or [jsDelivr](https://www.jsdelivr.com/). See the [load `web-vitals` from a CDN](#load-web-vitals-from-a-cdn) usage example below for details._
+_**Note:** If you're not using npm, you can still load `web-vitals` via `<script>` tags from a CDN like [unpkg.com](https://unpkg.com). See the [load `web-vitals` from a CDN](#load-web-vitals-from-a-cdn) usage example below for details._
 
 There are a few different builds of the `web-vitals` library, and how you load the library depends on which build you want to use.
 
@@ -158,9 +158,9 @@ _**Tip:** while it's certainly possible to inline the code in `dist/polyfill.js`
 
 The recommended way to use the `web-vitals` package is to install it from npm and integrate it into your build process.However, if you're not using npm, it's still possible to use `web-vitals` by requesting it from a CDN that serves npm package files.
 
-The following examples show how to load `web-vitals` from [unpkg.com](https://unpkg.com) (or [jsDelivr](https://www.jsdelivr.com/) in the comments):
+The following examples show how to load `web-vitals` from [unpkg.com](https://unpkg.com/browse/web-vitals/). It is also possible to load this from [jsDelivr](https://www.jsdelivr.com/package/npm/web-vitals), and [cdnjs](https://cdnjs.com/libraries/web-vitals).
 
-_**Important!** The [unpkg.com](https://unpkg.com) and [jsDelivr](https://www.jsdelivr.com/) CDNs are shown here for example purposes only. `unpkg.com` is not affiliated with Google, and there are no guarantees that the URLs shown in these examples will continue to work in the future. Self-hosting the built files rather than loading from the CDN is better for security, reliability, and performance reasons._
+_**Important!** The [unpkg.com](https://unpkg.com), [jsDelivr](https://www.jsdelivr.com/), and [cdnjs](https://cdnjs.com) CDNs are shown here for example purposes only. `unpkg.com`, `jsDelivr`, and `cdnjs` are not affiliated with Google, and there are no guarantees that loading the library from those CDNs will continue to work in the future. Self-hosting the built files rather than loading from the CDN is better for security, reliability, and performance reasons._
 
 **Load the "standard" build** _(using a module script)_
 
@@ -168,7 +168,6 @@ _**Important!** The [unpkg.com](https://unpkg.com) and [jsDelivr](https://www.js
 <!-- Append the `?module` param to load the module version of `web-vitals` -->
 <script type="module">
   import {onCLS, onFID, onLCP} from 'https://unpkg.com/web-vitals@3?module';
-  //import {onCLS, onFID, onLCP} from 'https://cdn.jsdelivr.net/npm/web-vitals@3/+esm';
 
   onCLS(console.log);
   onFID(console.log);
@@ -183,7 +182,6 @@ _**Important!** The [unpkg.com](https://unpkg.com) and [jsDelivr](https://www.js
   (function () {
     var script = document.createElement('script');
     script.src = 'https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js';
-    //script.src = 'https://cdn.jsdelivr.net/npm/web-vitals@3/dist/web-vitals.iife.js';
     script.onload = function () {
       // When loading `web-vitals` using a classic script, all the public
       // methods can be found on the `webVitals` global namespace.
@@ -206,7 +204,6 @@ _**Important!** The [unpkg.com](https://unpkg.com) and [jsDelivr](https://www.js
     onFID,
     onLCP,
   } from 'https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.js?module';
-  // } from 'https://cdn.jsdelivr.net/npm/web-vitals@3/dist/web-vitals.attribution.js/+esm';
 
   onCLS(console.log);
   onFID(console.log);
@@ -222,7 +219,6 @@ _**Important!** The [unpkg.com](https://unpkg.com) and [jsDelivr](https://www.js
     var script = document.createElement('script');
     script.src =
       'https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.iife.js';
-    //'https://cdn.jsdelivr.net/npm/web-vitals@3/dist/web-vitals.attribution.iife.js';
     script.onload = function () {
       // When loading `web-vitals` using a classic script, all the public
       // methods can be found on the `webVitals` global namespace.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can install this library from npm by running:
 npm install web-vitals
 ```
 
-_**Note:** If you're not using npm, you can still load `web-vitals` via `<script>` tags from a CDN like [unpkg.com](https://unpkg.com). See the [load `web-vitals` from a CDN](#load-web-vitals-from-a-cdn) usage example below for details._
+_**Note:** If you're not using npm, you can still load `web-vitals` via `<script>` tags from a CDN like [unpkg.com](https://unpkg.com) or [jsDelivr](https://www.jsdelivr.com/). See the [load `web-vitals` from a CDN](#load-web-vitals-from-a-cdn) usage example below for details._
 
 There are a few different builds of the `web-vitals` library, and how you load the library depends on which build you want to use.
 
@@ -158,9 +158,9 @@ _**Tip:** while it's certainly possible to inline the code in `dist/polyfill.js`
 
 The recommended way to use the `web-vitals` package is to install it from npm and integrate it into your build process. However, if you're not using npm, it's still possible to use `web-vitals` by requesting it from a CDN that serves npm package files.
 
-The following examples show how to load `web-vitals` from [unpkg.com](https://unpkg.com):
+The following examples show how to load `web-vitals` from [unpkg.com](https://unpkg.com) (or [jsDelivr](https://www.jsdelivr.com/) in the comments):
 
-_**Important!** The [unpkg.com](https://unpkg.com) CDN is shown here for example purposes only. `unpkg.com` is not affiliated with Google, and there are no guarantees that the URLs shown in these examples will continue to work in the future._
+_**Important!** The [unpkg.com](https://unpkg.com) and [jsDelivr](https://www.jsdelivr.com/) CDNs are shown here for example purposes only. `unpkg.com` is not affiliated with Google, and there are no guarantees that the URLs shown in these examples will continue to work in the future._
 
 **Load the "standard" build** _(using a module script)_
 
@@ -168,6 +168,7 @@ _**Important!** The [unpkg.com](https://unpkg.com) CDN is shown here for example
 <!-- Append the `?module` param to load the module version of `web-vitals` -->
 <script type="module">
   import {onCLS, onFID, onLCP} from 'https://unpkg.com/web-vitals@3?module';
+  //import {onCLS, onFID, onLCP} from 'https://cdn.jsdelivr.net/npm/web-vitals@3/+esm';
 
   onCLS(console.log);
   onFID(console.log);
@@ -182,6 +183,7 @@ _**Important!** The [unpkg.com](https://unpkg.com) CDN is shown here for example
   (function () {
     var script = document.createElement('script');
     script.src = 'https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js';
+    //script.src = 'https://cdn.jsdelivr.net/npm/web-vitals@3/dist/web-vitals.iife.js';
     script.onload = function () {
       // When loading `web-vitals` using a classic script, all the public
       // methods can be found on the `webVitals` global namespace.
@@ -204,6 +206,7 @@ _**Important!** The [unpkg.com](https://unpkg.com) CDN is shown here for example
     onFID,
     onLCP,
   } from 'https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.js?module';
+  // } from 'https://cdn.jsdelivr.net/npm/web-vitals@3/dist/web-vitals.attribution.js/+esm';
 
   onCLS(console.log);
   onFID(console.log);
@@ -219,6 +222,7 @@ _**Important!** The [unpkg.com](https://unpkg.com) CDN is shown here for example
     var script = document.createElement('script');
     script.src =
       'https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.iife.js';
+    //'https://cdn.jsdelivr.net/npm/web-vitals@3/dist/web-vitals.attribution.iife.js';
     script.onload = function () {
       // When loading `web-vitals` using a classic script, all the public
       // methods can be found on the `webVitals` global namespace.


### PR DESCRIPTION
Given the recent [unpkg.com outage](https://www.theverge.com/2024/4/12/24128276/open-source-unpkg-cdn-down) we should have backup CDNs in our README. See also #463 

Will merge with v4 branch and update after merged.