### PR TITLE
Remove visibilitychange listener after use

### DIFF
--- a/src/lib/onHidden.ts
+++ b/src/lib/onHidden.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-export const onHidden = (cb: () => void) => {
+export const onHidden = (cb: () => void, options?: boolean | AddEventListenerOptions) => {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {
       cb();
     }
-  });
+  }, options);
 };

--- a/src/lib/whenIdle.ts
+++ b/src/lib/whenIdle.ts
@@ -32,7 +32,7 @@ export const whenIdle = (cb: () => void): number => {
     cb();
   } else {
     handle = rIC(cb);
-    onHidden(cb);
+    onHidden(cb, { once: true });
   }
   return handle;
 };

--- a/src/onFID.ts
+++ b/src/onFID.ts
@@ -85,7 +85,7 @@ export const onFID = (
           handleEntries(po.takeRecords() as FIDMetric['entries']);
           po.disconnect();
         }),
-      );
+        {once: true});
 
       onBFCacheRestore(() => {
         metric = initMetric('FID');

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -110,7 +110,7 @@ export const onLCP = (
         });
       });
 
-      onHidden(stopListening);
+      onHidden(stopListening, {once: true});
 
       // Only report after a bfcache restore if the `PerformanceObserver`
       // successfully registered.


### PR DESCRIPTION
Similar to https://github.com/GoogleChrome/web-vitals/pull/554, we want to remove those event listeners after they've been used.