### PR TITLE
update README to use LCPAttribution.target

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ function sendToGoogleAnalytics({name, delta, value, id, attribution}) {
       eventParams.debug_target = attribution.interactionTarget;
       break;
     case 'LCP':
-      eventParams.debug_target = attribution.element;
+      eventParams.debug_target = attribution.target;
       break;
   }
 


### PR DESCRIPTION
Fixes #681 

This PR fixes a deprecated property usage in README. The example code was using `attribution.element` which was renamed to `attribution.target` in v5.

according to https://github.com/GoogleChrome/web-vitals/blob/main/docs/upgrading-to-v5.md:

```
Changed LCPAttribution.element to LCPAttribution.target as part of 585 for consistency.
```