### PR TITLE
fix: ensure we clear idle callbacks in whenIdleOrHidden

### DIFF
--- a/src/lib/whenIdleOrHidden.ts
+++ b/src/lib/whenIdleOrHidden.ts
@@ -22,19 +22,25 @@ import {runOnce} from './runOnce.js';
  */
 export const whenIdleOrHidden = (cb: () => void) => {
   const rIC = globalThis.requestIdleCallback || setTimeout;
+  const cIC = globalThis.cancelIdleCallback || clearTimeout;
 
   // If the document is hidden, run the callback immediately, otherwise
   // race an idle callback with the next `visibilitychange` event.
   if (document.visibilityState === 'hidden') {
     cb();
   } else {
-    cb = runOnce(cb);
-    addEventListener('visibilitychange', cb, {once: true, capture: true});
-    rIC(() => {
-      cb();
-      // Remove the above event listener since no longer required.
-      // See: https://github.com/GoogleChrome/web-vitals/issues/622
-      removeEventListener('visibilitychange', cb, {capture: true});
+    const wrappedCb = runOnce(cb);
+
+    let idleHandle = -1;
+    const onHidden = () => {
+      cIC(idleHandle);
+      wrappedCb();
+    };
+
+    addEventListener('visibilitychange', onHidden, {once: true, capture: true});
+    idleHandle = rIC(() => {
+      removeEventListener('visibilitychange', onHidden, {capture: true});
+      wrappedCb();
     });
   }
 };


### PR DESCRIPTION
This PR fixes an issue where the visibility event listener fires before the requestIdleCallback. In this case, the rIC is not cleared up and will run.

It's a minimal fix, but this PR makes sure that whichever case runs, the other is tidied up to avoid leaving state around. This also avoids keeping the reference to the callback open longer than necessary.