### PR TITLE
Emphasize the importance of proper event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,9 @@ addEventListener('visibilitychange', () => {
 });
 ```
 
+> [!IMPORTANT]
+> To ensure your event listener is executed after all metrics have been reported, attach it to `window` object with `addEventListener` or `window.addEventListener`.
+
 > [!NOTE]
 > See [the Page Lifecycle guide](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid) for an explanation of why `visibilitychange` is recommended over events like `beforeunload` and `unload`.
 


### PR DESCRIPTION
This is a followup to the issue: https://github.com/GoogleChrome/web-vitals/issues/502

When batching, attaching a `visibilitychange` event listener to `document` can cause CLS data to be missed because CLS data is reported on `visibilitychange` event on `document` as well and depending on when event listeners were attached, sometimes data will be reported before or after batching.

This is very easy to miss and some users, including myself, overlooked this (e.g. https://github.com/GoogleChrome/web-vitals/issues/500). This PR adds a much needed clarification.