### PR TITLE
Add retry logic for GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,12 @@ jobs:
       - name: Run server
         run: npm run test:server &
       - name: Run e2e tests for chrome
-        run: npm run test:e2e -- --browsers=chrome
+        run: |
+          for i in 1 2 3; do
+            npm run test:e2e -- --browsers=chrome && break
+            echo "Retry #$i failed, retrying in 5 seconds..." >&2
+            sleep 5
+          done
   firefox-tests:
     name: Run Firefox e2e tests
     # Runs best on macos for CI as linux requires extra setup
@@ -48,7 +53,12 @@ jobs:
       - name: Run server
         run: npm run test:server &
       - name: Run e2e tests for firefox
-        run: npm run test:e2e -- --browsers=firefox
+        run: |
+          for i in 1 2 3; do
+            npm run test:e2e -- --browsers=firefox && break
+            echo "Retry #$i failed, retrying in 5 seconds..." >&2
+            sleep 5
+          done
   safari-tests:
     name: Run Safari e2e tests
     # Requires macos
@@ -63,4 +73,9 @@ jobs:
       - name: Run server
         run: npm run test:server &
       - name: Run e2e tests for safari
-        run: npm run test:e2e -- --browsers=safari
+        run: |
+          for i in 1 2 3; do
+            npm run test:e2e -- --browsers=safari && break
+            echo "Retry #$i failed, retrying in 5 seconds..." >&2
+            sleep 5
+          done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,15 +30,23 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+      - name: Set environment variable for log path
+        ## Use /tmp for beacon logging as less prone to delays
+        run: echo "LOG_PATH=/tmp/beacons.log" >> $GITHUB_ENV
       - name: Run server
         run: npm run test:server &
       - name: Run e2e tests for chrome
         run: |
           for i in 1 2 3; do
-            npm run test:e2e -- --browsers=chrome && break
+            echo "Attempt #$i"
+            if npm run test:e2e -- --browsers=chrome; then
+              exit 0
+            fi
             echo "Retry #$i failed, retrying in 5 seconds..." >&2
             sleep 5
           done
+          echo "All attempts failed."
+          exit 1
   firefox-tests:
     name: Run Firefox e2e tests
     # Runs best on macos for CI as linux requires extra setup
@@ -50,15 +58,23 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+      - name: Set environment variable for log path
+        ## Use /tmp for beacon logging as less prone to delays
+        run: echo "LOG_PATH=/tmp/beacons.log" >> $GITHUB_ENV
       - name: Run server
         run: npm run test:server &
       - name: Run e2e tests for firefox
         run: |
           for i in 1 2 3; do
-            npm run test:e2e -- --browsers=firefox && break
+            echo "Attempt #$i"
+            if npm run test:e2e -- --browsers=firefox; then
+              exit 0
+            fi
             echo "Retry #$i failed, retrying in 5 seconds..." >&2
             sleep 5
           done
+          echo "All attempts failed."
+          exit 1
   safari-tests:
     name: Run Safari e2e tests
     # Requires macos
@@ -70,12 +86,20 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+      - name: Set environment variable for log path
+        ## Use /tmp for beacon logging as less prone to delays
+        run: echo "LOG_PATH=/tmp/beacons.log" >> $GITHUB_ENV
       - name: Run server
         run: npm run test:server &
       - name: Run e2e tests for safari
         run: |
           for i in 1 2 3; do
-            npm run test:e2e -- --browsers=safari && break
-            echo "Retry #$i failed, retrying in 5 seconds..." >&2
+            echo "Attempt #$i"
+            if npm run test:e2e -- --browsers=safari; then
+              exit 0
+            fi
+            echo "Retry #$i failed" >&2
             sleep 5
           done
+          echo "All attempts failed."
+          exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,13 +36,14 @@ jobs:
       - name: Run server
         run: npm run test:server &
       - name: Run e2e tests for chrome
+        ## Retire up to 5 times as tests on GitHub Actions are flakey :-(
         run: |
-          for i in 1 2 3; do
+          for i in 1 2 3 4 5; do
             echo "Attempt #$i"
             if npm run test:e2e -- --browsers=chrome; then
               exit 0
             fi
