### PR TITLE
Small simplification refactor of INP attribution

### DIFF
--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -130,7 +130,6 @@ const groupEntriesByRenderTime = (entry: PerformanceEventTiming) => {
         group.processingStart,
       );
       group.processingEnd = Math.max(entry.processingEnd, group.processingEnd);
-      group.renderTime = Math.max(group.renderTime, renderTime);
       group.entries.push(entry);
 
       break;


### PR DESCRIPTION
I wanted to do this while the code was still fresh in my mind. There are no expected functional changes here, just code simplification.

Currently, `previousRenderTimes` is used for easier lookup into event-timing-entry groups in `pendingEntriesGroupMap` and for quick event grouping by render time, but it's also not quite the same set of render times in `pendingEntriesGroupMap` (the times and groups grow together as events come in, but the map actually contains all the events referenceable by `previousRenderTimes` _and_ groups with events from `longestInteractionList`). The results in more bookkeeping and (speaking as someone recently getting their head around this code :) it can make some of this logic harder to follow because effects aren't always collocated.

This PR proposes getting rid of `previousRenderTimes` so that there are only two main data structures, an array tracking LoAFs and an array tracking groups of event timing entries. I think this makes it a little simpler to understand how events are grouped as they come in and which event groups are being preserved during cleanup, without a runtime or clarity tradeoff elsewhere.

`latestProcessingEnd` and the entry WeakMap are still here as secondary data sources because they're convenient ways to skip extra work and they're both only ever updated in a single place (the WeakMap now maps directly to entry groups, though).