### PR TITLE
Fix getSelector to not throw

### DIFF
--- a/src/lib/getSelector.ts
+++ b/src/lib/getSelector.ts
@@ -27,7 +27,7 @@ export const getSelector = (node: Node | null) => {
   let sel = '';
 
   try {
-    while (node?.nodeType === 1) {
+    while (node?.nodeType !== 9) {
       const el: Element = node as Element;
       const part = el.id
         ? '#' + el.id

--- a/src/lib/getSelector.ts
+++ b/src/lib/getSelector.ts
@@ -27,7 +27,7 @@ export const getSelector = (node: Node | null) => {
   let sel = '';
 
   try {
-    while (node?.nodeType !== 9) {
+    while (node?.nodeType === 1) {
       const el: Element = node as Element;
       const part = el.id
         ? '#' + el.id

--- a/src/lib/getSelector.ts
+++ b/src/lib/getSelector.ts
@@ -31,7 +31,7 @@ export const getSelector = (node: Node | null) => {
       const el: Element = node as Element;
       const part = el.id
         ? '#' + el.id
-        : [getName(el), ...Array.from(el.classList).sort()].join('.');
+        : [getName(el), ...Array.from(el.classList ?? []).sort()].join('.');
       if (sel.length + part.length > MAX_LEN - 1) {
         return sel || part;
       }


### PR DESCRIPTION
Only elements have class lists, apparently, so you need to actually check for if the node type is of element, not if it's not of type document.

I'm unsure if this is actually the source code that's included in Google Chrome, in which case it's enabled forcefully by default with no option of disabling. And so, if we have any exceptions, even if we catch them, it breaks the break on caught exceptions in DevTools, which breaks that feature for every website on the internet. In which case, Web Vitals needs to never have any exceptions, even if they're caught, ever.

However, this might not even be the code that's included in Google Chrome, in which case it doesn't matter. 