### PR TITLE
Cap RequestIdleCallback to 1 second to ensure metrics report even when busy

### DIFF
--- a/src/lib/whenIdleOrHidden.ts
+++ b/src/lib/whenIdleOrHidden.ts
@@ -29,7 +29,12 @@ export const whenIdleOrHidden = (cb: () => void) => {
     }
     return setTimeout(callback);
   };
-  const cIC = globalThis.cancelIdleCallback || clearTimeout;
+  const cIC = (ref: number | ReturnType<typeof setTimeout>) => {
+    if ('requestIdleCallback' in globalThis && typeof ref === 'number') {
+      return globalThis.cancelIdleCallback(ref);
+    }
+    return clearTimeout(ref);
+  };
 
   // If the document is hidden, run the callback immediately, otherwise
   // race an idle callback with the next `visibilitychange` event.
@@ -38,7 +43,7 @@ export const whenIdleOrHidden = (cb: () => void) => {
   } else {
     const wrappedCb = runOnce(cb);
 
-    let idleHandle = -1;
+    let idleHandle: number | ReturnType<typeof setTimeout> = -1;
     const onHidden = () => {
       cIC(idleHandle);
       wrappedCb();

--- a/src/lib/whenIdleOrHidden.ts
+++ b/src/lib/whenIdleOrHidden.ts
@@ -23,18 +23,13 @@ import {runOnce} from './runOnce.js';
  * https://github.com/GoogleChrome/web-vitals/issues/754
  */
 export const whenIdleOrHidden = (cb: () => void) => {
-  const rIC = (callback: () => void) => {
-    if ('requestIdleCallback' in globalThis) {
-      return globalThis.requestIdleCallback(callback, {timeout: 1000});
-    }
-    return setTimeout(callback);
-  };
-  const cIC = (ref: number | ReturnType<typeof setTimeout>) => {
-    if ('requestIdleCallback' in globalThis && typeof ref === 'number') {
-      return globalThis.cancelIdleCallback(ref);
-    }
-    return clearTimeout(ref);
-  };
+  // Cap the requestIdleCallback to 1 sec for very busy apps
+  // https://github.com/GoogleChrome/web-vitals/issues/754
+  // If not using rIC, then the setTimeout timeout should be 0
+  const timeout = 'requestIdleCallback' in globalThis ? 1000 : 0;
+
+  const rIC = globalThis.requestIdleCallback || setTimeout;
+  const cIC = globalThis.cancelIdleCallback || clearTimeout;
 
   // If the document is hidden, run the callback immediately, otherwise
   // race an idle callback with the next `visibilitychange` event.
@@ -43,16 +38,19 @@ export const whenIdleOrHidden = (cb: () => void) => {
   } else {
     const wrappedCb = runOnce(cb);
 
-    let idleHandle: number | ReturnType<typeof setTimeout> = -1;
+    let idleHandle = -1;
     const onHidden = () => {
       cIC(idleHandle);
       wrappedCb();
     };
 
     addEventListener('visibilitychange', onHidden, {once: true, capture: true});
-    idleHandle = rIC(() => {
-      removeEventListener('visibilitychange', onHidden, {capture: true});
-      wrappedCb();
-    });
+    idleHandle = rIC(
+      () => {
+        removeEventListener('visibilitychange', onHidden, {capture: true});
+        wrappedCb();
+      },
+      {timeout: timeout},
+    );
   }
 };

--- a/src/lib/whenIdleOrHidden.ts
+++ b/src/lib/whenIdleOrHidden.ts
@@ -19,9 +19,16 @@ import {runOnce} from './runOnce.js';
 /**
  * Runs the passed callback during the next idle period, or immediately
  * if the browser's visibility state is (or becomes) hidden.
+ * Cap the requestIdleCallback for very busy apps
+ * https://github.com/GoogleChrome/web-vitals/issues/754
  */
 export const whenIdleOrHidden = (cb: () => void) => {
-  const rIC = globalThis.requestIdleCallback || setTimeout;
+  const rIC = (callback: IdleRequestCallback) => {
+    if ('requestIdleCallback' in globalThis) {
+      return globalThis.requestIdleCallback(callback, {timeout: 1000});
+    }
+    return setTimeout(callback);
+  };
   const cIC = globalThis.cancelIdleCallback || clearTimeout;
 
   // If the document is hidden, run the callback immediately, otherwise

--- a/src/lib/whenIdleOrHidden.ts
+++ b/src/lib/whenIdleOrHidden.ts
@@ -23,7 +23,7 @@ import {runOnce} from './runOnce.js';
  * https://github.com/GoogleChrome/web-vitals/issues/754
  */
 export const whenIdleOrHidden = (cb: () => void) => {
-  const rIC = (callback: IdleRequestCallback) => {
+  const rIC = (callback: () => void) => {
     if ('requestIdleCallback' in globalThis) {
       return globalThis.requestIdleCallback(callback, {timeout: 1000});
     }

--- a/src/lib/whenIdleOrHidden.ts
+++ b/src/lib/whenIdleOrHidden.ts
@@ -19,8 +19,6 @@ import {runOnce} from './runOnce.js';
 /**
  * Runs the passed callback during the next idle period, or immediately
  * if the browser's visibility state is (or becomes) hidden.
- * Cap the requestIdleCallback for very busy apps
- * https://github.com/GoogleChrome/web-vitals/issues/754
  */
 export const whenIdleOrHidden = (cb: () => void) => {
   // Cap the requestIdleCallback to 1 sec for very busy apps


### PR DESCRIPTION
Fixes #754 