### PR TITLE
Extend INP attribution with extra LoAF information: longest script and buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,6 +1005,9 @@ interface INPAttribution {
    * This includes scripts < 5 milliseconds and other timings not attributed
    * by Long Animation Frame (including when a frame is < 50ms and so has no
    * Long Animation Frame).
+   * When no Long Animation Frames are present this will be undefined, rather
+   * than everything being unattributed to make it clearer when it's expected
+   * to be small.
    */
   totalUnattributedDuration?: number;
 }
@@ -1071,7 +1074,7 @@ interface LCPAttribution {
 #### `TTFBAttribution`
 
 ```ts
-export interface TTFBAttribution {
+interface TTFBAttribution {
   /**
    * The total time from when the user initiates loading the page to when the
    * page starts to handle the request. Large values here are typically due

--- a/README.md
+++ b/README.md
@@ -881,29 +881,6 @@ interface FCPAttribution {
 #### `INPAttribution`
 
 ```ts
-/**
- * Summary information about the longest script intersecting the INP duration
- * as provided by the Long Animation Frame API.
- *
- * NOTE: Only scripts above 5 milliseconds are included in long animation
- * frames.
- */
-interface LongestScriptSummary {
-  /**
-   * The longest Long Animation Frame script that intersects the INP
-   * interaction.
-   */
-  entry: PerformanceScriptTiming;
-  /**
-   * The INP sub-part where the longest script ran.
-   */
-  subpart: INPSubpart; //'input-delay' | 'processing-duration' | 'presentation-delay';
-  /**
-   * The amount of time the longest script intersected the INP duration.
-   */
-  intersectingDuration: number;
-}
-
 interface INPAttribution {
   /**
    * By default, a selector identifying the element that the user first
@@ -975,14 +952,15 @@ interface INPAttribution {
    * candidate interaction's `startTime` and the `processingEnd` time of the
    * last event processed within that animation frame. If the browser does not
    * support the Long Animation Frame API or no `long-animation-frame` entries
-   * are detect, this array will be empty.
+   * are detected, this array will be empty.
    */
   longAnimationFrameEntries: PerformanceLongAnimationFrameTiming[];
   /**
-   * The longest Long Animation Frame script that intersects the INP
-   * interaction.
+   * Summary information about the longest script entry intersecting the INP
+   * duration. Note, only script entries above 5 milliseconds are reported by
+   * the Long Animation Frame API.
    */
-  longestScript?: longestScriptSummary;
+  longestScript?: INPLongestScriptSummary;
   /**
    * The total duration of Long Animation Frame scripts that intersect the INP
    * duration excluding any forced style and layout (that is included in
@@ -991,7 +969,7 @@ interface INPAttribution {
   totalScriptDuration?: number;
   /**
    * The total style and layout duration from any Long Animation Frames
-   * intersecting INP interaction. This includes any end-of-frame style and
+   * intersecting the INP interaction. This includes any end-of-frame style and
    * layout duration + any forced style and layout duration.
    */
   totalStyleAndLayoutDuration?: number;
@@ -1010,6 +988,26 @@ interface INPAttribution {
    * to be small.
    */
   totalUnattributedDuration?: number;
+}
+```
+
+#### `INPLongestScriptSummary`
+
+```ts
+interface INPLongestScriptSummary {
+  /**
+   * The longest Long Animation Frame script entry that intersects the INP
+   * interaction.
+   */
+  entry: PerformanceScriptTiming;
+  /**
+   * The INP sub-part where the longest script ran.
+   */
+  subpart: 'input-delay' | 'processing-duration' | 'presentation-delay';
+  /**
+   * The amount of time the longest script intersected the INP duration.
+   */
+  intersectingDuration: number;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1001,7 +1001,7 @@ interface INPLongestScriptSummary {
    */
   entry: PerformanceScriptTiming;
   /**
-   * The INP sub-part where the longest script ran.
+   * The INP subpart where the longest script ran.
    */
   subpart: 'input-delay' | 'processing-duration' | 'presentation-delay';
   /**

--- a/README.md
+++ b/README.md
@@ -882,15 +882,15 @@ interface FCPAttribution {
 
 ```ts
 /**
- * Summary information about the slowest script intersecting the INP duration
+ * Summary information about the longest script intersecting the INP duration
  * as provided by the Long Animation Frame API.
  *
  * NOTE: Only scripts above 5 milliseconds are included in long animation
  * frames.
  */
-export interface longestScriptSummary {
+interface LongestScriptSummary {
   /**
-   * The slowest Long Animation Frame script that intersects the INP
+   * The longest Long Animation Frame script that intersects the INP
    * interaction.
    */
   entry: PerformanceScriptTiming;
@@ -899,7 +899,7 @@ export interface longestScriptSummary {
    */
   subpart: INPSubpart; //'input-delay' | 'processing-duration' | 'presentation-delay';
   /**
-   * The amount of time the slowest script intersected the INP duration.
+   * The amount of time the longest script intersected the INP duration.
    */
   intersectingDuration: number;
 }
@@ -979,7 +979,7 @@ interface INPAttribution {
    */
   longAnimationFrameEntries: PerformanceLongAnimationFrameTiming[];
   /**
-   * The slowest Long Animation Frame script that intersects the INP
+   * The longest Long Animation Frame script that intersects the INP
    * interaction.
    */
   longestScript?: longestScriptSummary;

--- a/README.md
+++ b/README.md
@@ -881,6 +881,29 @@ interface FCPAttribution {
 #### `INPAttribution`
 
 ```ts
+/**
+ * Summary information about the slowest script intersecting the INP duration
+ * as provided by the Long Animation Frame API.
+ *
+ * NOTE: Only scripts above 5 milliseconds are included in long animation
+ * frames.
+ */
+export interface longestScriptSummary {
+  /**
+   * The slowest Long Animation Frame script that intersects the INP
+   * interaction.
+   */
+  entry: PerformanceScriptTiming;
+  /**
+   * The INP sub-part where the longest script ran.
+   */
+  subpart: INPSubpart; //'input-delay' | 'processing-duration' | 'presentation-delay';
+  /**
+   * The amount of time the slowest script intersected the INP duration.
+   */
+  intersectingDuration: number;
+}
+
 interface INPAttribution {
   /**
    * By default, a selector identifying the element that the user first
@@ -898,14 +921,6 @@ interface INPAttribution {
    */
   interactionTime: DOMHighResTimeStamp;
   /**
-   * The best-guess timestamp of the next paint after the interaction.
-   * In general, this timestamp is the same as the `startTime + duration` of
-   * the event timing entry. However, since duration values are rounded to the
-   * nearest 8ms (and can be rounded down), this value is clamped to always be
-   * reported after the processing times.
-   */
-  nextPaintTime: DOMHighResTimeStamp;
-  /**
    * The type of interaction, based on the event type of the `event` entry
    * that corresponds to the interaction (i.e. the first `event` entry
    * containing an `interactionId` dispatched in a given animation frame).
@@ -914,19 +929,18 @@ interface INPAttribution {
    */
   interactionType: 'pointer' | 'keyboard';
   /**
+   * The best-guess timestamp of the next paint after the interaction.
+   * In general, this timestamp is the same as the `startTime + duration` of
+   * the event timing entry. However, since duration values are rounded to the
+   * nearest 8ms (and can be rounded down), this value is clamped to always be
+   * reported after the processing times.
+   */
+  nextPaintTime: DOMHighResTimeStamp;
+  /**
    * An array of Event Timing entries that were processed within the same
    * animation frame as the INP candidate interaction.
    */
   processedEventEntries: PerformanceEventTiming[];
-  /**
-   * If the browser supports the Long Animation Frame API, this array will
-   * include any `long-animation-frame` entries that intersect with the INP
-   * candidate interaction's `startTime` and the `processingEnd` time of the
-   * last event processed within that animation frame. If the browser does not
-   * support the Long Animation Frame API or no `long-animation-frame` entries
-   * are detect, this array will be empty.
-   */
-  longAnimationFrameEntries: PerformanceLongAnimationFrameTiming[];
   /**
    * The time from when the user interacted with the page until when the
    * browser was first able to start processing event listeners for that
@@ -955,6 +969,44 @@ interface INPAttribution {
    * (e.g. usually in the `dom-interactive` phase) it can result in long delays.
    */
   loadState: LoadState;
+  /**
+   * If the browser supports the Long Animation Frame API, this array will
+   * include any `long-animation-frame` entries that intersect with the INP
+   * candidate interaction's `startTime` and the `processingEnd` time of the
+   * last event processed within that animation frame. If the browser does not
+   * support the Long Animation Frame API or no `long-animation-frame` entries
+   * are detect, this array will be empty.
+   */
+  longAnimationFrameEntries: PerformanceLongAnimationFrameTiming[];
+  /**
+   * The slowest Long Animation Frame script that intersects the INP
+   * interaction.
+   */
+  longestScript?: longestScriptSummary;
+  /**
+   * The total duration of Long Animation Frame scripts that intersect the INP
+   * duration excluding any forced style and layout (that is included in
+   * totalStyleAndLayout). Note, this is limited to scripts > 5 milliseconds.
+   */
+  totalScriptDuration?: number;
+  /**
+   * The total style and layout duration from any Long Animation Frames
+   * intersecting INP interaction. This includes any end-of-frame style and
+   * layout duration + any forced style and layout duration.
+   */
+  totalStyleAndLayoutDuration?: number;
+  /**
+   * The off main-thread presentation delay from the end of the last Long
+   * Animation Frame (where available) until the INP end point.
+   */
+  totalPaintDuration?: number;
+  /**
+   * The total unattributed time not included in any of the previous totals.
+   * This includes scripts < 5 milliseconds and other timings not attributed
+   * by Long Animation Frame (including when a frame is < 50ms and so has no
+   * Long Animation Frame).
+   */
+  totalUnattributedDuration?: number;
 }
 ```
 

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -261,7 +261,7 @@ export const onINP = (
     return intersectingLoAFs;
   };
 
-  const attributeLoAFDetails = (attribution: INPAttribution, value: number) => {
+  const attributeLoAFDetails = (attribution: INPAttribution) => {
     // If there is no LoAF data then nothing further to attribute
     if (!attribution.longAnimationFrameEntries?.length) {
       return;
@@ -330,8 +330,7 @@ export const onINP = (
       ? lastLoAF.startTime + lastLoAF.duration
       : 0;
     if (lastLoAFEndTime >= interactionTime + inputDelay + processingDuration) {
-      totalPaintDuration =
-        attribution.interactionTime + value - lastLoAFEndTime;
+      totalPaintDuration = attribution.nextPaintTime - lastLoAFEndTime;
     }
 
     if (longestScriptEntry && longestScriptSubpart) {
@@ -345,7 +344,8 @@ export const onINP = (
     attribution.totalStyleAndLayoutDuration = totalStyleAndLayoutDuration;
     attribution.totalPaintDuration = totalPaintDuration;
     attribution.totalUnattributedDuration =
-      value -
+      interactionTime +
+      attribution.nextPaintTime -
       totalScriptDuration -
       totalStyleAndLayoutDuration -
       totalPaintDuration;
@@ -407,7 +407,7 @@ export const onINP = (
       totalUnattributedDuration: undefined,
     };
 
-    attributeLoAFDetails(attribution, metric.value);
+    attributeLoAFDetails(attribution);
 
     // Use `Object.assign()` to ensure the original metric object is returned.
     const metricWithAttribution: INPMetricWithAttribution = Object.assign(

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -23,10 +23,10 @@ import {whenIdleOrHidden} from '../lib/whenIdleOrHidden.js';
 import {onINP as unattributedOnINP} from '../onINP.js';
 import {
   INPAttribution,
+  INPAttributionReportOpts,
   INPMetric,
   INPMetricWithAttribution,
-  INPSubpart,
-  INPAttributionReportOpts,
+  INPLongestScriptSummary,
 } from '../types.js';
 
 interface pendingEntriesGroup {
@@ -277,7 +277,7 @@ export const onINP = (
     let totalPaintDuration = 0;
     let longestScriptDuration = 0;
     let longestScriptEntry: PerformanceScriptTiming | undefined;
-    let longestScriptSubpart: INPSubpart | undefined;
+    let longestScriptSubpart: INPLongestScriptSummary['subpart'] | undefined;
 
     for (const loafEntry of attribution.longAnimationFrameEntries) {
       totalStyleAndLayoutDuration =
@@ -295,7 +295,7 @@ export const onINP = (
           scriptEndTime - Math.max(interactionTime, script.startTime);
         // Since forcedStyleAndLayoutDuration doesn't provide timestamps, we
         // apportion the total based on the intersectingScriptDuration. Not
-        // correct depending on when it occured, but the best we can do.
+        // correct depending on when it occurred, but the best we can do.
         const intersectingForceStyleAndLayoutDuration = script.duration
           ? (intersectingScriptDuration / script.duration) *
             script.forcedStyleAndLayoutDuration
@@ -308,7 +308,7 @@ export const onINP = (
         totalStyleAndLayoutDuration += intersectingForceStyleAndLayoutDuration;
 
         if (intersectingScriptDuration > longestScriptDuration) {
-          // Set the subpart this occured in.
+          // Set the subpart this occurred in.
           longestScriptSubpart =
             script.startTime < interactionTime + inputDelay
               ? 'input-delay'

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -289,7 +289,7 @@ export const onINP = (
       for (const script of loafEntry.scripts) {
         const scriptEndTime = script.startTime + script.duration;
         if (scriptEndTime < interactionTime) {
-          return;
+          continue;
         }
         const intersectingScriptDuration =
           scriptEndTime - Math.max(interactionTime, script.startTime);

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -267,7 +267,7 @@ export const onINP = (
     const inputDelay = attribution.inputDelay;
     const processingDuration = attribution.processingDuration;
     let totalScriptsDuration = 0;
-    let totalScriptForcedStyleAndLayoutDuration = 0;
+    let totalScriptsForcedStyleAndLayoutDuration = 0;
     let longestScriptDuration = 0;
     let longestScriptEntry!: PerformanceScriptTiming;
     let longestScriptSubpart!: INPSubpart;
@@ -291,7 +291,7 @@ export const onINP = (
         const intersectingScriptDuration =
           scriptEndTime - Math.max(interactionTime, script.startTime);
         totalScriptsDuration += intersectingScriptDuration;
-        totalScriptForcedStyleAndLayoutDuration +=
+        totalScriptsForcedStyleAndLayoutDuration +=
           script.forcedStyleAndLayoutDuration;
         let subpart: INPSubpart = 'processingDuration';
         if (script.startTime < interactionTime + inputDelay) {
@@ -317,8 +317,8 @@ export const onINP = (
       intersectingDuration: longestScriptDuration,
     };
     attribution.scriptsDuration = totalScriptsDuration;
-    attribution.scriptForcedStyleAndLayoutDuration =
-      totalScriptForcedStyleAndLayoutDuration;
+    attribution.scriptsForcedStyleAndLayoutDuration =
+      totalScriptsForcedStyleAndLayoutDuration;
   };
 
   const attributeINP = (metric: INPMetric): INPMetricWithAttribution => {

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -344,8 +344,8 @@ export const onINP = (
     attribution.totalStyleAndLayoutDuration = totalStyleAndLayoutDuration;
     attribution.totalPaintDuration = totalPaintDuration;
     attribution.totalUnattributedDuration =
-      interactionTime +
       attribution.nextPaintTime -
+      interactionTime -
       totalScriptDuration -
       totalStyleAndLayoutDuration -
       totalPaintDuration;

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -266,8 +266,8 @@ export const onINP = (
     const interactionTime = attribution.interactionTime;
     const inputDelay = attribution.inputDelay;
     const processingDuration = attribution.processingDuration;
-    let totalScriptsDuration = 0;
-    let totalScriptsForcedStyleAndLayoutDuration = 0;
+    let totalScriptDuration = 0;
+    let totalForcedStyleAndLayoutDuration = 0;
     let longestScriptDuration = 0;
     let longestScriptEntry!: PerformanceScriptTiming;
     let longestScriptSubpart!: INPSubpart;
@@ -290,17 +290,17 @@ export const onINP = (
         }
         const intersectingScriptDuration =
           scriptEndTime - Math.max(interactionTime, script.startTime);
-        totalScriptsDuration += intersectingScriptDuration;
-        totalScriptsForcedStyleAndLayoutDuration +=
+        totalScriptDuration += intersectingScriptDuration;
+        totalForcedStyleAndLayoutDuration +=
           script.forcedStyleAndLayoutDuration;
-        let subpart: INPSubpart = 'processingDuration';
+        let subpart: INPSubpart = 'processing-duration';
         if (script.startTime < interactionTime + inputDelay) {
-          subpart = 'inputDelay';
+          subpart = 'input-delay';
         } else if (
           script.startTime >=
           interactionTime + inputDelay + processingDuration
         ) {
-          subpart = 'presentationDelay';
+          subpart = 'presentation-delay';
         }
 
         if (intersectingScriptDuration > longestScriptDuration) {
@@ -316,9 +316,9 @@ export const onINP = (
       subpart: longestScriptSubpart,
       intersectingDuration: longestScriptDuration,
     };
-    attribution.scriptsDuration = totalScriptsDuration;
-    attribution.scriptsForcedStyleAndLayoutDuration =
-      totalScriptsForcedStyleAndLayoutDuration;
+    attribution.totalScriptDuration = totalScriptDuration;
+    attribution.totalForcedStyleAndLayoutDuration =
+      totalForcedStyleAndLayoutDuration;
   };
 
   const attributeINP = (metric: INPMetric): INPMetricWithAttribution => {

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -400,6 +400,11 @@ export const onINP = (
       processingDuration: processingEnd - processingStart,
       presentationDelay: nextPaintTime - processingEnd,
       loadState: getLoadState(firstEntry.startTime),
+      longestScript: undefined,
+      totalScriptDuration: undefined,
+      totalStyleAndLayoutDuration: undefined,
+      totalPaintDuration: undefined,
+      totalUnattributedDuration: undefined,
     };
 
     attributeLoAFDetails(attribution, metric.value);

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -267,7 +267,7 @@ export const onINP = (
     const inputDelay = attribution.inputDelay;
     const processingDuration = attribution.processingDuration;
     let totalScriptsDuration = 0;
-    let totalScriptThrashingDuration = 0;
+    let totalScriptForcedStyleAndLayoutDuration = 0;
     let longestScriptDuration = 0;
     let longestScriptEntry!: PerformanceScriptTiming;
     let longestScriptSubpart!: INPSubpart;
@@ -291,7 +291,8 @@ export const onINP = (
         const intersectingScriptDuration =
           scriptEndTime - Math.max(interactionTime, script.startTime);
         totalScriptsDuration += intersectingScriptDuration;
-        totalScriptThrashingDuration += script.forcedStyleAndLayoutDuration;
+        totalScriptForcedStyleAndLayoutDuration +=
+          script.forcedStyleAndLayoutDuration;
         let subpart: INPSubpart = 'processingDuration';
         if (script.startTime < interactionTime + inputDelay) {
           subpart = 'inputDelay';
@@ -316,7 +317,8 @@ export const onINP = (
       intersectingDuration: longestScriptDuration,
     };
     attribution.scriptsDuration = totalScriptsDuration;
-    attribution.scriptThrashingDuration = totalScriptThrashingDuration;
+    attribution.scriptForcedStyleAndLayoutDuration =
+      totalScriptForcedStyleAndLayoutDuration;
   };
 
   const attributeINP = (metric: INPMetric): INPMetricWithAttribution => {

--- a/src/lib/InteractionManager.ts
+++ b/src/lib/InteractionManager.ts
@@ -138,6 +138,8 @@ export class InteractionManager {
           this._longestInteractionMap.delete(interaction.id);
         }
       }
+    } else {
+      return;
     }
 
     this._onAfterProcessingInteraction?.(interaction!);

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,8 +89,52 @@ declare global {
   }
 
   // https://w3c.github.io/long-animation-frame/#sec-PerformanceLongAnimationFrameTiming
+  export type ScriptInvokerType =
+    | 'classic-script'
+    | 'module-script'
+    | 'event-listener'
+    | 'user-callback'
+    | 'resolve-promise'
+    | 'reject-promise';
+
+  // https://w3c.github.io/long-animation-frame/#sec-PerformanceLongAnimationFrameTiming
+  export type ScriptWindowAttribution =
+    | 'self'
+    | 'descendant'
+    | 'ancestor'
+    | 'same-page'
+    | 'other';
+
+  // https://w3c.github.io/long-animation-frame/#sec-PerformanceLongAnimationFrameTiming
+  interface PerformanceScriptTiming extends PerformanceEntry {
+    /* Overloading PerformanceEntry */
+    readonly startTime: DOMHighResTimeStamp;
+    readonly duration: DOMHighResTimeStamp;
+    readonly name: string;
+    readonly entryType: string;
+
+    readonly invokerType: ScriptInvokerType;
+    readonly invoker: string;
+    readonly executionStart: DOMHighResTimeStamp;
+    readonly sourceURL: string;
+    readonly sourceFunctionName: string;
+    readonly sourceCharPosition: number;
+    readonly pauseDuration: DOMHighResTimeStamp;
+    readonly forcedStyleAndLayoutDuration: DOMHighResTimeStamp;
+    readonly window?: Window;
+    readonly windowAttribution: ScriptWindowAttribution;
+  }
+
+  // https://w3c.github.io/long-animation-frame/#sec-PerformanceLongAnimationFrameTiming
   interface PerformanceLongAnimationFrameTiming extends PerformanceEntry {
-    renderStart: DOMHighResTimeStamp;
-    duration: DOMHighResTimeStamp;
+    readonly startTime: DOMHighResTimeStamp;
+    readonly duration: DOMHighResTimeStamp;
+    readonly name: string;
+    readonly entryType: string;
+    readonly renderStart: DOMHighResTimeStamp;
+    readonly styleAndLayoutStart: DOMHighResTimeStamp;
+    readonly blockingDuration: DOMHighResTimeStamp;
+    readonly firstUIEventTimestamp: DOMHighResTimeStamp;
+    readonly scripts: PerformanceScriptTiming[];
   }
 }

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -172,6 +172,9 @@ export interface INPAttribution {
    * This includes scripts < 5 milliseconds and other timings not attributed
    * by Long Animation Frame (including when a frame is < 50ms and so has no
    * Long Animation Frame).
+   * When no Long Animation Frames are present this will be undefined, rather
+   * than everything being unattributed to make it clearer when it's expected
+   * to be small.
    */
   totalUnattributedDuration?: number;
 }

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -152,24 +152,28 @@ export interface INPAttribution {
   loadState: LoadState;
   /**
    * The total duration of Long Animation Frame scripts that intersect the INP
-   * duration. Note, this is limited to scripts > 5 milliseconds.
+   * duration excluding any forced style and layout (that is included in
+   * totalStyleAndLayout). Note, this is limited to scripts > 5 milliseconds.
    */
   totalScriptDuration?: number;
   /**
-   * The total forced style and layout duration from any
-   * Long Animation Frames intersecting INP interaction.
+   * The total style and layout duration from any Long Animation Frames
+   * intersecting INP interaction. This includes any end-of-frame style and
+   * layout duration + any forced style and layout duration.
    */
-  totalForcedStyleAndLayoutDuration?: number;
+  totalStyleAndLayoutDuration?: number;
   /**
-   * The non-forced (i.e. end-of-frame) style and layout duration from the last
-   * long animation frame intersecting the INP interaction.
+   * The off main-thread presentation delay from the end of the last Long
+   * Animation Frame (where available) until the INP end point.
    */
-  styleAndLayoutDuration?: number;
+  totalPaintDuration?: number;
   /**
-   * The off main-thread presentation delay from the end of the last long
-   * animation frame until the INP end point.
+   * The total unattributed time not included in any of the previous totals.
+   * This includes scripts < 5 milliseconds and other timings not attributed
+   * by Long Animation Frame (including when a frame is < 50ms and so has no
+   * Long Animation Frame).
    */
-  framePresentationDelay?: number;
+  totalUnattributedDuration?: number;
 }
 
 /**

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -43,7 +43,7 @@ export type INPSubpart =
   | 'presentation-delay';
 
 /**
- * Summary information about the slowest script intersecting the INP duration
+ * Summary information about the longest script intersecting the INP duration
  * as provided by the Long Animation Frame API.
  *
  * NOTE: Only scripts above 5 milliseconds are included in long animation
@@ -51,7 +51,7 @@ export type INPSubpart =
  */
 export interface longestScriptSummary {
   /**
-   * The slowest Long Animation Frame script that intersects the INP
+   * The longest Long Animation Frame script that intersects the INP
    * interaction.
    */
   entry: PerformanceScriptTiming;
@@ -60,7 +60,7 @@ export interface longestScriptSummary {
    */
   subpart: INPSubpart; //'input-delay' | 'processing-duration' | 'presentation-delay';
   /**
-   * The amount of time the slowest script intersected the INP duration.
+   * The amount of time the longest script intersected the INP duration.
    */
   intersectingDuration: number;
 }
@@ -87,7 +87,7 @@ export interface INPAttribution {
    */
   interactionTime: DOMHighResTimeStamp;
   /**
-   * The slowest Long Animation Frame script that intersects the INP
+   * The longest Long Animation Frame script that intersects the INP
    * interaction.
    */
   longestScript?: longestScriptSummary;

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -38,9 +38,9 @@ export interface INPMetric extends Metric {
 }
 
 export type INPSubpart =
-  | 'inputDelay'
-  | 'processingDuration'
-  | 'presentationDelay';
+  | 'input-delay'
+  | 'processing-duration'
+  | 'presentation-delay';
 
 /**
  * Summary information about the slowest script intersecting the INP duration
@@ -58,7 +58,7 @@ export interface longestScriptSummary {
   /**
    * The INP sub-part where the longest script ran.
    */
-  subpart: INPSubpart; //'inputDelay' | 'processingDuration' | 'presentationDelay';
+  subpart: INPSubpart; //'input-delay' | 'processing-duration' | 'presentation-delay';
   /**
    * The amount of time the slowest script intersected the INP duration.
    */
@@ -154,12 +154,12 @@ export interface INPAttribution {
    * The total duration of Long Animation Frame scripts that intersect the INP
    * duration. Note, this is limited to scripts > 5 milliseconds.
    */
-  scriptsDuration?: number;
+  totalScriptDuration?: number;
   /**
    * The total forced style and layout duration from any
    * Long Animation Frames intersecting INP interaction.
    */
-  scriptsForcedStyleAndLayoutDuration?: number;
+  totalForcedStyleAndLayoutDuration?: number;
   /**
    * The non-forced (i.e. end-of-frame) style and layout duration from the last
    * long animation frame intersecting the INP interaction.

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -44,7 +44,7 @@ export interface INPLongestScriptSummary {
    */
   entry: PerformanceScriptTiming;
   /**
-   * The INP sub-part where the longest script ran.
+   * The INP subpart where the longest script ran.
    */
   subpart: 'input-delay' | 'processing-duration' | 'presentation-delay';
   /**

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -37,6 +37,34 @@ export interface INPMetric extends Metric {
   entries: PerformanceEventTiming[];
 }
 
+export type INPSubpart =
+  | 'inputDelay'
+  | 'processingDuration'
+  | 'presentationDelay';
+
+/**
+ * Summary information about the slowest script intersecting the INP duration
+ * as provided by the Long Animation Frame API.
+ *
+ * NOTE: Only scripts above 5 milliseconds are included in long animation
+ * frames.
+ */
+export interface longestScriptSummary {
+  /**
+   * The slowest Long Animation Frame script that intersects the INP
+   * interaction.
+   */
+  entry: PerformanceScriptTiming;
+  /**
+   * The INP sub-part where the longest script ran.
+   */
+  subpart: INPSubpart; //'inputDelay' | 'processingDuration' | 'presentationDelay';
+  /**
+   * The amount of time the slowest script intersected the INP duration.
+   */
+  intersectingDuration: number;
+}
+
 /**
  * An object containing potentially-helpful debugging information that
  * can be sent along with the INP value for the current page visit in order
@@ -58,6 +86,11 @@ export interface INPAttribution {
    * within the frame, only the first time is reported).
    */
   interactionTime: DOMHighResTimeStamp;
+  /**
+   * The slowest Long Animation Frame script that intersects the INP
+   * interaction.
+   */
+  longestScript?: longestScriptSummary;
   /**
    * The best-guess timestamp of the next paint after the interaction.
    * In general, this timestamp is the same as the `startTime + duration` of
@@ -107,6 +140,7 @@ export interface INPAttribution {
    * `requestAnimationFrame()` callbacks, `ResizeObserver` and
    * `IntersectionObserver` callbacks, and style/layout calculation) as well
    * as off-main-thread work (such as compositor, GPU, and raster work).
+   * The subparts of INP
    */
   presentationDelay: number;
   /**
@@ -116,6 +150,26 @@ export interface INPAttribution {
    * (e.g. usually in the `dom-interactive` phase) it can result in long delays.
    */
   loadState: LoadState;
+  /**
+   * The total duration of Long Animation Frame scripts that intersect the INP
+   * duration. Note, this is limited to scripts > 5 milliseconds.
+   */
+  scriptsDuration?: number;
+  /**
+   * The total forced style and layout duration from any
+   * Long Animation Frames intersecting INP interaction.
+   */
+  scriptThrashingDuration?: number;
+  /**
+   * The non-forced (i.e. end-of-frame) style and layout duration from the last
+   * long animation frame intersecting the INP interaction.
+   */
+  styleAndLayoutDuration?: number;
+  /**
+   * The off main-thread presentation delay from the end of the last long
+   * animation frame until the INP end point.
+   */
+  framePresentationDelay?: number;
 }
 
 /**

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -159,7 +159,7 @@ export interface INPAttribution {
    * The total forced style and layout duration from any
    * Long Animation Frames intersecting INP interaction.
    */
-  scriptThrashingDuration?: number;
+  scriptForcedStyleAndLayoutDuration?: number;
   /**
    * The non-forced (i.e. end-of-frame) style and layout duration from the last
    * long animation frame intersecting the INP interaction.

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -37,28 +37,16 @@ export interface INPMetric extends Metric {
   entries: PerformanceEventTiming[];
 }
 
-export type INPSubpart =
-  | 'input-delay'
-  | 'processing-duration'
-  | 'presentation-delay';
-
-/**
- * Summary information about the longest script intersecting the INP duration
- * as provided by the Long Animation Frame API.
- *
- * NOTE: Only scripts above 5 milliseconds are included in long animation
- * frames.
- */
-export interface longestScriptSummary {
+export interface INPLongestScriptSummary {
   /**
-   * The longest Long Animation Frame script that intersects the INP
+   * The longest Long Animation Frame script entry that intersects the INP
    * interaction.
    */
   entry: PerformanceScriptTiming;
   /**
    * The INP sub-part where the longest script ran.
    */
-  subpart: INPSubpart; //'input-delay' | 'processing-duration' | 'presentation-delay';
+  subpart: 'input-delay' | 'processing-duration' | 'presentation-delay';
   /**
    * The amount of time the longest script intersected the INP duration.
    */
@@ -87,10 +75,13 @@ export interface INPAttribution {
    */
   interactionTime: DOMHighResTimeStamp;
   /**
-   * The longest Long Animation Frame script that intersects the INP
-   * interaction.
+   * The type of interaction, based on the event type of the `event` entry
+   * that corresponds to the interaction (i.e. the first `event` entry
+   * containing an `interactionId` dispatched in a given animation frame).
+   * For "pointerdown", "pointerup", or "click" events this will be "pointer",
+   * and for "keydown" or "keyup" events this will be "keyboard".
    */
-  longestScript?: longestScriptSummary;
+  interactionType: 'pointer' | 'keyboard';
   /**
    * The best-guess timestamp of the next paint after the interaction.
    * In general, this timestamp is the same as the `startTime + duration` of
@@ -100,27 +91,10 @@ export interface INPAttribution {
    */
   nextPaintTime: DOMHighResTimeStamp;
   /**
-   * The type of interaction, based on the event type of the `event` entry
-   * that corresponds to the interaction (i.e. the first `event` entry
-   * containing an `interactionId` dispatched in a given animation frame).
-   * For "pointerdown", "pointerup", or "click" events this will be "pointer",
-   * and for "keydown" or "keyup" events this will be "keyboard".
-   */
-  interactionType: 'pointer' | 'keyboard';
-  /**
    * An array of Event Timing entries that were processed within the same
    * animation frame as the INP candidate interaction.
    */
   processedEventEntries: PerformanceEventTiming[];
-  /**
-   * If the browser supports the Long Animation Frame API, this array will
-   * include any `long-animation-frame` entries that intersect with the INP
-   * candidate interaction's `startTime` and the `processingEnd` time of the
-   * last event processed within that animation frame. If the browser does not
-   * support the Long Animation Frame API or no `long-animation-frame` entries
-   * are detect, this array will be empty.
-   */
-  longAnimationFrameEntries: PerformanceLongAnimationFrameTiming[];
   /**
    * The time from when the user interacted with the page until when the
    * browser was first able to start processing event listeners for that
@@ -140,7 +114,6 @@ export interface INPAttribution {
    * `requestAnimationFrame()` callbacks, `ResizeObserver` and
    * `IntersectionObserver` callbacks, and style/layout calculation) as well
    * as off-main-thread work (such as compositor, GPU, and raster work).
-   * The subparts of INP
    */
   presentationDelay: number;
   /**
@@ -151,6 +124,21 @@ export interface INPAttribution {
    */
   loadState: LoadState;
   /**
+   * If the browser supports the Long Animation Frame API, this array will
+   * include any `long-animation-frame` entries that intersect with the INP
+   * candidate interaction's `startTime` and the `processingEnd` time of the
+   * last event processed within that animation frame. If the browser does not
+   * support the Long Animation Frame API or no `long-animation-frame` entries
+   * are detected, this array will be empty.
+   */
+  longAnimationFrameEntries: PerformanceLongAnimationFrameTiming[];
+  /**
+   * Summary information about the longest script entry intersecting the INP
+   * duration. Note, only script entries above 5 milliseconds are reported by
+   * the Long Animation Frame API.
+   */
+  longestScript?: INPLongestScriptSummary;
+  /**
    * The total duration of Long Animation Frame scripts that intersect the INP
    * duration excluding any forced style and layout (that is included in
    * totalStyleAndLayout). Note, this is limited to scripts > 5 milliseconds.
@@ -158,7 +146,7 @@ export interface INPAttribution {
   totalScriptDuration?: number;
   /**
    * The total style and layout duration from any Long Animation Frames
-   * intersecting INP interaction. This includes any end-of-frame style and
+   * intersecting the INP interaction. This includes any end-of-frame style and
    * layout duration + any forced style and layout duration.
    */
   totalStyleAndLayoutDuration?: number;

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -159,7 +159,7 @@ export interface INPAttribution {
    * The total forced style and layout duration from any
    * Long Animation Frames intersecting INP interaction.
    */
-  scriptForcedStyleAndLayoutDuration?: number;
+  scriptsForcedStyleAndLayoutDuration?: number;
   /**
    * The non-forced (i.e. end-of-frame) style and layout duration from the last
    * long animation frame intersecting the INP interaction.

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -550,7 +550,7 @@ describe('onINP()', async function () {
           inp1.attribution.interactionTime +
             (inp1.attribution.inputDelay + inp1.attribution.processingDuration),
       );
-      // Assert that the INP phase durations adds up to the total duration.
+      // Assert that the INP subpart durations adds up to the total duration.
       assert.equal(
         inp1.attribution.nextPaintTime - inp1.attribution.interactionTime,
         inp1.attribution.inputDelay +
@@ -558,7 +558,7 @@ describe('onINP()', async function () {
           inp1.attribution.presentationDelay,
       );
 
-      // Assert that the INP phases timestamps match the values in
+      // Assert that the INP subparts timestamps match the values in
       // the `processedEventEntries` array.
       const sortedEntries1 = inp1.attribution.processedEventEntries.sort(
         (a, b) => {
@@ -631,7 +631,7 @@ describe('onINP()', async function () {
           inp2.attribution.interactionTime +
             (inp2.attribution.inputDelay + inp2.attribution.processingDuration),
       );
-      // Assert that the INP phase durations adds up to the total duration.
+      // Assert that the INP subpart durations adds up to the total duration.
       assert.equal(
         inp2.attribution.nextPaintTime - inp2.attribution.interactionTime,
         inp2.attribution.inputDelay +
@@ -639,7 +639,7 @@ describe('onINP()', async function () {
           inp2.attribution.presentationDelay,
       );
 
-      // Assert that the INP phases timestamps match the values in
+      // Assert that the INP subparts timestamps match the values in
       // the `processedEventEntries` array.
       const sortedEntries2 = inp2.attribution.processedEventEntries.sort(
         (a, b) => {

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -841,6 +841,32 @@ describe('onINP()', async function () {
 
       const [inp1] = await getBeacons();
       assert(inp1.attribution.longAnimationFrameEntries.length > 0);
+      assert.equal(
+        inp1.attribution.longestScript.entry.invokerType,
+        'event-listener',
+      );
+      assert.equal(
+        inp1.attribution.longestScript.entry.invoker,
+        'DOMWindow.onpointerdown',
+      );
+      assert.equal(
+        inp1.attribution.longestScript.subpart,
+        'processing-duration',
+      );
+      assert.equal(inp1.attribution.longestScript.intersectingDuration, 100);
+      assert(inp1.attribution.totalScriptDuration > 0);
+      assert(inp1.attribution.totalStyleAndLayoutDuration >= 0);
+      assert(inp1.attribution.totalPaintDuration >= 0);
+      assert(inp1.attribution.totalUnattributedDuration >= 0);
+      assert(
+        Math.abs(
+          inp1.value -
+            (inp1.attribution.totalScriptDuration +
+              inp1.attribution.totalStyleAndLayoutDuration +
+              inp1.attribution.totalPaintDuration +
+              inp1.attribution.totalUnattributedDuration),
+        ) < 0.1,
+      );
     });
   });
 });

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -643,7 +643,7 @@ describe('onLCP()', async function () {
       assert.equal(lcp.navigationType, 'prerender');
       assert.equal(lcp.attribution.target, 'html>body>main>p>img.bar.foo');
 
-      // Assert each individual LCP sub-part accounts for `activationStart`
+      // Assert each individual LCP subpart accounts for `activationStart`
       assert.equal(
         lcp.attribution.timeToFirstByte,
         Math.max(0, navEntry.responseStart - navEntry.activationStart),

--- a/wdio.conf.cjs
+++ b/wdio.conf.cjs
@@ -88,6 +88,19 @@ module.exports.config = {
         // binary: '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary'
       };
     }
+    if (browserName === 'firefox') {
+      capability['moz:firefoxOptions'] = {
+        args: [],
+        prefs: {
+          // Temporarily disable interactionid on Firefox nightly as unstable
+          // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1960645
+          // TODO: Remove this once this hits stable
+          'dom.performance.event_timing.enable_interactionid': false,
+        },
+        // Uncomment to test on Firefox Nightly (now with INP support)
+        // binary: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox'
+      };
+    }
     return capability;
   }),
   //


### PR DESCRIPTION
Closes #559 

This is an alternative to #574 which provides some extra attribution information:

- `totalScriptDuration` - the total duration of all intersecting scripts
- `totalStyleAndLayoutDuration` - The total style and layout duration including any end-of-frame style and layout duration plus any forced style and layout duration.
- `totalPaintDuration` -  the off-main-thread presentation delays (end of LoAF -> end of INP).
- `totalUnattributedDuration` - The total unattributed time not included in any of the previous totals including scripts < 5 milliseconds and other timings not attributed by LoAF (including when a frame is < 50ms and so has no LoAF).
- `longestScript` - the longest intersection script
   - `entry` - the entry
   - `subpart` - the subpart the script ocured in
   - `intersectingDuration` - the intersecting duration (as it may be not all of the script intersected the INP time).

The first four give more information on whether this is a script, or style and layout, or frame presentation delay.

The last item pulls out the important script (by intersecting duration, which is not easily obtainable form the current raw LoAF entry).

Example output:

```json
{
    "interactionTarget": "div.devsite-top-logo-row-wrapper>div.devsite-top-logo-row>devsite-appearance-selector",
    "interactionType": "pointer",
    "interactionTime": 25221.30000000447,
    "nextPaintTime": 25477.30000000447,
    "processedEventEntries": ...,
    "longAnimationFrameEntries": ...,
    "inputDelay": 32.599999994039536,
    "processingDuration": 164.20000000298023,
    "presentationDelay": 59.20000000298023,
    "loadState": "complete",
    "longestScript": {
        "entry": {
            "name": "script",
            "entryType": "script",
            "startTime": 25264.89999999851,
            "duration": 141,
            "invoker": "DEVSITE-HEADER.onclick",
            "invokerType": "event-listener",
            "windowAttribution": "self",
            "executionStart": 25264.89999999851,
            "forcedStyleAndLayoutDuration": 141,
            "pauseDuration": 0,
            "sourceURL": "https://www.gstatic.com/devrel-devsite/prod/v6bfb74446ce17cd0d3af9b93bf26e056161cb79c5a6475bd6a9c25286fcb7861/js/devsite_app_module.js",
            "sourceFunctionName": "",
            "sourceCharPosition": -1
        },
        "subpart": "processing-duration",
        "intersectingDuration": 141
    },
    "totalScriptDuration": 15,
    "totalStyleAndLayoutDuration": 156.29999999701977,
    "totalPaintDuration": 43.900000005960464,
    "totalUnattributedDuration": 40.79999999701977
}
```
