### PR TITLE
[soft-navigation] expose reset for cls and inp on navigation

### DIFF
--- a/src/attribution/onCLS.ts
+++ b/src/attribution/onCLS.ts
@@ -86,7 +86,7 @@ export const onCLS = (
   onReport: (metric: CLSMetricWithAttribution) => void,
   opts?: ReportOpts,
 ) => {
-  unattributedOnCLS((metric: CLSMetric) => {
+  return unattributedOnCLS((metric: CLSMetric) => {
     const metricWithAttribution = attributeCLS(metric);
     onReport(metricWithAttribution);
   }, opts);

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -331,7 +331,7 @@ export const onINP = (
   if (!loafObserver) {
     loafObserver = observe('long-animation-frame', handleLoAFEntries);
   }
-  unattributedOnINP((metric: INPMetric) => {
+  return unattributedOnINP((metric: INPMetric) => {
     const metricWithAttribution = attributeINP(metric);
     onReport(metricWithAttribution);
   }, opts);

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -78,12 +78,24 @@ export const onINP = (
   // Set defaults
   opts = opts || {};
 
+  let metric = initMetric('INP');
+  let report: ReturnType<typeof bindReporter>;
+
+  const reset = () => {
+    resetInteractions();
+
+    metric = initMetric('INP');
+    report = bindReporter(
+      onReport,
+      metric,
+      INPThresholds,
+      opts!.reportAllChanges,
+    );
+  };
+
   whenActivated(() => {
     // TODO(philipwalton): remove once the polyfill is no longer needed.
     initInteractionCountPolyfill();
-
-    let metric = initMetric('INP');
-    let report: ReturnType<typeof bindReporter>;
 
     const handleEntries = (entries: INPMetric['entries']) => {
       // Queue the `handleEntries()` callback in the next idle task.
@@ -147,4 +159,6 @@ export const onINP = (
       });
     }
   });
+
+  return {reset};
 };


### PR DESCRIPTION
## Description

This PR exposes `reset` functions for the return values of `onCLS` and `onINP`. These functions allow for resetting the metric measurements, particularly useful in single-page applications (SPAs) with soft navigation.

## Motivation

Surface web-vitals performance signals on soft-navigation within SPAs. 

[Soft-navigation](https://developer.chrome.com/docs/web-platform/soft-navigations-experiment) is an experimental feature within Chrome, but we can instrument SPAs to observe signals during soft-navigation. Resetting the observability of CLS and INP on soft-navigation, as signaled by the client, will provide us additional context on the performance of soft-navigations.

## How to use

 ```javascript
 const { reset: resetCLS } = onCLS(handleCLS, { reportAllChanges: true });
 const { reset: resetINP } = onINP(handleINP, { reportAllChanges: true });

function onSoftNavigation() {
  resetCLS();
  resetINP();
}
```

Similar to the [batching example](https://github.com/GoogleChrome/web-vitals?tab=readme-ov-file#batch-multiple-reports-together), clients could collect groups of events for each soft-navigation and report on them.