### PR TITLE
soft-navs: Replace filter() with find()/some() for early termination

### DIFF
--- a/src/lib/softNavs.ts
+++ b/src/lib/softNavs.ts
@@ -29,10 +29,7 @@ export const getSoftNavigationEntry = (
 ): SoftNavigationEntry | undefined => {
   if (!navigationId) return;
 
-  const softNavEntry = window.performance
+  return window.performance
     .getEntriesByType('soft-navigation')
-    .filter((entry) => entry.navigationId === navigationId);
-  if (softNavEntry) return softNavEntry[0];
-
-  return;
+    .find((entry) => entry.navigationId === navigationId);
 };

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -144,7 +144,7 @@ export const onINP = (
       whenIdleOrHidden(() => {
         // Only process entries, if at least some of them have interaction ids
         // (otherwise run into lots of errors later for empty INP entries)
-        if (entries.filter((entry) => entry.interactionId).length === 0) return;
+        if (!entries.some((entry) => entry.interactionId)) return;
         for (const entry of entries) {
           if ('largestInteractionContentfulPaint' in entry) {
             handleSoftNavEntry(entry);


### PR DESCRIPTION
### summary
- Replace `filter()[0]` with `find()` in `getSoftNavigationEntry()` (`src/lib/softNavs.ts`)
- Replace `filter().length === 0` with `!some()` in `onINP` entry handler (`src/onINP.ts`)

Both changes are functionally equivalent but improve clarity and efficiency
by short-circuiting on first match instead of iterating the entire array.

### Details

`softNavs.ts`: `filter()` returns an array, so the existing `if (softNavEntry)` guard was always truthy
```js
Boolean([]) // ← returns true
``` 
the code worked only because `array[0]` is `undefined` on empty results. Using `find()` makes the intent explicit and avoids the misleading branch.

`onINP.ts`: `filter(...).length === 0` allocates an intermediate array just to check emptiness. `!some(...)` returns as soon as a matching entry is found.
