### PR TITLE
Update README to note Firefox now supports LCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,11 +1067,11 @@ The `web-vitals` code has been tested and will run without error in all major br
 Browser support for each function is as follows:
 
 - `onCLS()`: Chromium
-- `onFCP()`: Chromium, Firefox, Safari 14.1+
+- `onFCP()`: Chromium, Firefox, Safari
 - `onFID()`: Chromium, Firefox _(Deprecated)_
 - `onINP()`: Chromium
-- `onLCP()`: Chromium
-- `onTTFB()`: Chromium, Firefox, Safari 15+
+- `onLCP()`: Chromium, Firefox
+- `onTTFB()`: Chromium, Firefox, Safari
 
 ## Limitations
 


### PR DESCRIPTION
As this is a recent addition we could add version number (Firefox 122) but instead went the other way and removed the Safari version numbers (the given metrics have been support in Safari for nearly 3 years now).