### PR TITLE
Remove eslint-plugin-node rules from ESLint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -59,10 +59,6 @@
         "@typescript-eslint/camelcase": "off",
         "comma-dangle": ["error", "always-multiline"],
         "indent": ["error", 2],
-        "node/no-missing-import": "off",
-        "node/no-unsupported-features/es-syntax": "off",
-        "node/no-missing-require": "off",
-        "node/shebang": "off",
         "no-dupe-class-members": "off",
         "prefer-spread": "off",
         "space-before-function-paren": [


### PR DESCRIPTION
I removed unmaintained eslint-plugin-node configuration from .eslintrc.

The .eslintrc file includes several [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node) rules that are configured to "off":
- node/no-missing-import
- node/no-unsupported-features/es-syntax
- node/no-missing-require
- node/shebang

However, `eslint-plugin-node` is not installed as a dependency in this project, and the plugin is no longer maintained. The community has moved to `eslint-plugin-n` as its successor, but the plugin-derived rules are not used (configured to "off") in this project so I don't think `esling-plugin-n` should be installed for now

Since these rules are disabled, this change has no impact on linting behavior. This cleanup removes unnecessary configuration for an unmaintained package