### PR TITLE
Add guard against getEntriesByType

### DIFF
--- a/src/lib/getNavigationEntry.ts
+++ b/src/lib/getNavigationEntry.ts
@@ -15,7 +15,11 @@
  */
 
 export const getNavigationEntry = (): PerformanceNavigationTiming | void => {
-  const navigationEntry = performance.getEntriesByType('navigation')[0];
+  // JSDOM does not implement getEntriesByType: https://github.com/jsdom/jsdom/issues/3309
+  const navigationEntry =
+    self.performance &&
+    performance.getEntriesByType &&
+    performance.getEntriesByType('navigation')[0];
 
   // Check to ensure the `responseStart` property is present and valid.
   // In some cases a zero value is reported by the browser (for

--- a/src/lib/getNavigationEntry.ts
+++ b/src/lib/getNavigationEntry.ts
@@ -16,10 +16,7 @@
 
 export const getNavigationEntry = (): PerformanceNavigationTiming | void => {
   // JSDOM does not implement getEntriesByType: https://github.com/jsdom/jsdom/issues/3309
-  const navigationEntry =
-    self.performance &&
-    performance.getEntriesByType &&
-    performance.getEntriesByType('navigation')[0];
+  const navigationEntry = performance.getEntriesByType?.('navigation')[0];
 
   // Check to ensure the `responseStart` property is present and valid.
   // In some cases a zero value is reported by the browser (for


### PR DESCRIPTION
Causing failures when testing Google upgrades.