### PR TITLE
Change INP target map to selector to reduce memory usage

### DIFF
--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -36,7 +36,7 @@ export interface INPAttribution {
    * If this value is an empty string, that generally means the element was
    * removed from the DOM after the interaction.
    */
-  interactionTarget: string;
+  interactionTarget: string | undefined;
   /**
    * A reference to the HTML element identified by `interactionTargetSelector`.
    * NOTE: for attribution purpose, a selector identifying the element is


### PR DESCRIPTION
Fixes #580 

This has a couple of advantages:
- Selector more likely to be useful if taken when element is still in DOM
- Saves memory

And one disadvantage:
- Node may not be available if developers don't want to depend on our selector but instead roll their own and need attributes from the Node.

I think that's an acceptable tradeoff.