-            echo "Retry #$i failed, retrying in 5 seconds..." >&2
+            echo "Attempt #$i failed" >&2
             sleep 5
           done
           echo "All attempts failed."
@@ -64,16 +65,17 @@ jobs:
       - name: Run server
         run: npm run test:server &
       - name: Run e2e tests for firefox
+        ## Retire up to 5 times as tests on GitHub Actions are flakey :-(
         run: |
-          for i in 1 2 3; do
+          for i in 1 2 3 4 5; do
             echo "Attempt #$i"
             if npm run test:e2e -- --browsers=firefox; then
               exit 0
             fi
-            echo "Retry #$i failed, retrying in 5 seconds..." >&2
+            echo "Attempt #$i failed" >&2
             sleep 5
           done
-          echo "All attempts failed."
+          echo "All attempts failed"
           exit 1
   safari-tests:
     name: Run Safari e2e tests
@@ -92,14 +94,15 @@ jobs:
       - name: Run server
         run: npm run test:server &
       - name: Run e2e tests for safari
+        ## Retire up to 5 times as tests on GitHub Actions are flakey :-(
         run: |
-          for i in 1 2 3; do
+          for i in 1 2 3 4 5; do
             echo "Attempt #$i"
             if npm run test:e2e -- --browsers=safari; then
               exit 0
             fi
-            echo "Retry #$i failed" >&2
+            echo "Attempt #$i failed" >&2
             sleep 5
           done
-          echo "All attempts failed."
+          echo "All attempts failed"
           exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
   chrome-tests:
     name: Run Chrome e2e tests
     # Runs best on macos for CI as linux requires extra chrome flags
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   firefox-tests:
     name: Run Firefox e2e tests
     # Runs best on macos for CI as linux requires extra setup
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
   chrome-tests:
     name: Run Chrome e2e tests
     # Runs best on macos for CI as linux requires extra chrome flags
-    runs-on: ubunutu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   firefox-tests:
     name: Run Firefox e2e tests
     # Runs best on macos for CI as linux requires extra setup
-    runs-on: ubunutu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
   chrome-tests:
     name: Run Chrome e2e tests
     # Runs best on macos for CI as linux requires extra chrome flags
-    runs-on: macos-latest
+    runs-on: ubunutu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   firefox-tests:
     name: Run Firefox e2e tests
     # Runs best on macos for CI as linux requires extra setup
