### PR TITLE
Use `visibility-state` performance entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "yargs": "^17.7.2"
   },
   "lint-staged": {
-    "**/*.{cjs,css,html,js,json,html,md,ts,yml,yaml}": "prettier --write --ignore-path .gitignore",
-    "**/*.{js,ts}": "eslint --fix --ignore-path .gitignore"
+    "**/*.{js,ts}": "eslint --fix --ignore-path .gitignore",
+    "**/*.{cjs,css,html,js,json,html,md,ts,yml,yaml}": "prettier --write --ignore-path .gitignore"
   }
 }

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "yargs": "^17.7.2"
   },
   "lint-staged": {
-    "**/*.{js,ts}": "eslint --fix --ignore-path .gitignore",
-    "**/*.{cjs,css,html,js,json,html,md,ts,yml,yaml}": "prettier --write --ignore-path .gitignore"
+    "**/*.{cjs,css,html,js,json,html,md,ts,yml,yaml}": "prettier --write --ignore-path .gitignore",
+    "**/*.{js,ts}": "eslint --fix --ignore-path .gitignore"
   }
 }

--- a/src/lib/getVisibilityWatcher.ts
+++ b/src/lib/getVisibilityWatcher.ts
@@ -77,6 +77,9 @@ export const getVisibilityWatcher = () => {
     // a perfect heuristic, but it's the best we can do until the
     // `visibility-state` performance entry becomes available in all browsers.
     firstHiddenTime = firstVisibilityStateHiddenTime ?? initHiddenTime();
+    // We're still going to listen to for changes so we can handle things like
+    // bfcache restores and/or prerender without having to examine individual
+    // timestamps in detail.
     addChangeListeners();
 
     // Reset the time on bfcache restores.

--- a/src/lib/getVisibilityWatcher.ts
+++ b/src/lib/getVisibilityWatcher.ts
@@ -64,11 +64,12 @@ const removeChangeListeners = () => {
 export const getVisibilityWatcher = () => {
   if (firstHiddenTime < 0) {
     // Check if we have a previous hidden `visibility-state` performance entry.
-    const firstVisibilityStateHiddenTime =
-      !document.prerendering &&
-      performance
+    // prettier-ignore - Prettier and eslint disagree on this line!
+    const firstVisibilityStateHiddenTime = !document.prerendering
+      ? globalThis.performance
         .getEntriesByType('visibility-state')
-        .filter((e) => e.name === 'hidden')[0]?.startTime;
+        .filter((e) => e.name === 'hidden')[0]?.startTime
+      : undefined;
     // Prefer that, but if it's not available and the document is hidden when
     // this code runs, assume it was hidden since navigation start. This isn't
     // a perfect heuristic, but it's the best we can do until the

--- a/src/lib/getVisibilityWatcher.ts
+++ b/src/lib/getVisibilityWatcher.ts
@@ -65,6 +65,7 @@ export const getVisibilityWatcher = () => {
   if (firstHiddenTime < 0) {
     // Check if we have a previous hidden `visibility-state` performance entry.
     const firstVisibilityStateHiddenTime =
+      !document.prerendering &&
       PerformanceObserver.supportedEntryTypes.includes('visibility-state')
         ? performance
           .getEntriesByType('visibility-state')

--- a/src/lib/getVisibilityWatcher.ts
+++ b/src/lib/getVisibilityWatcher.ts
@@ -64,12 +64,14 @@ const removeChangeListeners = () => {
 export const getVisibilityWatcher = () => {
   if (firstHiddenTime < 0) {
     // Check if we have a previous hidden `visibility-state` performance entry.
-    // prettier-ignore - Prettier and eslint disagree on this line!
+    /* eslint-disable indent */
     const firstVisibilityStateHiddenTime = !document.prerendering
       ? globalThis.performance
-        .getEntriesByType('visibility-state')
-        .filter((e) => e.name === 'hidden')[0]?.startTime
+          .getEntriesByType('visibility-state')
+          .filter((e) => e.name === 'hidden')[0]?.startTime
       : undefined;
+    /* eslint-enable indent */
+
     // Prefer that, but if it's not available and the document is hidden when
     // this code runs, assume it was hidden since navigation start. This isn't
     // a perfect heuristic, but it's the best we can do until the

--- a/src/lib/getVisibilityWatcher.ts
+++ b/src/lib/getVisibilityWatcher.ts
@@ -63,11 +63,18 @@ const removeChangeListeners = () => {
 
 export const getVisibilityWatcher = () => {
   if (firstHiddenTime < 0) {
-    // If the document is hidden when this code runs, assume it was hidden
-    // since navigation start. This isn't a perfect heuristic, but it's the
-    // best we can do until an API is available to support querying past
-    // visibilityState.
-    firstHiddenTime = initHiddenTime();
+    // Check if we have a previous hidden `visibility-state` performance entry.
+    const firstVisibilityStateHiddenTime =
+      PerformanceObserver.supportedEntryTypes.includes('visibility-state')
+        ? performance
+          .getEntriesByType('visibility-state')
+          .filter((e) => e.name === 'hidden')[0]?.startTime
+        : undefined;
+    // Prefer that, but if it's not available and the document is hidden when
+    // this code runs, assume it was hidden since navigation start. This isn't
+    // a perfect heuristic, but it's the best we can do until the
+    // `visibility-state` performance entry becomes available in all browsers.
+    firstHiddenTime = firstVisibilityStateHiddenTime ?? initHiddenTime();
     addChangeListeners();
 
     // Reset the time on bfcache restores.

--- a/src/lib/getVisibilityWatcher.ts
+++ b/src/lib/getVisibilityWatcher.ts
@@ -66,11 +66,9 @@ export const getVisibilityWatcher = () => {
     // Check if we have a previous hidden `visibility-state` performance entry.
     const firstVisibilityStateHiddenTime =
       !document.prerendering &&
-      PerformanceObserver.supportedEntryTypes.includes('visibility-state')
-        ? performance
-          .getEntriesByType('visibility-state')
-          .filter((e) => e.name === 'hidden')[0]?.startTime
-        : undefined;
+      performance
+        .getEntriesByType('visibility-state')
+        .filter((e) => e.name === 'hidden')[0]?.startTime;
     // Prefer that, but if it's not available and the document is hidden when
     // this code runs, assume it was hidden since navigation start. This isn't
     // a perfect heuristic, but it's the best we can do until the

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -33,6 +33,12 @@ describe('onLCP()', async function () {
     browserSupportsLCP = await browserSupportsEntry('largest-contentful-paint');
   });
 
+  let browserSupportsVisibilityState;
+  before(async function () {
+    browserSupportsVisibilityState =
+      await browserSupportsEntry('visibility-state');
+  });
+
   beforeEach(async function () {
     await navigateTo('about:blank');
     await clearBeacons();
@@ -210,6 +216,38 @@ describe('onLCP()', async function () {
 
     // Click on the h1.
     const h1 = await $('h1');
+    await h1.click();
+
+    // Wait a bit to ensure no beacons were sent.
+    await browser.pause(1000);
+
+    const beacons = await getBeacons();
+    assert.strictEqual(beacons.length, 0);
+  });
+
+  it('does not report if the document was hidden before library loaded', async function () {
+    if (!browserSupportsLCP) this.skip();
+    if (!browserSupportsVisibilityState) this.skip();
+
+    // Don't load the library until we click
+    await navigateTo('/test/lcp?loadAfterInput=1');
+
+    // Can't mock visibility-state entries so switch to a blank tab and back
+    // To emit real entries:
+    const handle1 = await browser.getWindowHandle();
+    await browser.newWindow('https://example.com');
+    await browser.pause(500);
+    await browser.closeWindow();
+    await browser.switchToWindow(handle1);
+
+    // Click on the h1 to load the library
+    const h1 = await $('h1');
+    await h1.click();
+
+    // Wait until web-vitals is loaded
+    await webVitalsLoaded();
+
+    // Click on the h1 again not it's loaded to trigger LCP
     await h1.click();
 
     // Wait a bit to ensure no beacons were sent.

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -233,7 +233,7 @@ describe('onLCP()', async function () {
     await navigateTo('/test/lcp?loadAfterInput=1');
 
     // Can't mock visibility-state entries so switch to a blank tab and back
-    // To emit real entries:
+    // to emit real entries:
     const handle1 = await browser.getWindowHandle();
     await browser.newWindow('https://example.com');
     await browser.pause(500);


### PR DESCRIPTION
Certain metrics (LCP, FCP) should not be emitted if the page was initially loaded in a hidden state since the performance metrics are based on navigation start and paints won't happen until the page is shown.

In the past there was no API to check for the initial hidden value, so the best we could do was observe `visibilitychange` changes. However, this did not handle cases when a page was hidden initially, before the library was loaded and started monitoring for those events.

From Chrome 115 the [`VisibilityStateEntry`](https://chromestatus.com/feature/5683502144028672) was added to the Performance Timeline so we should also check that when supported to better handle this case.

Other browsers can still only depend on `visibilitychange` events and so may still report larger FCP and LCP times when the page is initially opened in a hidden state.