### PR TITLE
Avoid throwing error if interaction does not exist

### DIFF
--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -238,7 +238,7 @@ export const onINP = (
   };
 
   interactionManager._onBeforeProcessingEntry = groupEntriesByRenderTime;
-  interactionManager._onAfterProcessingInteraction = saveInteractionTarget;
+  interactionManager._onAfterProcessingINPCandidate = saveInteractionTarget;
 
   const getIntersectingLoAFs = (
     start: DOMHighResTimeStamp,

--- a/src/lib/InteractionManager.ts
+++ b/src/lib/InteractionManager.ts
@@ -138,9 +138,8 @@ export class InteractionManager {
           this._longestInteractionMap.delete(interaction.id);
         }
       }
-    }
 
-    if (interaction) {
+      // Call any post-processing on the interaction
       this._onAfterProcessingINPCandidate?.(interaction!);
     }
   }

--- a/src/lib/InteractionManager.ts
+++ b/src/lib/InteractionManager.ts
@@ -58,7 +58,7 @@ export class InteractionManager {
 
   _onBeforeProcessingEntry?: (entry: PerformanceEventTiming) => void;
 
-  _onAfterProcessingInteraction?: (interaction: Interaction) => void;
+  _onAfterProcessingINPCandidate?: (interaction: Interaction) => void;
 
   _resetInteractions() {
     prevInteractionCount = getInteractionCount();
@@ -138,10 +138,10 @@ export class InteractionManager {
           this._longestInteractionMap.delete(interaction.id);
         }
       }
-    } else {
-      return;
     }
 
-    this._onAfterProcessingInteraction?.(interaction!);
+    if (interaction) {
+      this._onAfterProcessingINPCandidate?.(interaction!);
+    }
   }
 }

--- a/src/lib/InteractionManager.ts
+++ b/src/lib/InteractionManager.ts
@@ -138,6 +138,8 @@ export class InteractionManager {
           this._longestInteractionMap.delete(interaction.id);
         }
       }
+    } else {
+      return;
     }
 
     this._onAfterProcessingInteraction?.(interaction!);

--- a/src/lib/InteractionManager.ts
+++ b/src/lib/InteractionManager.ts
@@ -140,7 +140,7 @@ export class InteractionManager {
       }
 
       // Call any post-processing on the interaction
-      this._onAfterProcessingINPCandidate?.(interaction!);
+      this._onAfterProcessingINPCandidate?.(interaction);
     }
   }
 }


### PR DESCRIPTION
Fixes a bug introduced in #585.

After 10 interactions, it's possible, the next one interaction has an `interactionId` but is not longer than the smallest one.

In this case we should not run `_onAfterProcessingInteraction` (and specifically `saveInteractionTarget` which assumes an interaction will be passed).

Also includes a rename of `_onAfterProcessingInteraction` to the more accurate `_onAfterProcessingINPCandidate`