### PR TITLE
Remove workaround for Firefox Bug 1965441 in FCP tests

### DIFF
--- a/test/e2e/onFCP-test.js
+++ b/test/e2e/onFCP-test.js
@@ -348,11 +348,7 @@ describe('onFCP()', async function () {
         /^(loading|dom-(interactive|content-loaded)|complete)$/,
       );
 
-      // TODO Firefox has a bug causing this to fail. Remove once fixed
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1965441
-      if (browser.capabilities.browserName !== 'firefox') {
-        assert.deepEqual(fcp.attribution.fcpEntry, fcpEntry);
-      }
+      assert.deepEqual(fcp.attribution.fcpEntry, fcpEntry);
 
       // When FCP is reported, not all values on the NavigationTiming entry
       // are finalized, so just check some keys that should be set before FCP.


### PR DESCRIPTION
Previously, Firefox had a bug where `PerformancePaintTiming.toJSON()` did not fully serialize all attributes (including those from `PaintTimingMixin`). As a result, `assert.deepEqual` failed when comparing `fcp.attribution.fcpEntry` with the native `fcpEntry`, and tests included a Firefox-specific workaround to skip this check.

This issue has been fixed in Firefox 140. `toJSON()` now returns the complete data structure, so the Firefox-specific workaround in the FCP test can be safely removed.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1965441
