### PR TITLE
Remove pagehide from the README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,14 +405,9 @@ addEventListener('visibilitychange', () => {
     flushQueue();
   }
 });
-
-// NOTE: Safari does not reliably fire the `visibilitychange` event when the
-// page is being unloaded. If Safari support is needed, you should also flush
-// the queue in the `pagehide` event.
-addEventListener('pagehide', flushQueue);
 ```
 
-_**Note:** see [the Page Lifecycle guide](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid) for an explanation of why `visibilitychange` and `pagehide` are recommended over events like `beforeunload` and `unload`._
+_**Note:** see [the Page Lifecycle guide](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid) for an explanation of why `visibilitychange` is recommended over events like `beforeunload` and `unload`._
 
 <a name="bundle-versions"><a>
 


### PR DESCRIPTION
When this library's README was originally published, there were [lots of browser bugs](https://github.com/w3c/page-visibility/issues/59) related to `visibilitychange`, where it wouldn't reliably fire when the page was being unloaded in various scenarios.

Since then, those bugs have all been fixed, and the use of `pagehide` is no longer needed to maximize coverage and the examples in the README can be simplified.