### PR TITLE
Prep changelog for v.5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### v5.3.0 (2026-05-28)
+
+- Remove `getFirstHiddenTimePolyfill`
+  ([#729](https://github.com/GoogleChrome/web-vitals/pull/729))
+- Fixed issue where the same configuration object to multiple metric functions can result in errors
+  ([#731](https://github.com/GoogleChrome/web-vitals/pull/731))
+- Add more robust `interactionTarget` setting for INP
+  ([#744](https://github.com/GoogleChrome/web-vitals/pull/744))
+
 ### v5.2.0 (2026-03-25)
 
 - Replace `filter()[0]` with `find()` for better performance ([#658](https://github.com/GoogleChrome/web-vitals/pull/658))


### PR DESCRIPTION
The most important change here is #744 since Chrome 148 has increased the number of `null` targets shown by Event Timing.

That PR also allows for the fallback to `targetSelector` (not released yet in Chrome but this bug might increase the priority of that).