### PR TITLE
fix(types): sync types with TS v5.5 by adding `readonly`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -81,12 +81,12 @@ declare global {
 
   // https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface
   interface LargestContentfulPaint extends PerformanceEntry {
-    renderTime: DOMHighResTimeStamp;
-    loadTime: DOMHighResTimeStamp;
-    size: number;
-    id: string;
-    url: string;
-    element?: Element;
+    readonly renderTime: DOMHighResTimeStamp;
+    readonly loadTime: DOMHighResTimeStamp;
+    readonly size: number;
+    readonly id: string;
+    readonly url: string;
+    readonly element: Element | null;
   }
 
   // https://w3c.github.io/long-animation-frame/#sec-PerformanceLongAnimationFrameTiming


### PR DESCRIPTION
The type of `LargestContentfulPaint` conflicts with the new TypeScript@5.5.2, which throws an error:

```
error TS2687: All declarations of 'element' must have identical modifiers.
error TS2687: All declarations of 'id' must have identical modifiers.
...
```

The type has `readonly` which requires our type to be identical as well. The TypeScript:

```ts
// typescript@5.5.2/node_modules/typescript/lib/lib.dom.d.ts:14706:14

/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint) */
interface LargestContentfulPaint extends PerformanceEntry {
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/element) */
    readonly element: Element | null;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/id) */
    readonly id: string;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/loadTime) */
    readonly loadTime: DOMHighResTimeStamp;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/renderTime) */
    readonly renderTime: DOMHighResTimeStamp;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/size) */
    readonly size: number;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/url) */
    readonly url: string;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/toJSON) */
    toJSON(): any;
}
```

Fixes #498