### PR TITLE
Fix flakey LCP test

### DIFF
--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -17,10 +17,12 @@
 import assert from 'assert';
 import {beaconCountIs, clearBeacons, getBeacons} from '../utils/beacons.js';
 import {browserSupportsEntry} from '../utils/browserSupportsEntry.js';
+import {firstContentfulPaint} from '../utils/firstContentfulPaint.js';
 import {imagesPainted} from '../utils/imagesPainted.js';
 import {navigateTo} from '../utils/navigateTo.js';
 import {stubForwardBack} from '../utils/stubForwardBack.js';
 import {stubVisibilityChange} from '../utils/stubVisibilityChange.js';
+import {webVitalsLoaded} from '../utils/webVitalsLoaded.js';
 
 describe('onLCP()', async function () {
   // Retry all tests in this suite up to 2 times.
@@ -263,8 +265,11 @@ describe('onLCP()', async function () {
       readyState: 'interactive',
     });
 
-    // Wait for a frame to be painted.
-    await browser.executeAsync((done) => requestAnimationFrame(done));
+    // Wait until the library is loaded and the first paint occurs to ensure
+    // that an LCP entry can be dispatched prior to the document changing to
+    // hidden.
+    await webVitalsLoaded();
+    await firstContentfulPaint();
 
     await stubVisibilityChange('hidden');
     await stubVisibilityChange('visible');

--- a/test/utils/webVitalsLoaded.js
+++ b/test/utils/webVitalsLoaded.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns a promise that resolves once the web-vitals library has been
+ * loaded via the `__testImport()` function.
+ * @return {Promise<void>}
+ */
+export function webVitalsLoaded() {
+  return browser.waitUntil(async () => {
+    const isLoaded = await browser.execute(() => self.__isWebVitalsLoaded);
+    return isLoaded === true;
+  });
+}

--- a/test/views/layout.njk
+++ b/test/views/layout.njk
@@ -237,6 +237,10 @@
         const importPromise = import(modulePath);
         self.__readyPromises.push(importPromise);
 
+        importPromise.then(() => {
+          self.__isWebVitalsLoaded = true;
+        });
+
         return await importPromise;
       };
 


### PR DESCRIPTION
This PR fixes the first issue in #601 by waiting until the library is loaded and a frame has painted (which means an LCP entry should be dispatched) before changing the visibility state in the test to hidden.