### PR TITLE
Remove unneeded modules with tsconfig `verbatimModuleSyntax`

### DIFF
--- a/src/attribution/index.ts
+++ b/src/attribution/index.ts
@@ -26,4 +26,4 @@ export {INPThresholds} from '../onINP.js';
 export {LCPThresholds} from '../onLCP.js';
 export {TTFBThresholds} from '../onTTFB.js';
 
-export * from '../types.js';
+export type * from '../types.js';

--- a/src/attribution/onCLS.ts
+++ b/src/attribution/onCLS.ts
@@ -19,7 +19,7 @@ import {getLoadState} from '../lib/getLoadState.js';
 import {getSelector} from '../lib/getSelector.js';
 import {initUnique} from '../lib/initUnique.js';
 import {onCLS as unattributedOnCLS} from '../onCLS.js';
-import {
+import type {
   CLSAttribution,
   CLSMetric,
   CLSMetricWithAttribution,

--- a/src/attribution/onFCP.ts
+++ b/src/attribution/onFCP.ts
@@ -18,7 +18,7 @@ import {getBFCacheRestoreTime} from '../lib/bfcache.js';
 import {getLoadState} from '../lib/getLoadState.js';
 import {getNavigationEntry} from '../lib/getNavigationEntry.js';
 import {onFCP as unattributedOnFCP} from '../onFCP.js';
-import {
+import type {
   FCPAttribution,
   FCPMetric,
   FCPMetricWithAttribution,

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -17,11 +17,14 @@
 import {getLoadState} from '../lib/getLoadState.js';
 import {getSelector} from '../lib/getSelector.js';
 import {initUnique} from '../lib/initUnique.js';
-import {InteractionManager, Interaction} from '../lib/InteractionManager.js';
+import {
+  InteractionManager,
+  type Interaction,
+} from '../lib/InteractionManager.js';
 import {observe} from '../lib/observe.js';
 import {whenIdleOrHidden} from '../lib/whenIdleOrHidden.js';
 import {onINP as unattributedOnINP} from '../onINP.js';
-import {
+import type {
   INPAttribution,
   INPAttributionReportOpts,
   INPMetric,

--- a/src/attribution/onLCP.ts
+++ b/src/attribution/onLCP.ts
@@ -19,7 +19,7 @@ import {getSelector} from '../lib/getSelector.js';
 import {initUnique} from '../lib/initUnique.js';
 import {LCPEntryManager} from '../lib/LCPEntryManager.js';
 import {onLCP as unattributedOnLCP} from '../onLCP.js';
-import {
+import type {
   LCPAttribution,
   LCPMetric,
   LCPMetricWithAttribution,

--- a/src/attribution/onTTFB.ts
+++ b/src/attribution/onTTFB.ts
@@ -15,7 +15,7 @@
  */
 
 import {onTTFB as unattributedOnTTFB} from '../onTTFB.js';
-import {
+import type {
   TTFBMetric,
   TTFBMetricWithAttribution,
   AttributionReportOpts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,4 @@ export {onINP, INPThresholds} from './onINP.js';
 export {onLCP, LCPThresholds} from './onLCP.js';
 export {onTTFB, TTFBThresholds} from './onTTFB.js';
 
-export * from './types.js';
+export type * from './types.js';

--- a/src/lib/bindReporter.ts
+++ b/src/lib/bindReporter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {MetricType, MetricRatingThresholds} from '../types.js';
+import type {MetricType, MetricRatingThresholds} from '../types.js';
 
 const getRating = (
   value: number,

--- a/src/lib/getLoadState.ts
+++ b/src/lib/getLoadState.ts
@@ -15,7 +15,7 @@
  */
 
 import {getNavigationEntry} from './getNavigationEntry.js';
-import {LoadState} from '../types.js';
+import type {LoadState} from '../types.js';
 
 export const getLoadState = (timestamp: number): LoadState => {
   if (document.readyState === 'loading') {

--- a/src/lib/initMetric.ts
+++ b/src/lib/initMetric.ts
@@ -18,7 +18,7 @@ import {getBFCacheRestoreTime} from './bfcache.js';
 import {generateUniqueID} from './generateUniqueID.js';
 import {getActivationStart} from './getActivationStart.js';
 import {getNavigationEntry} from './getNavigationEntry.js';
-import {MetricType} from '../types.js';
+import type {MetricType} from '../types.js';
 
 export const initMetric = <MetricName extends MetricType['name']>(
   name: MetricName,

--- a/src/onCLS.ts
+++ b/src/onCLS.ts
@@ -24,7 +24,7 @@ import {observe} from './lib/observe.js';
 import {runOnce} from './lib/runOnce.js';
 import {onFCP} from './onFCP.js';
 import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
-import {CLSMetric, MetricRatingThresholds, ReportOpts} from './types.js';
+import type {CLSMetric, MetricRatingThresholds, ReportOpts} from './types.js';
 
 /** Thresholds for CLS. See https://web.dev/articles/cls#what_is_a_good_cls_score */
 export const CLSThresholds: MetricRatingThresholds = [0.1, 0.25];

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -22,7 +22,7 @@ import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
 import {initMetric} from './lib/initMetric.js';
 import {observe} from './lib/observe.js';
 import {whenActivated} from './lib/whenActivated.js';
-import {FCPMetric, MetricRatingThresholds, ReportOpts} from './types.js';
+import type {FCPMetric, MetricRatingThresholds, ReportOpts} from './types.js';
 
 /** Thresholds for FCP. See https://web.dev/articles/fcp#what_is_a_good_fcp_score */
 export const FCPThresholds: MetricRatingThresholds = [1800, 3000];

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -25,7 +25,11 @@ import {whenActivated} from './lib/whenActivated.js';
 import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
 import {whenIdleOrHidden} from './lib/whenIdleOrHidden.js';
 
-import {INPMetric, MetricRatingThresholds, INPReportOpts} from './types.js';
+import type {
+  INPMetric,
+  MetricRatingThresholds,
+  INPReportOpts,
+} from './types.js';
 
 /** Thresholds for INP. See https://web.dev/articles/inp#what_is_a_good_inp_score */
 export const INPThresholds: MetricRatingThresholds = [200, 500];

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -26,7 +26,7 @@ import {observe} from './lib/observe.js';
 import {runOnce} from './lib/runOnce.js';
 import {whenActivated} from './lib/whenActivated.js';
 import {whenIdleOrHidden} from './lib/whenIdleOrHidden.js';
-import {LCPMetric, MetricRatingThresholds, ReportOpts} from './types.js';
+import type {LCPMetric, MetricRatingThresholds, ReportOpts} from './types.js';
 
 /** Thresholds for LCP. See https://web.dev/articles/lcp#what_is_a_good_lcp_score */
 export const LCPThresholds: MetricRatingThresholds = [2500, 4000];

--- a/src/onTTFB.ts
+++ b/src/onTTFB.ts
@@ -18,7 +18,7 @@ import {bindReporter} from './lib/bindReporter.js';
 import {initMetric} from './lib/initMetric.js';
 import {onBFCacheRestore} from './lib/bfcache.js';
 import {getNavigationEntry} from './lib/getNavigationEntry.js';
-import {MetricRatingThresholds, ReportOpts, TTFBMetric} from './types.js';
+import type {MetricRatingThresholds, ReportOpts, TTFBMetric} from './types.js';
 import {getActivationStart} from './lib/getActivationStart.js';
 import {whenActivated} from './lib/whenActivated.js';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-export * from './types/base.js';
+export type * from './types/base.js';
 
-export * from './types/cls.js';
-export * from './types/fcp.js';
-export * from './types/inp.js';
-export * from './types/lcp.js';
-export * from './types/ttfb.js';
+export type * from './types/cls.js';
+export type * from './types/fcp.js';
+export type * from './types/inp.js';
+export type * from './types/lcp.js';
+export type * from './types/ttfb.js';
 
 // --------------------------------------------------------------------------
 // Everything below is modifications to built-in modules.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "rootDir": "./src",
     "strict": true,
     "target": "esnext",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts"],
   "exclude": []


### PR DESCRIPTION
I noticed when browsing the distributed code in the npm package that the various `types` modules are actually present in build output and reachable from package.json `exports`. If you use the `type` keyword with relevant import and export statements, these statements will be erased like any other types during the build, thereby making the various `types.js` modules unreachable.

This behavior can be enforced with the `verbatimModuleSyntax` tsconfig option: https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax.

The same final result would effectively be achieved by any bundler consuming the NPM package that does treeshaking (as the types.js modules all just contain `export {};` as the only code), but this change could help other kinds of consumers, and also humans reading the code directly.