### PR TITLE
Use queueMicrotask() for PerformanceObserver callbacks

### DIFF
--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -44,7 +44,7 @@ export const observe = <K extends keyof PerformanceEntryMap>(
         // Delay by a microtask to workaround a bug in Safari where the
         // callback is invoked immediately, rather than in a separate task.
         // See: https://github.com/GoogleChrome/web-vitals/issues/277
-        Promise.resolve().then(() => {
+        queueMicrotask(() => {
           callback(list.getEntries() as PerformanceEntryMap[K]);
         });
       });


### PR DESCRIPTION
This PR replaces `Promise.resolve().then(){ with `queueMicrotask()` when scheduling the `PerformanceObserver` callback.

This change makes the intention of microtask queuing clear and documents the Safari workaround, and also reduces the overhead of creating unnecessary promises.

`queueMicrotask()` is part of the Baseline widely available set, so this change should not introduce any new browser compatibility issues.