### PR TITLE
Address flaky test

### DIFF
--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -959,6 +959,9 @@ describe('onLCP()', async function () {
       // Wait until all images are loaded and fully rendered.
       await imagesPainted();
 
+      // Wait until web-vitals is loaded
+      await webVitalsLoaded();
+
       // Load a new page to trigger the hidden state.
       await navigateTo('about:blank');
 


### PR DESCRIPTION
This test fails a bit cause it doesn't wait for web-vitals to load before navigating away.