### PR TITLE
Fix flakey tests

### DIFF
--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -386,7 +386,7 @@ export const onINP = (
     const firstEntry = metric.entries[0];
     const group = entryToEntriesGroupMap.get(firstEntry)!;
 
-    const processingStart = firstEntry.processingStart;
+    const processingStart = group.processingStart;
 
     // Due to the fact that durations can be rounded down to the nearest 8ms,
     // we have to clamp `nextPaintTime` so it doesn't appear to occur before
@@ -396,7 +396,6 @@ export const onINP = (
       firstEntry.startTime + firstEntry.duration,
       processingStart,
     );
-
     // For the purposes of attribution, clamp `processingEnd` to `nextPaintTime`,
     // so processing is never reported as taking longer than INP (which can
     // happen via the web APIs in the case of sync modals, e.g. `alert()`).

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -336,7 +336,7 @@ describe('onINP()', async function () {
     await beaconCountIs(1);
 
     const [inp3] = await getBeacons();
-    assert(inp3.value >= 100); // 2nd-highest pointerdown blocking time.
+    assert(inp3.value >= 100 - ROUNDING_ERROR); // 2nd-highest blocking time.
     assert(inp3.value < inp2.value); // Should have gone down.
     assert(allEntriesPresentTogether(inp3.entries));
     assert.strictEqual(inp3.rating, 'good');
@@ -381,7 +381,7 @@ describe('onINP()', async function () {
     assert(inp1.value >= 600); // Initial pointerdown blocking time.
     assert(inp2.value >= 400); // Initial pointerdown blocking time.
     assert(inp2.value < inp1.value); // Should have gone down.
-    assert(inp3.value >= 100); // 2nd-highest pointerdown blocking time.
+    assert(inp3.value >= 100 - ROUNDING_ERROR); // 2nd-highest blocking time.
     assert(inp3.value < inp2.value); // Should have gone down.
     assert(allEntriesPresentTogether(inp1.entries));
     assert(allEntriesPresentTogether(inp2.entries));
@@ -620,7 +620,7 @@ describe('onINP()', async function () {
 
     const [inp2_1] = await getBeacons({instance: 2});
 
-    assert(inp2_1.value > 100 - 8);
+    assert(inp2_1.value > 100 - ROUNDING_ERROR);
     assert(inp2_1.id.match(/^v5-\d+-\d+$/));
     assert.strictEqual(inp2_1.name, 'INP');
     assert.strictEqual(inp2_1.value, inp2_1.delta);
@@ -874,19 +874,19 @@ describe('onINP()', async function () {
       assertIsCloseTo(
         inp2.attribution.interactionTime + inp2.attribution.inputDelay,
         sortedEntries2[0].processingStart,
-        1,
+        ROUNDING_ERROR,
       );
       assertIsCloseTo(
         inp2.attribution.interactionTime +
           inp2.attribution.inputDelay +
           inp2.attribution.processingDuration,
         sortedEntries2.at(-1).processingEnd,
-        1,
+        ROUNDING_ERROR,
       );
       assertIsCloseTo(
         inp2.attribution.nextPaintTime - inp2.attribution.presentationDelay,
         sortedEntries2.at(-1).processingEnd,
-        1,
+        ROUNDING_ERROR,
       );
     });
 


### PR DESCRIPTION
Firefox rounds event timing to nearest 8ms. We check for ROUNDING_ERROR in many tests but not all.

It also seems to emit event timing out of order sometimes so don't assume the first entry is the processingStart and instead use the group one.