### PR TITLE
Add ReportCallback type back but deprecate it

### DIFF
--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -1,8 +1,8 @@
 # Upgrading to v4
 
-This document lists the full set of changes between version 3 and version 4 that are relevant to anyone wanting to upgrade to the new version. This document groups changes into "breaking changes" and "new features" across both the "standard" and "attribution" builds (see [build options](/#build-options) for details).
+This document lists the full set of changes between version 3 and version 4 that are relevant to anyone wanting to upgrade to the new version. This document groups changes into "breaking changes", "new features", and "deprecations" across both the "standard" and "attribution" builds (see [build options](/#build-options) for details).
 
-## ⚠️ Breaking changes
+## ❌ Breaking changes
 
 ### Standard build
 
@@ -56,3 +56,12 @@ No new features were introduced into the "standard" build, outside of the breaki
 #### `TTFBAttribution`
 
 - **Added** `cacheDuration`, which marks the total time spent checking the HTTP cache for a match ([#458](https://github.com/GoogleChrome/web-vitals/pull/458)).
+
+## ⚠️ Deprecations
+
+### Standard and attribution builds
+
+- The `onFID()` function has been deprecated. Developers should use `onINP()` instead ([#435](https://github.com/GoogleChrome/web-vitals/pull/435)).
+- The `ReportCallback` type has been deprecated in favor of explicit callback types for each metric function ([#483](https://github.com/GoogleChrome/web-vitals/pull/483)).
+
+_All deprecated APIs will be removed in the next major version._

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -61,7 +61,7 @@ No new features were introduced into the "standard" build, outside of the breaki
 
 ### Standard and attribution builds
 
-- The `onFID()` function has been deprecated. Developers should use `onINP()` instead ([#435](https://github.com/GoogleChrome/web-vitals/pull/435)).
+- The `onFID()` function [has been deprecated]https://web.dev/blog/inp-cwv-launch#fid_deprecation_timeline). Developers should use `onINP()` instead ([#435](https://github.com/GoogleChrome/web-vitals/pull/435)).
 - The `ReportCallback` type has been deprecated in favor of explicit callback types for each metric function ([#483](https://github.com/GoogleChrome/web-vitals/pull/483)).
 
 _All deprecated APIs will be removed in the next major version._

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -116,6 +116,15 @@ export type MetricWithAttribution =
  */
 export type MetricRatingThresholds = [number, number];
 
+/**
+ * @deprecated Use metric-specific function types instead, such as:
+ * `(metric: LCPMetric) => void`. If a single callback type is needed for
+ * multiple metrics, use `(metric: MetricType) => void`.
+ */
+export interface ReportCallback {
+  (metric: MetricType): void;
+}
+
 export interface ReportOpts {
   reportAllChanges?: boolean;
   durationThreshold?: number;


### PR DESCRIPTION
Fixes #482 by re-adding the `ReportCallback` type but marking it as deprecated.

In most cases developers should not need to explicitly type their metric function callbacks (e.g. the type can be inferred from usage), but in the event that you do, the recommended replacement for `ReportCallback` is either:

- Specify a metric-specific function type, e.g. `(meric: LCPMetric) => void`, or
- Specify a type that could be used for any metric function, e.g. `(metric: MetricType) => void`

The `MetricType` type can be imported as follows:

```ts
// If using the "standard" build:
import type {MetricType} from 'web-vitals';

// If using the "attribution" build:
import type {MetricType} from 'web-vitals/attribution';
```