### PR TITLE
Fix link markdown in `docs/upgrading-to-v4.md`

### DIFF
--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -61,7 +61,7 @@ No new features were introduced into the "standard" build, outside of the breaki
 
 ### Standard and attribution builds
 
-- The `onFID()` function [has been deprecated]https://web.dev/blog/inp-cwv-launch#fid_deprecation_timeline). Developers should use `onINP()` instead ([#435](https://github.com/GoogleChrome/web-vitals/pull/435)).
+- The `onFID()` function [has been deprecated](https://web.dev/blog/inp-cwv-launch#fid_deprecation_timeline). Developers should use `onINP()` instead ([#435](https://github.com/GoogleChrome/web-vitals/pull/435)).
 - The `ReportCallback` type has been deprecated in favor of explicit callback types for each metric function ([#483](https://github.com/GoogleChrome/web-vitals/pull/483)).
 
 _All deprecated APIs will be removed in the next major version._


### PR DESCRIPTION
The link was not rendering correctly in https://github.com/GoogleChrome/web-vitals/blob/cae70b1/docs/upgrading-to-v4.md:

![Screenshot 2025-05-08 at 11 32 30 PM](https://github.com/user-attachments/assets/0029f16b-89af-4c60-9be5-81a0da155162)