### PR TITLE
fix: distribute tsconfig and rollup config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
     "attribution.js",
     "attribution.d.ts",
     "dist",
-    "src"
+    "src",
+    "tsconfig.json",
+    "rollup.config.js"
   ],
   "scripts": {
     "build": "run-s clean build:ts build:js",


### PR DESCRIPTION
Summary:

We currently distribute the source code for the project, but not the
configuration files, meaning that users cannot build the project. This commit
adds the tsconfig.json and rollup.config.js files to the distributed package.

Test Plan:

- Run `npm run build` and ensure that the project builds successfully
- In another project add this package as a dependency and run `npm install &&
  cd node_modules/web-vitals && npm install --ignore-scripts && npm run build` and ensure that
  the project builds successfully

Motivation:

I am currently working on a [patch](https://github.com/GoogleChrome/web-vitals-extension/pull/184) for the web vitals Chrome extension and need
to use a development build of this web-vitals package.  To do that, I want to make a patch like

```diff
diff --git a/package.json b/package.json
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "scripts": {
     "lint": "npx eslint src --fix",
-    "build": "npm install; cp node_modules/web-vitals/dist/web-vitals.attribution.js src/browser_action/web-vitals.js"
+    "build": "npm install && (cd node_modules/web-vitals/ && npm install --ignore-scripts && npm run build) && cp node_modules/web-vitals/dist/web-vitals.attribution.js src/browser_action/web-vitals.js"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
@@ -21,6 +21,10 @@
     "eslint-config-google": "^0.14.0"
   },
   "dependencies": {
-    "web-vitals": "^4.0.0"
+    "web-vitals": "git://github.com/GoogleChrome/web-vitals.git#soft-navs"
+  }
```

however, the `npm run build` part fails because we don't distribute
`tsconfig.json` and `rollup.config.js`.  This commit fixes that.
