### PR TITLE
Add more robust `interactionTarget` setting for INP

### DIFF
--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -130,10 +130,19 @@ export const onINP = (
 
   const saveInteractionTarget = (interaction: Interaction) => {
     if (!interactionTargetMap.get(interaction)) {
-      const node = interaction.entries[0].target;
+      // Use find to get first selector
+      const node = interaction.entries.find((e) => e.target)?.target;
       if (node) {
         const customTarget = opts.generateTarget?.(node) ?? getSelector(node);
         interactionTargetMap.set(interaction, customTarget);
+      } else {
+        // Fall back to targetSelector
+        const selector = interaction.entries.find(
+          (e) => e.targetSelector,
+        )?.targetSelector;
+        if (selector) {
+          interactionTargetMap.set(interaction, selector);
+        }
       }
     }
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ declare global {
   interface PerformanceEventTiming extends PerformanceEntry {
     duration: DOMHighResTimeStamp;
     readonly interactionId: number;
+    readonly targetSelector: string;
   }
 
   // https://wicg.github.io/layout-instability/#sec-layout-shift-attribution


### PR DESCRIPTION
Chrome 148 made it so we see `null` targets in Event Timing more often.

In particular I'm seeing this for `first-input`,  `pointerdown`, and `pointerup` events. It is showing for the equivalent `click` events but currently the library does not filter to those and assumes the first interaction entry will have it.

This adds `find` method to look for the first non-null entry.

It also adds a fallback for the upcoming `targetSelector` value: [chromestatus](https://chromestatus.com/feature/5143499213242368) and [spec PR](https://github.com/w3c/event-timing/pull/160)