### PR TITLE
Fix missing FCP and LCP for prerendered pages

### DIFF
--- a/src/lib/getVisibilityWatcher.ts
+++ b/src/lib/getVisibilityWatcher.ts
@@ -15,6 +15,7 @@
  */
 
 import {onBFCacheRestore} from './bfcache.js';
+import {getActivationStart} from './getActivationStart.js';
 
 let firstHiddenTime = -1;
 
@@ -64,11 +65,14 @@ const removeChangeListeners = () => {
 export const getVisibilityWatcher = () => {
   if (firstHiddenTime < 0) {
     // Check if we have a previous hidden `visibility-state` performance entry.
+    const activationStart = getActivationStart();
     /* eslint-disable indent */
     const firstVisibilityStateHiddenTime = !document.prerendering
       ? globalThis.performance
           .getEntriesByType('visibility-state')
-          .filter((e) => e.name === 'hidden')[0]?.startTime
+          .filter(
+            (e) => e.name === 'hidden' && e.startTime > activationStart,
+          )[0]?.startTime
       : undefined;
     /* eslint-enable indent */
 

--- a/test/e2e/onCLS-test.js
+++ b/test/e2e/onCLS-test.js
@@ -29,8 +29,12 @@ describe('onCLS()', async function () {
   this.retries(2);
 
   let browserSupportsCLS;
+  let browserSupportsPrerender;
   before(async function () {
     browserSupportsCLS = await browserSupportsEntry('layout-shift');
+    browserSupportsPrerender = await browser.execute(() => {
+      return 'onprerenderingchange' in document;
+    });
 
     // Set a standard screen size so thresholds are the same
     browser.setWindowSize(1280, 1024);
@@ -722,8 +726,18 @@ describe('onCLS()', async function () {
 
   it('reports prerender as nav type for prerender', async function () {
     if (!browserSupportsCLS) this.skip();
+    if (!browserSupportsPrerender) this.skip();
 
     await navigateTo('/test/cls?prerender=1');
+
+    await beaconCountIs(1);
+    await clearBeacons();
+
+    // Wait a bit to allow the prerender to happen
+    await browser.pause(1000);
+
+    const prerenderLink = await $('#prerender-link');
+    await prerenderLink.click();
 
     // Wait until all images are loaded and rendered, then change to hidden.
     await imagesPainted();

--- a/test/e2e/onTTFB-test.js
+++ b/test/e2e/onTTFB-test.js
@@ -58,7 +58,11 @@ describe('onTTFB()', async function () {
   // Retry all tests in this suite up to 2 times.
   this.retries(2);
 
+  let browserSupportsPrerender;
   beforeEach(async function () {
+    browserSupportsPrerender = await browser.execute(() => {
+      return 'onprerenderingchange' in document;
+    });
     // In Safari when navigating to 'about:blank' between tests the
     // Navigation Timing data is consistently negative, so the tests fail.
     if (browser.capabilities.browserName !== 'Safari') {
@@ -122,6 +126,8 @@ describe('onTTFB()', async function () {
   });
 
   it('accounts for time prerendering the page', async function () {
+    if (!browserSupportsPrerender) this.skip();
+
     await navigateTo('/test/ttfb?prerender=1');
 
     const ttfb = await getTTFBBeacon();
@@ -143,6 +149,8 @@ describe('onTTFB()', async function () {
   });
 
   it('reports the correct value when run while prerendering', async function () {
+    if (!browserSupportsPrerender) this.skip();
+
     // Use 500 so prerendering finishes before load but after the module runs.
     await navigateTo('/test/ttfb?prerender=500&imgDelay=1000');
 

--- a/test/views/cls.njk
+++ b/test/views/cls.njk
@@ -29,6 +29,7 @@
   {% endif %}
 
   <p id="p5"><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+  <p><a id="prerender-link" href="/test/cls{% if attribution %}?attribution=1{% endif %}">Prerender link</a></p>
 
   <script type="module">
     const {onCLS} = await __testImport('{{ modulePath }}');
@@ -61,4 +62,15 @@
       });
     }
   </script>
+  {% if prerender %}
+  <script type="speculationrules">
+  {
+    "prerender": [
+      {
+        "urls": ["/test/cls{% if attribution %}?attribution=1{% endif %}"]
+      }
+    ]
+  }
+  </script>
+{% endif %}
 {% endblock %}

--- a/test/views/fcp.njk
+++ b/test/views/fcp.njk
@@ -34,7 +34,7 @@
       fcp.instance = 1;
 
       // Log for easier manual testing.
-      console.log('FCP"', fcp);
+      console.log('FCP:', fcp);
 
       // Test sending the metric to an analytics endpoint.
       navigator.sendBeacon(`/collect`, JSON.stringify(__toSafeObject(fcp)));

--- a/test/views/fcp.njk
+++ b/test/views/fcp.njk
@@ -26,6 +26,7 @@
   <p>Text below the image</p>
 
   <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+  <p><a id="prerender-link" href="/test/fcp{% if attribution %}?attribution=1{% endif %}">Prerender link</a></p>
 
   <script type="module">
     const {onFCP} = await __testImport('{{ modulePath }}');
@@ -56,4 +57,15 @@
       });
     }
   </script>
+  {% if prerender %}
+  <script type="speculationrules">
+  {
+    "prerender": [
+      {
+        "urls": ["/test/fcp{% if attribution %}?attribution=1{% endif %}"]
+      }
+    ]
+  }
+  </script>
+{% endif %}
 {% endblock %}

--- a/test/views/inp.njk
+++ b/test/views/inp.njk
@@ -108,6 +108,7 @@
   </script>
 
   <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+  <p><a id="prerender-link" href="/test/inp{% if attribution %}?attribution=1{% endif %}">Prerender link</a></p>
 
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec porta orci, ac sagittis augue. Nullam orci tellus, suscipit sed magna id, mattis iaculis ex. Etiam felis lectus, accumsan eu magna lacinia, lobortis tempus lacus. Donec nulla metus, blandit eget ullamcorper in, placerat eu massa. Curabitur vitae elementum orci, ac tincidunt neque. Maecenas accumsan odio sit amet arcu elementum, non vestibulum enim finibus. Phasellus malesuada lacinia suscipit. Cras ac gravida urna. In et mauris non tellus pretium ultrices. Fusce mattis a risus at tincidunt. Donec ac fringilla magna, nec suscipit lectus. Sed risus massa, rutrum ut leo quis, tempor dapibus dui. Proin in mauris non risus maximus tincidunt quis a mauris.</p>
 
@@ -144,4 +145,15 @@
       });
     }
   </script>
+  {% if prerender %}
+  <script type="speculationrules">
+  {
+    "prerender": [
+      {
+        "urls": ["/test/inp{% if attribution %}?attribution=1{% endif %}"]
+      }
+    ]
+  }
+  </script>
+{% endif %}
 {% endblock %}

--- a/test/views/layout.njk
+++ b/test/views/layout.njk
@@ -42,7 +42,7 @@
        * @return {void}
        */
       self.__stubVisibilityChange = (visibilityState) => {
-        self.__stubVisibilityState(visibilityState)
+        self.__stubVisibilityState(visibilityState);
         document.dispatchEvent(new Event('visibilitychange'));
       }
 
@@ -74,6 +74,28 @@
        * @return {Promise<void>}
        */
       self.__stubPrerender = () => {
+
+        // We need to overload getEntriesByType to return an initial hidden
+        // state for prerender.
+        // We should also really add entries on visibiltychange, but we
+        // only use iniitial entries, so no need.
+        const originalGetEntriesByType =
+          window.performance.getEntriesByType.bind(performance);
+        window.performance.getEntriesByType = function(type) {
+          const entries = originalGetEntriesByType(type);
+          if (type === 'visibility-state' && entries.length > 0) {
+            const modifiedEntries = [...entries];
+            modifiedEntries[0] = {
+              name: 'hidden',
+              entryType: 'visibility-state',
+              startTime: 0,
+              duration: 0
+            };
+            return modifiedEntries;
+          }
+          return entries;
+        };
+
         return new Promise((resolve) => {
           const navEntry = performance.getEntriesByType('navigation')[0];
           // Only stub if the page isn't actually prerendered.
@@ -210,10 +232,6 @@
         }, true);
       }
 
-      if (params.has('prerender')) {
-        self.__stubPrerender();
-      }
-
       if (params.has('wasDiscarded')) {
         self.__stubWasDiscarded();
       }
@@ -228,6 +246,11 @@
 
       if (self.__loadAfterInput) {
         self.__readyPromises.push(self.__afterFirstInput);
+      }
+
+      if (params.has('prerender')) {
+        self.__stubPrerender();
+        self.__readyPromises.push(self.__stubPrerender);
       }
 
       // Import a module and automatically add that to the list of ready promises.

--- a/test/views/layout.njk
+++ b/test/views/layout.njk
@@ -73,58 +73,6 @@
       /**
        * @return {Promise<void>}
        */
-      self.__stubPrerender = () => {
-
-        // We need to overload getEntriesByType to return an initial hidden
-        // state for prerender.
-        // We should also really add entries on visibiltychange, but we
-        // only use iniitial entries, so no need.
-        const originalGetEntriesByType =
-          window.performance.getEntriesByType.bind(performance);
-        window.performance.getEntriesByType = function(type) {
-          const entries = originalGetEntriesByType(type);
-          if (type === 'visibility-state' && entries.length > 0) {
-            const modifiedEntries = [...entries];
-            modifiedEntries[0] = {
-              name: 'hidden',
-              entryType: 'visibility-state',
-              startTime: 0,
-              duration: 0
-            };
-            return modifiedEntries;
-          }
-          return entries;
-        };
-
-        return new Promise((resolve) => {
-          const navEntry = performance.getEntriesByType('navigation')[0];
-          // Only stub if the page isn't actually prerendered.
-          if (!(document.prerendering || navEntry.activationStart > 0)) {
-            self.__stubVisibilityState('hidden');
-            Object.defineProperty(document, 'prerendering', {
-              value: true,
-              configurable: true,
-            });
-            setTimeout(() => {
-              const time = self.performance ? performance.now() : 0;
-              const fcpEntry = performance.getEntriesByName('first-contentful-paint')[0];
-              Object.defineProperty(navEntry, 'activationStart', {
-                configurable: true,
-                enumerable: true,
-                value: Math.min(time, fcpEntry?.startTime ?? time),
-              });
-              self.__stubVisibilityChange('visible');
-              delete document.prerendering;
-              document.dispatchEvent(new Event('prerenderingchange'));
-              resolve();
-            }, Number(params.get('prerender')) || 0);
-          }
-        });
-      }
-
-      /**
-       * @return {Promise<void>}
-       */
       self.__stubWasDiscarded = () => {
         return new Promise((resolve) => {
           // Only stub if the page isn't actually discarded.
@@ -217,6 +165,7 @@
 
       self.__lazyLoad = Boolean(infer('lazyLoad'));
       self.__loadAfterInput = Boolean(infer('loadAfterInput'));
+      self.__prerender = Boolean(infer('loadAfterInput'));
 
       if (params.has('hidden')) {
         // Stub the page being loaded in the hidden state, but defer to the
@@ -246,11 +195,6 @@
 
       if (self.__loadAfterInput) {
         self.__readyPromises.push(self.__afterFirstInput);
-      }
-
-      if (params.has('prerender')) {
-        self.__stubPrerender();
-        self.__readyPromises.push(self.__stubPrerender);
       }
 
       // Import a module and automatically add that to the list of ready promises.

--- a/test/views/lcp.njk
+++ b/test/views/lcp.njk
@@ -25,6 +25,7 @@
   <p>Text below the image</p>
 
   <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+  <p><a id="prerender-link" href="/test/lcp{% if attribution %}?attribution=1{% endif %}">Prerender link</a></p>
 
   <!-- Include a tall element to ensure scrolling is possible. -->
   <div style="height: 100vh"></div>
@@ -62,4 +63,15 @@
       });
     }
   </script>
+  {% if prerender %}
+  <script type="speculationrules">
+  {
+    "prerender": [
+      {
+        "urls": ["/test/lcp{% if attribution %}?attribution=1{% endif %}"]
+      }
+    ]
+  }
+  </script>
+{% endif %}
 {% endblock %}

--- a/test/views/ttfb.njk
+++ b/test/views/ttfb.njk
@@ -23,6 +23,7 @@
   <p>Text below the image</p>
 
   <p><a id="navigate-away" href="https://example.com">Navigate away</a></p>
+  <p><a id="prerender-link" href="/test/ttfb{% if attribution %}?attribution=1{% endif %}">Prerender link</a></p>
 
   <script>
     // Set the blocking values based on query params if present.
@@ -65,4 +66,15 @@
     });
   }
 </script>
+  {% if prerender %}
+  <script type="speculationrules">
+  {
+    "prerender": [
+      {
+        "urls": ["/test/ttfb{% if attribution %}?attribution=1{% endif %}"]
+      }
+    ]
+  }
+  </script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
As noted in https://github.com/GoogleChrome/web-vitals/pull/612#issuecomment-2872294421 we're failing to log FCP and LCP since web-vitals v5.0.0 due to incorrect logic.

This wasn't flagged by our test suite as it emulates prerender and did not emulate the correct stats of `visibility-state` performance entries (which we now use as of #612 ) so all tests passed :-(

Since we implemented these tests Puppeteer has gained prerender support. So I've switched the test suite to that.