### PR TITLE
Remove obsolete husky v4 config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,11 +125,6 @@
   "bugs": {
     "url": "https://github.com/GoogleChrome/web-vitals/issues"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint"
-    }
-  },
   "prettier": {
     "arrowParens": "always",
     "bracketSpacing": false,


### PR DESCRIPTION
This PR removes the obsolete husky v4 config from `package.json`
The `husky.hooks` field in `package.json` is Husky v4 syntax and has been ignored since upgrading to v9
The actual pre-commit hook is managed in `.husky/pre-commit`, so this change has no functional impact