### PR TITLE
Remove unused `@rollup/plugin-replace` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.23.6",
         "@rollup/plugin-babel": "^6.0.4",
-        "@rollup/plugin-replace": "^5.0.5",
         "@rollup/plugin-terser": "^0.4.4",
         "@typescript-eslint/eslint-plugin": "^6.16.0",
         "@typescript-eslint/parser": "^6.16.0",
@@ -3202,27 +3201,6 @@
         "@types/babel__core": {
           "optional": true
         },
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-replace": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
-      "integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "magic-string": "^0.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
         "rollup": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "@babel/core": "^7.23.6",
     "@babel/preset-env": "^7.23.6",
     "@rollup/plugin-babel": "^6.0.4",
-    "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",


### PR DESCRIPTION
## Summary
This PR proposes removing the unused `@rollup/plugin-replace` dependency.

Currently, the plugin is listed in `package.json` but it is not used in `rollup.config.js`, so removing it could benefit because:
* reduced `node_modules` size
* reduced mainteinance burden

## Potential use
Though before removing it, I'd like to discuss a use case where it could be valuable

https://github.com/GoogleChrome/web-vitals/blob/8c51520318e9e81313af688ac75f2880282f9b55/src/lib/generateUniqueID.ts#L22-L24

For example in this function, the hardcoded `v5` version can be injected dynamically from `package.json` at build time, which can avoid version hardcoding.

So my question is which approach would be preferable:
1. Remove the plugin (as proposed in this PR)
2. Keep and utilise the plugin for version injection

I'm happy to update this PR based on the preferred approach!