### PR TITLE
Fix interaction count after bfcache restore

### DIFF
--- a/src/lib/interactions.ts
+++ b/src/lib/interactions.ts
@@ -51,7 +51,7 @@ const getInteractionCountForNavigation = () => {
 };
 
 export const resetInteractions = () => {
-  prevInteractionCount = 0;
+  prevInteractionCount = getInteractionCount();
   longestInteractionList.length = 0;
   longestInteractionMap.clear();
 };


### PR DESCRIPTION
While reviewing the INP implementation, I noticed what I believe is a bug in INP/`interactions.ts`. Currently, `prevInteractionCount` is always `0`, but based on the comment
```js
// Used to store the interaction count after a bfcache restore, since p98
// interaction latencies should only consider the current navigation.
```
I believe `prevInteractionCount` should be set to `getInteractionCount()` when reset, so the next time `getInteractionCountForNavigation()` is called it should return `0` instead of the count of interactions that happened before the bfcache restore.