### PR TITLE
Guard INP attribution no entries

### DIFF
--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -68,13 +68,13 @@ export interface INPAttribution {
    * be the return value of that function, falling back to the default if that
    * returns null or undefined.
    */
-  interactionTarget: string;
+  interactionTarget?: string;
   /**
    * The time when the user first interacted during the frame where the INP
    * candidate interaction occurred (if more than one interaction occurred
    * within the frame, only the first time is reported).
    */
-  interactionTime: DOMHighResTimeStamp;
+  interactionTime?: DOMHighResTimeStamp;
   /**
    * The type of interaction, based on the event type of the `event` entry
    * that corresponds to the interaction (i.e. the first `event` entry
@@ -82,7 +82,7 @@ export interface INPAttribution {
    * For "pointerdown", "pointerup", or "click" events this will be "pointer",
    * and for "keydown" or "keyup" events this will be "keyboard".
    */
-  interactionType: 'pointer' | 'keyboard';
+  interactionType?: 'pointer' | 'keyboard';
   /**
    * The best-guess timestamp of the next paint after the interaction.
    * In general, this timestamp is the same as the `startTime + duration` of
@@ -90,24 +90,24 @@ export interface INPAttribution {
    * nearest 8ms (and can be rounded down), this value is clamped to always be
    * reported after the processing times.
    */
-  nextPaintTime: DOMHighResTimeStamp;
+  nextPaintTime?: DOMHighResTimeStamp;
   /**
    * An array of Event Timing entries that were processed within the same
    * animation frame as the INP candidate interaction.
    */
-  processedEventEntries: PerformanceEventTiming[];
+  processedEventEntries?: PerformanceEventTiming[];
   /**
    * The time from when the user interacted with the page until when the
    * browser was first able to start processing event listeners for that
    * interaction. This time captures the delay before event processing can
    * begin due to the main thread being busy with other work.
    */
-  inputDelay: number;
+  inputDelay?: number;
   /**
    * The time from when the first event listener started running in response to
    * the user interaction until when all event listener processing has finished.
    */
-  processingDuration: number;
+  processingDuration?: number;
   /**
    * The time from when the browser finished processing all event listeners for
    * the user interaction until the next frame is presented on the screen and
@@ -116,14 +116,14 @@ export interface INPAttribution {
    * `IntersectionObserver` callbacks, and style/layout calculation) as well
    * as off-main-thread work (such as compositor, GPU, and raster work).
    */
-  presentationDelay: number;
+  presentationDelay?: number;
   /**
    * The loading state of the document at the time when the interaction
    * corresponding to INP occurred (see `LoadState` for details). If the
    * interaction occurred while the document was loading and executing script
    * (e.g. usually in the `dom-interactive` phase) it can result in long delays.
    */
-  loadState: LoadState;
+  loadState?: LoadState;
   /**
    * If the browser supports the Long Animation Frame API, this array will
    * include any `long-animation-frame` entries that intersect with the INP
@@ -132,7 +132,7 @@ export interface INPAttribution {
    * support the Long Animation Frame API or no `long-animation-frame` entries
    * are detected, this array will be empty.
    */
-  longAnimationFrameEntries: PerformanceLongAnimationFrameTiming[];
+  longAnimationFrameEntries?: PerformanceLongAnimationFrameTiming[];
   /**
    * Summary information about the longest script entry intersecting the INP
    * duration. Note, only script entries above 5 milliseconds are reported by
@@ -172,5 +172,5 @@ export interface INPAttribution {
  * An INP-specific version of the Metric object with attribution.
  */
 export interface INPMetricWithAttribution extends INPMetric {
-  attribution?: INPAttribution;
+  attribution: INPAttribution;
 }


### PR DESCRIPTION
Fixes #639 

INP attribution doesn't currently check if there are any `event` entries, whereas all the other metrics do.

This can result in an error when attempting to access the first entry.

This does require making each of the `attribution` fields optional (similar to CLS), but given this can only happen when it would error anyway I think that's OK without a major change.