### PR TITLE
Handle CLS with no sources

### DIFF
--- a/src/attribution/onCLS.ts
+++ b/src/attribution/onCLS.ts
@@ -72,7 +72,7 @@ export const onCLS = (
   layoutShiftManager._onAfterProcessingUnexpectedShift = (
     entry: LayoutShift,
   ) => {
-    if (entry.sources.length) {
+    if (entry?.sources?.length) {
       const largestSource = getLargestLayoutShiftSource(entry.sources);
       if (largestSource) {
         const generateTargetFn = opts.generateTarget ?? getSelector;
@@ -88,7 +88,7 @@ export const onCLS = (
 
     if (metric.entries.length) {
       const largestEntry = getLargestLayoutShiftEntry(metric.entries);
-      if (largestEntry?.sources.length) {
+      if (largestEntry?.sources?.length) {
         const largestSource = getLargestLayoutShiftSource(largestEntry.sources);
         if (largestSource) {
           attribution = {


### PR DESCRIPTION
In #585 we changed this code:

```js
    if (largestEntry?.sources?.length) {
      const largestSource = getLargestLayoutShiftSource(largestEntry.sources);
```

to this:

```ts
    if (entry.sources.length) {
      const largestSource = getLargestLayoutShiftSource(entry.sources);
```

Unfortunately that removed a check for entry sources which is causing a bug (b/420907153 is the internal issue id)

I've not been able to reliable reproduce how this happens, so can't add a test for it but guessing it happens when the browser garbage collects old entries between emitting the Performance Observer entries and web-vitals processing them?

Either way this is just restoring a check that was there previously (in two places now since we split the logic).