### PR TITLE
INP attribution: allow for LoAFs observed before interaction events

### DIFF
--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -27,6 +27,7 @@ import {observe} from './lib/observe.js';
 import {onHidden} from './lib/onHidden.js';
 import {initInteractionCountPolyfill} from './lib/polyfills/interactionCountPolyfill.js';
 import {whenActivated} from './lib/whenActivated.js';
+import {whenIdle} from './lib/whenIdle.js';
 
 import {INPMetric, MetricRatingThresholds, ReportOpts} from './types.js';
 
@@ -75,15 +76,23 @@ export const onINP = (
     let report: ReturnType<typeof bindReporter>;
 
     const handleEntries = (entries: INPMetric['entries']) => {
-      entries.forEach(processInteractionEntry);
+      // Queue the `handleEntries()` callback in the next idle task.
+      // This is needed to increase the chances that all event entries that
+      // occurred between the user interaction and the next paint
+      // have been dispatched. Note: there is currently an experiment
+      // running in Chrome (EventTimingKeypressAndCompositionInteractionId)
+      // 123+ that if rolled out fully may make this no longer necessary.
+      whenIdle(() => {
+        entries.forEach(processInteractionEntry);
 
-      const inp = estimateP98LongestInteraction();
+        const inp = estimateP98LongestInteraction();
 
-      if (inp && inp.latency !== metric.value) {
-        metric.value = inp.latency;
-        metric.entries = inp.entries;
-        report();
-      }
+        if (inp && inp.latency !== metric.value) {
+          metric.value = inp.latency;
+          metric.entries = inp.entries;
+          report();
+        }
+      });
     };
 
     const po = observe('event', handleEntries, {

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -326,6 +326,9 @@ describe('onINP()', async function () {
 
     await browser.keys(['a', 'b', 'c']);
 
+    // Ensure the interaction completes.
+    await nextFrame();
+
     await stubForwardBack();
     await beaconCountIs(1);
 


### PR DESCRIPTION
fixes #485

As described there, I added an extra condition to keep any LoAFs around that are _after_ any existing known interactions, in case those interactions then come in later.

I then realized that would leave the LoAF collection unbounded, since a page can have a bunch of slow animation frames without the user interacting. I added a `MAX_UNPAIRED_LOAFS` of 20, so it will only keep the 20 most recent LoAFs after any known user interaction events. The number isn't hugely important, that just allows a one second delay in event-timing reporting even if the page somehow has filled the time with the shortest (50ms) long animation frames possible. LoAF entries are fairly light weight, so that's not so bad.

As I was implementing this, however, I realized that even without this change the `pendingLoAFs` array can grow without bound on a page with e.g. animations and a busy main thread, since LoAFs are appended as they come in but clean up is only scheduled by user interactions. Seems like we should fix? @philipwalton @tunetheweb 

My only idea right now is to split the event timing and LoAF cleanups into two separate functions, and run each as their respective entries come in, since that's the only time each list of entries grows.