### PR TITLE
fix: key initUnique instanceMap by class to prevent cross-class instance collisions

### DIFF
--- a/src/lib/initUnique.ts
+++ b/src/lib/initUnique.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-const instanceMap: WeakMap<object, unknown> = new WeakMap();
+const instanceMap: WeakMap<
+  new () => unknown,
+  WeakMap<object, unknown>
+> = new WeakMap();
 
 /**
  * A function that accepts and identity object and a class object and returns
@@ -22,8 +25,13 @@ const instanceMap: WeakMap<object, unknown> = new WeakMap();
  * identity object was previously used.
  */
 export function initUnique<T>(identityObj: object, ClassObj: new () => T): T {
-  if (!instanceMap.get(identityObj)) {
-    instanceMap.set(identityObj, new ClassObj());
+  let classInstances = instanceMap.get(ClassObj);
+  if (!classInstances) {
+    classInstances = new WeakMap();
+    instanceMap.set(ClassObj, classInstances);
   }
-  return instanceMap.get(identityObj)! as T;
+  if (!classInstances.get(identityObj)) {
+    classInstances.set(identityObj, new ClassObj());
+  }
+  return classInstances.get(identityObj)! as T;
 }

--- a/test/unit/initUnique-test.js
+++ b/test/unit/initUnique-test.js
@@ -1,0 +1,26 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert';
+import {initUnique} from '../../dist/modules/lib/initUnique.js';
+
+class A {}
+class B {}
+
+describe('initUnique', () => {
+  it('returns the same instance for the same class and same opts', () => {
+    const opts = {};
+    assert.strictEqual(initUnique(opts, A), initUnique(opts, A));
+  });
+
+  it('returns different instances for different classes with the same opts', () => {
+    const opts = {};
+    const a = initUnique(opts, A);
+    const b = initUnique(opts, B);
+    assert.notStrictEqual(a, b);
+    assert.ok(a instanceof A);
+    assert.ok(b instanceof B);
+  });
+
+  it('returns different instances for the same class with different opts', () => {
+    assert.notStrictEqual(initUnique({}, A), initUnique({}, A));
+  });
+});


### PR DESCRIPTION
resolves #731

## Problem
`initUnique` used only the `identityObj` (i.e. the `opts` object) as the `WeakMap` key, completely ignoring which class was requested. When the same `opts` object is passed to multiple metric functions  (for example `onCLS` followed by `onINP`)  the first stored instance is returned for every subsequent call regardless of the requested class:

```js
const opts = {reportAllChanges: true};
onCLS(sendToAnalytics, opts);
onINP(sendToAnalytics, opts); // receives a LayoutShiftManager, not InteractionManager
```

At runtime this surfaces as a `TypeError` because methods like `_estimateP98LongestInteraction` exist on `InteractionManager` but not on `LayoutShiftManager`. In minified builds the error appears as:
```
Uncaught TypeError: c2.P is not a function
```
## Fix
Replace the single-level `WeakMap<object, unknown>` with a two-level structure keyed first by class, then by identity object:
```
ClassObj → WeakMap<identityObj → instance>
```
This correctly isolates instances across different classes while preserving the intended behaviour: the attribution wrappers (`attribution/onCLS`, `attribution/onINP`) clone `opts` with `Object.assign` and pass the same clone to both themselves and the inner unattributed call,
so those two still share a single manager instance as designed.
## Notes
- Attribution builds were already unaffected by this bug. Both `attribution/onCLS.ts` and `attribution/onINP.ts` call `opts = Object.assign({}, opts)` before invoking `initUnique`, which incidentally gave each invocation a unique key. The non-attribution builds had no such protection.
- The `soft-navs` branch is particularly prone to be affected by this issue because `reportSoftNavs` gives users a strong reason to share a single `opts` object across all metric functions. On that branch the crash is deterministic: every soft navigation triggers `_resetInteractions()`, a method that exists only on `InteractionManager`.