### PR TITLE
Add 103 Early Hints test

### DIFF
--- a/test/e2e/onTTFB-test.js
+++ b/test/e2e/onTTFB-test.js
@@ -400,9 +400,7 @@ describe('onTTFB()', async function () {
     });
 
     it('reports the correct value for Early Hints', async function () {
-      await navigateTo(
-        '/test/ttfb?earlyHintsDelay=50&attribution=1',
-      );
+      await navigateTo('/test/ttfb?earlyHintsDelay=50&attribution=1');
 
       const ttfb = await getTTFBBeacon();
 

--- a/test/e2e/onTTFB-test.js
+++ b/test/e2e/onTTFB-test.js
@@ -401,7 +401,6 @@ describe('onTTFB()', async function () {
 
     it('reports the correct value for Early Hints', async function () {
       await navigateTo(
-        // '/test/ttfb?responseStart=10&earlyHintsDelay=50&attribution=1',
         '/test/ttfb?earlyHintsDelay=50&attribution=1',
       );
 

--- a/test/e2e/onTTFB-test.js
+++ b/test/e2e/onTTFB-test.js
@@ -398,6 +398,35 @@ describe('onTTFB()', async function () {
       assert.strictEqual(ttfb.attribution.requestDuration, 0);
       assert.strictEqual(ttfb.attribution.navigationEntry, undefined);
     });
+
+    it('reports the correct value for Early Hints', async function () {
+      await navigateTo(
+        // '/test/ttfb?responseStart=10&earlyHintsDelay=50&attribution=1',
+        '/test/ttfb?earlyHintsDelay=50&attribution=1',
+      );
+
+      const ttfb = await getTTFBBeacon();
+
+      if ('finalResponseHeadersStart' in ttfb.attribution.navigationEntry) {
+        assert.strictEqual(
+          ttfb.value,
+          ttfb.attribution.navigationEntry.responseStart,
+        );
+        assert.strictEqual(
+          ttfb.value,
+          ttfb.attribution.navigationEntry.firstInterimResponseStart,
+        );
+        assert(
+          ttfb.value <
+            ttfb.attribution.navigationEntry.finalResponseHeadersStart,
+        );
+      } else {
+        assert.strictEqual(
+          ttfb.value,
+          ttfb.attribution.navigationEntry.responseStart,
+        );
+      }
+    });
   });
 });
 

--- a/test/server.js
+++ b/test/server.js
@@ -39,6 +39,19 @@ app.use((req, res, next) => {
   }
 });
 
+// Allow the use of a `earlyHintsDelay` query param to delay any response
+// after sending an early hints
+app.use((req, res, next) => {
+  if (req.query && req.query.earlyHintsDelay) {
+    res.writeEarlyHints({
+      'link': '</styles.css>; rel=preload; as=style',
+    });
+    setTimeout(next, req.query.earlyHintsDelay);
+  } else {
+    next();
+  }
+});
+
 // Add a "collect" endpoint to simulate analytics beacons.
 app.post('/collect', bodyParser.text(), (req, res) => {
   // Uncomment to log the metric when manually testing.


### PR DESCRIPTION
Adds a 103 Early Hint test to ensure Chrome is reporting the `firstInterimResponseStart` as TTFB value (as set in https://chromestatus.com/feature/5158830722514944). Note Chrome 115 to 132 does not report this correctly.

Originally proposed in #566 but pulling out as abandoning those other changes.
