### PR TITLE
Turn off flakey Firefox tests

### DIFF
--- a/test/e2e/onFCP-test.js
+++ b/test/e2e/onFCP-test.js
@@ -175,8 +175,7 @@ describe('onFCP()', async function () {
     assert.strictEqual(fcp1.value, fcp1.delta);
     // Temp fix to address Firefox flakiness.
     // See https://github.com/GoogleChrome/web-vitals/issues/472
-    console.log(':' + browser.browserName + ':');
-    if (browser.browserName !== 'firefox') {
+    if (browser.capabilities.browserName !== 'firefox') {
       assert.strictEqual(fcp1.rating, 'good');
     }
     assert.strictEqual(fcp1.entries.length, 1);
@@ -195,7 +194,7 @@ describe('onFCP()', async function () {
     assert.strictEqual(fcp2.value, fcp2.delta);
     // Temp fix to address Firefox flakiness.
     // See https://github.com/GoogleChrome/web-vitals/issues/472
-    if (browser.browserName !== 'firefox') {
+    if (browser.capabilities.browserName !== 'firefox') {
       assert.strictEqual(fcp2.rating, 'good');
     }
     assert.strictEqual(fcp2.entries.length, 0);
@@ -214,7 +213,7 @@ describe('onFCP()', async function () {
     assert.strictEqual(fcp3.value, fcp3.delta);
     // Temp fix to address Firefox flakiness.
     // See https://github.com/GoogleChrome/web-vitals/issues/472
-    if (browser.browserName !== 'firefox') {
+    if (browser.capabilities.browserName !== 'firefox') {
       assert.strictEqual(fcp3.rating, 'good');
     }
     assert.strictEqual(fcp3.entries.length, 0);

--- a/test/e2e/onFCP-test.js
+++ b/test/e2e/onFCP-test.js
@@ -175,6 +175,7 @@ describe('onFCP()', async function () {
     assert.strictEqual(fcp1.value, fcp1.delta);
     // Temp fix to address Firefox flakiness.
     // See https://github.com/GoogleChrome/web-vitals/issues/472
+    console.log(':' + browser.browserName + ':');
     if (browser.browserName !== 'firefox') {
       assert.strictEqual(fcp1.rating, 'good');
     }

--- a/test/e2e/onFCP-test.js
+++ b/test/e2e/onFCP-test.js
@@ -173,7 +173,11 @@ describe('onFCP()', async function () {
     assert(fcp1.id.match(/^v4-\d+-\d+$/));
     assert.strictEqual(fcp1.name, 'FCP');
     assert.strictEqual(fcp1.value, fcp1.delta);
-    assert.strictEqual(fcp1.rating, 'good');
+    // Temp fix to address Firefox flakiness.
+    // See https://github.com/GoogleChrome/web-vitals/issues/472
+    if (browser.browserName !== 'firefox') {
+      assert.strictEqual(fcp1.rating, 'good');
+    }
     assert.strictEqual(fcp1.entries.length, 1);
     assert.match(fcp1.navigationType, /navigate|reload/);
 
@@ -188,7 +192,11 @@ describe('onFCP()', async function () {
     assert(fcp2.id !== fcp1.id);
     assert.strictEqual(fcp2.name, 'FCP');
     assert.strictEqual(fcp2.value, fcp2.delta);
-    assert.strictEqual(fcp2.rating, 'good');
+    // Temp fix to address Firefox flakiness.
+    // See https://github.com/GoogleChrome/web-vitals/issues/472
+    if (browser.browserName !== 'firefox') {
+      assert.strictEqual(fcp2.rating, 'good');
+    }
     assert.strictEqual(fcp2.entries.length, 0);
     assert.strictEqual(fcp2.navigationType, 'back-forward-cache');
 
@@ -203,7 +211,11 @@ describe('onFCP()', async function () {
     assert(fcp3.id !== fcp2.id);
     assert.strictEqual(fcp3.name, 'FCP');
     assert.strictEqual(fcp3.value, fcp3.delta);
-    assert.strictEqual(fcp3.rating, 'good');
+    // Temp fix to address Firefox flakiness.
+    // See https://github.com/GoogleChrome/web-vitals/issues/472
+    if (browser.browserName !== 'firefox') {
+      assert.strictEqual(fcp3.rating, 'good');
+    }
     assert.strictEqual(fcp3.entries.length, 0);
     assert.strictEqual(fcp3.navigationType, 'back-forward-cache');
   });

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -682,7 +682,7 @@ const assertStandardReportsAreCorrect = (beacons) => {
   assert.strictEqual(lcp.value, lcp.delta);
   // Temp fix to address Firefox flakiness.
   // See https://github.com/GoogleChrome/web-vitals/issues/472
-  if (browser.browserName !== 'firefox') {
+  if (browser.capabilities.browserName !== 'firefox') {
     assert.strictEqual(lcp.rating, 'good');
   }
   assert.strictEqual(lcp.entries.length, 1);

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -680,7 +680,11 @@ const assertStandardReportsAreCorrect = (beacons) => {
   assert(lcp.id.match(/^v4-\d+-\d+$/));
   assert.strictEqual(lcp.name, 'LCP');
   assert.strictEqual(lcp.value, lcp.delta);
-  assert.strictEqual(lcp.rating, 'good');
+  // Temp fix to address Firefox flakiness.
+  // See https://github.com/GoogleChrome/web-vitals/issues/472
+  if (browser.browserName !== 'firefox') {
+    assert.strictEqual(lcp.rating, 'good');
+  }
   assert.strictEqual(lcp.entries.length, 1);
   assert.match(lcp.navigationType, /navigate|reload/);
 };


### PR DESCRIPTION
Makes progress on #472 by commenting out the frequently failing tests.