### PR TITLE
Eliminate use of `?module` query string for unpkg since no longer working

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,11 @@ _**Important!** The [unpkg.com](https://unpkg.com), [jsDelivr](https://www.jsdel
 
 ```html
 <script type="module">
-  import {onCLS, onINP, onLCP} from 'https://unpkg.com/web-vitals@4/dist/web-vitals.js';
+  import {
+    onCLS,
+    onINP,
+    onLCP,
+  } from 'https://unpkg.com/web-vitals@4/dist/web-vitals.js';
 
   onCLS(console.log);
   onINP(console.log);

--- a/README.md
+++ b/README.md
@@ -122,9 +122,8 @@ _**Important!** The [unpkg.com](https://unpkg.com), [jsDelivr](https://www.jsdel
 **Load the "standard" build** _(using a module script)_
 
 ```html
-<!-- Append the `?module` param to load the module version of `web-vitals` -->
 <script type="module">
-  import {onCLS, onINP, onLCP} from 'https://unpkg.com/web-vitals@4?module';
+  import {onCLS, onINP, onLCP} from 'https://unpkg.com/web-vitals@4/dist/web-vitals.js';
 
   onCLS(console.log);
   onINP(console.log);
@@ -154,13 +153,12 @@ _**Important!** The [unpkg.com](https://unpkg.com), [jsDelivr](https://www.jsdel
 **Load the "attribution" build** _(using a module script)_
 
 ```html
-<!-- Append the `?module` param to load the module version of `web-vitals` -->
 <script type="module">
   import {
     onCLS,
     onINP,
     onLCP,
-  } from 'https://unpkg.com/web-vitals@4/dist/web-vitals.attribution.js?module';
+  } from 'https://unpkg.com/web-vitals@4/dist/web-vitals.attribution.js';
 
   onCLS(console.log);
   onINP(console.log);


### PR DESCRIPTION
I discovered today that our [`benchmark-web-vitals`](https://github.com/GoogleChromeLabs/wpp-research/blob/0184694a93dfa197ac29e4fe428e424dbd7a19b5/cli/commands/benchmark-web-vitals.mjs) command just stopped working. After disabling headless mode in Puppeteer and enabling DevTools, I discovered this in the console:

![unnamed](https://github.com/user-attachments/assets/223e5fbb-b060-42f3-a35f-ba08ae4ead7f)

So for some reason, unpkg is no longer redirecting https://unpkg.com/web-vitals@3?module to https://unpkg.com/web-vitals@3.5.2/dist/web-vitals.js but rather to https://unpkg.com/web-vitals@3.5.2/dist/web-vitals.iife.js and this breaks our integration which is using the script module version.

This PR updates the code examples (which we based our integration off of) to remove the use of `?module`.