-    runs-on: macos-latest
+    runs-on: ubunutu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/test/e2e/onFCP-test.js
+++ b/test/e2e/onFCP-test.js
@@ -130,7 +130,7 @@ describe('onFCP()', async function () {
   it('does not report if the document changes to hidden before the first entry', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await navigateTo('/test/fcp?invisible=1', {readyState: 'interactive'});
+    await navigateTo('/test/fcp?invisible=1', {readyState: 'complete'});
 
     await stubVisibilityChange('hidden');
     await stubVisibilityChange('visible');
@@ -211,7 +211,7 @@ describe('onFCP()', async function () {
   it('reports if the page is restored from bfcache even when the document was hidden at page load time', async function () {
     if (!browserSupportsFCP) this.skip();
 
-    await navigateTo('/test/fcp?hidden=1', {readyState: 'interactive'});
+    await navigateTo('/test/fcp?hidden=1', {readyState: 'complete'});
 
     await stubVisibilityChange('visible');
 

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -618,7 +618,7 @@ describe('onINP()', async function () {
       await beaconCountIs(1);
 
       const [inp1] = await getBeacons();
-      assert.equal(inp1.attribution.loadState, 'dom-interactive');
+      assert.match(inp1.attribution.loadState, /^(loading|dom-interactive)$/);
 
       await clearBeacons();
 

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -43,7 +43,7 @@ describe('onINP()', async function () {
   it('reports the correct value on visibility hidden after interactions (reportAllChanges === false)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await navigateTo('/test/inp?click=100', {readyState: 'interactive'});
+    await navigateTo('/test/inp?click=100', {readyState: 'complete'});
 
     const h1 = await $('h1');
     await simulateUserLikeClick(h1);
@@ -67,7 +67,7 @@ describe('onINP()', async function () {
     if (!browserSupportsINP) this.skip();
 
     await navigateTo('/test/inp?click=100&reportAllChanges=1', {
-      readyState: 'interactive',
+      readyState: 'complete',
     });
 
     const h1 = await $('h1');
@@ -89,9 +89,9 @@ describe('onINP()', async function () {
   it('reports the correct value when script is loaded late (reportAllChanges === false)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    // Don't await the `interactive` ready state because DCL is delayed until
+    // Don't await the `complete` ready state because DCL is delayed until
     // after user input.
-    await navigateTo('/test/inp?click=100&loadAfterInput=1');
+    await navigateTo('/test/inp?click=150&loadAfterInput=1');
 
     // Wait until
     await nextFrame();
@@ -117,9 +117,9 @@ describe('onINP()', async function () {
   it('reports the correct value when loaded late (reportAllChanges === true)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    // Don't await the `interactive` ready state because DCL is delayed until
+    // Don't await the `complete` ready state because DCL is delayed until
     // after user input.
-    await navigateTo('/test/inp?click=100&reportAllChanges=1&loadAfterInput=1');
+    await navigateTo('/test/inp?click=150&reportAllChanges=1&loadAfterInput=1');
 
     // Wait until
     await nextFrame();
@@ -143,7 +143,7 @@ describe('onINP()', async function () {
   it('reports the correct value on page unload after interactions (reportAllChanges === false)', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await navigateTo('/test/inp?click=100', {readyState: 'interactive'});
+    await navigateTo('/test/inp?click=100', {readyState: 'complete'});
 
     const h1 = await $('h1');
     await simulateUserLikeClick(h1);
@@ -167,7 +167,7 @@ describe('onINP()', async function () {
     if (!browserSupportsINP) this.skip();
 
     await navigateTo('/test/inp?click=100&reportAllChanges=1', {
-      readyState: 'interactive',
+      readyState: 'complete',
     });
 
     const h1 = await $('h1');
@@ -192,7 +192,7 @@ describe('onINP()', async function () {
     if (!browserSupportsINP) this.skip();
 
     await navigateTo('/test/inp?click=60&pointerdown=600', {
-      readyState: 'interactive',
+      readyState: 'complete',
     });
 
     const h1 = await $('h1');
@@ -254,7 +254,7 @@ describe('onINP()', async function () {
     if (!browserSupportsINP) this.skip();
 
     await navigateTo('/test/inp?click=60&pointerdown=600&reportAllChanges=1', {
-      readyState: 'interactive',
+      readyState: 'complete',
     });
 
     const h1 = await $('h1');
@@ -293,7 +293,7 @@ describe('onINP()', async function () {
   it('reports a new interaction after bfcache restore', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await navigateTo('/test/inp', {readyState: 'interactive'});
+    await navigateTo('/test/inp', {readyState: 'complete'});
 
     await setBlockingTime('click', 100);
 
@@ -379,7 +379,7 @@ describe('onINP()', async function () {
   it('does not report if there were no interactions', async function () {
     if (!browserSupportsINP) this.skip();
 
-    await navigateTo('/test/inp', {readyState: 'interactive'});
+    await navigateTo('/test/inp', {readyState: 'complete'});
 
     await stubVisibilityChange('hidden');
 
@@ -394,7 +394,7 @@ describe('onINP()', async function () {
     if (!browserSupportsINP) this.skip();
 
     await navigateTo('/test/inp?click=100&prerender=1', {
-      readyState: 'interactive',
+      readyState: 'complete',
     });
 
     const h1 = await $('h1');
@@ -419,7 +419,7 @@ describe('onINP()', async function () {
     if (!browserSupportsINP) this.skip();
 
     await navigateTo('/test/inp?click=100&wasDiscarded=1', {
-      readyState: 'interactive',
+      readyState: 'complete',
     });
 
     const h1 = await $('h1');
@@ -646,7 +646,7 @@ describe('onINP()', async function () {
       if (!browserSupportsINP) this.skip();
 
       await navigateTo('/test/inp?attribution=1&mouseup=100&click=50', {
-        readyState: 'interactive',
+        readyState: 'complete',
       });
 
       const h1 = await $('h1');
@@ -672,7 +672,7 @@ describe('onINP()', async function () {
       if (!browserSupportsINP) this.skip();
 
       await navigateTo('/test/inp?attribution=1&mouseup=100&click=50', {
-        readyState: 'interactive',
+        readyState: 'complete',
       });
 
       const button = await $('#reset');
@@ -700,7 +700,7 @@ describe('onINP()', async function () {
       if (!browserSupportsLoAF) this.skip();
 
       await navigateTo('/test/inp?attribution=1&pointerdown=100', {
-        readyState: 'interactive',
+        readyState: 'complete',
       });
 
       // Click on the <textarea>.

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -202,7 +202,7 @@ describe('onLCP()', async function () {
   it('does not report if the document was hidden at page load time', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await navigateTo('/test/lcp?hidden=1', {readyState: 'interactive'});
+    await navigateTo('/test/lcp?hidden=1', {readyState: 'complete'});
 
     await stubVisibilityChange('visible');
 
@@ -370,7 +370,7 @@ describe('onLCP()', async function () {
   it('reports if the page is restored from bfcache even when the document was hidden at page load time', async function () {
     if (!browserSupportsLCP) this.skip();
 
-    await navigateTo('/test/lcp?hidden=1', {readyState: 'interactive'});
+    await navigateTo('/test/lcp?hidden=1', {readyState: 'complete'});
 
     await stubVisibilityChange('visible');
 

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -260,7 +260,7 @@ describe('onLCP()', async function () {
     if (!browserSupportsLCP) this.skip();
 
     await navigateTo('/test/lcp?imgDelay=0&imgHidden=1', {
-      readyState: 'interactive',
+      readyState: 'complete',
     });
 
     // Wait for a frame to be painted.

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -266,8 +266,8 @@ describe('onLCP()', async function () {
       readyState: 'complete',
     });
 
-    // Wait for a frame to be painted.
-    await browser.executeAsync((done) => requestAnimationFrame(done));
+    // Wait a bit to ensurethe library it loaded as this test is flakey.
+    await browser.pause(1000);
 
     await stubVisibilityChange('hidden');
     await stubVisibilityChange('visible');

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -106,6 +106,9 @@ describe('onLCP()', async function () {
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
 
+    // Wait a frame to give the library a chance to load and execute.
+    await browser.executeAsync((done) => requestAnimationFrame(done));
+
     // Load a new page to trigger the hidden state.
     await navigateTo('about:blank');
 

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -266,7 +266,7 @@ describe('onLCP()', async function () {
       readyState: 'complete',
     });
 
-    // Wait a bit to ensurethe library it loaded as this test is flakey.
+    // Wait a bit to ensure the library is loaded, as this test is flakey.
     await browser.pause(1000);
 
     await stubVisibilityChange('hidden');

--- a/test/server.js
+++ b/test/server.js
@@ -18,7 +18,7 @@ import express from 'express';
 import fs from 'fs-extra';
 import nunjucks from 'nunjucks';
 
-const BEACON_FILE = 'test/beacons.log';
+const BEACON_FILE = process.env.LOG_PATH || './test/beacons.log';
 const app = express();
 
 nunjucks.configure('./test/views/', {noCache: true});

--- a/test/utils/beacons.js
+++ b/test/utils/beacons.js
@@ -16,7 +16,7 @@
 
 import fs from 'fs-extra';
 
-const BEACON_FILE = './test/beacons.log';
+const BEACON_FILE = process.env.LOG_PATH || './test/beacons.log';
 
 /**
  * @param {Object} count


### PR DESCRIPTION
Fixes #601 

We already test suite twice, but frequently this fails due to flakiness.

This PR adds:
- change to log beacons to /tmp which uses the in-memory tmpfs so should be less subject to delays.
- additional logic to the rerun the whole GitHub Action step, which should relaunch the browser as well. Note there is no native GitHub Action logic for this, so have to use an a third-party action ([such as this one](https://github.com/marketplace/actions/retry-step)), of just add a loop. I went for the latter option here.

It doesn't solve the flakiness, but at least automates the reruns I'm doing manually anyway...