### PR TITLE
Fix INP attribution across soft navigations and resolve dummy metric attribution crash

### DIFF
--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -392,32 +392,32 @@ export const onINP = (
       (metric.navigationType === 'soft-navigation' ||
         metric.navigationType === 'back-forward-cache')
     ) {
-      const navStartTime = metric.navigationStartTime;
-      if (navStartTime) {
-        // For simplicity make some assumptions for values we can't get
-        // to avoid undefined/null values which would be unexpected.
-        // - Assume interactionType as pointer as the most common
-        // - Assume interactionTime of nav start time
-        // - Assume nextPaintTime as interactionTime + length
-        const attribution: INPAttribution = {
-          interactionTarget: '',
-          interactionType: 'pointer',
-          interactionTime: navStartTime,
-          nextPaintTime: navStartTime + metric.value,
-          processedEventEntries: [],
-          longAnimationFrameEntries: [],
-          inputDelay: 0,
-          processingDuration: 0,
-          presentationDelay: metric.value,
-          loadState: getLoadState(navStartTime),
-          longestScript: undefined,
-          totalScriptDuration: undefined,
-          totalStyleAndLayoutDuration: undefined,
-          totalPaintDuration: undefined,
-          totalUnattributedDuration: undefined,
-        };
-        return Object.assign(metric, {attribution});
-      }
+      // A hard-navigation metric carried into a bfcache restore has a
+      // `navigationStartTime` of 0, so default to 0 if not set.
+      const navStartTime = metric.navigationStartTime || 0;
+      // For simplicity make some assumptions for values we can't get
+      // to avoid undefined/null values which would be unexpected.
+      // - Assume interactionType as pointer as the most common
+      // - Assume interactionTime of nav start time
+      // - Assume nextPaintTime as interactionTime + length
+      const attribution: INPAttribution = {
+        interactionTarget: '',
+        interactionType: 'pointer',
+        interactionTime: navStartTime,
+        nextPaintTime: navStartTime + metric.value,
+        processedEventEntries: [],
+        longAnimationFrameEntries: [],
+        inputDelay: 0,
+        processingDuration: 0,
+        presentationDelay: metric.value,
+        loadState: getLoadState(navStartTime),
+        longestScript: undefined,
+        totalScriptDuration: undefined,
+        totalStyleAndLayoutDuration: undefined,
+        totalPaintDuration: undefined,
+        totalUnattributedDuration: undefined,
+      };
+      return Object.assign(metric, {attribution});
     }
 
     const firstEntry = metric.entries[0];

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -138,7 +138,10 @@ export const onINP = (
     };
 
     const handleSoftNavEntry = (entry: PerformanceSoftNavigation) => {
-      handleEntries(po?.takeRecords() as INPMetric['entries']);
+      // Flush any pending entries into the current (old) navigation's metric
+      // synchronously, so they're reported against that navigation before the
+      // metric is reported and reset below.
+      processEntries(po?.takeRecords() as INPMetric['entries']);
       updateINPMetric();
       report(true);
       initNewINPMetric(
@@ -150,29 +153,33 @@ export const onINP = (
       );
     };
 
+    const processEntries = (
+      entries: (PerformanceEventTiming | PerformanceSoftNavigation)[],
+    ) => {
+      // Only process entries, if at least some of them have interaction ids
+      // (otherwise run into lots of errors later for empty INP entries).
+      if (!entries.some((entry) => entry.interactionId)) return;
+      for (const entry of entries) {
+        if (entry.entryType === 'soft-navigation') {
+          handleSoftNavEntry(entry as PerformanceSoftNavigation);
+          continue;
+        }
+        interactionManager._processEntry(entry as PerformanceEventTiming);
+      }
+
+      updateINPMetric();
+    };
+
     const handleEntries = (
       entries: (PerformanceEventTiming | PerformanceSoftNavigation)[],
     ) => {
-      // Queue the `handleEntries()` callback in the next idle task.
+      // Queue the `processEntries()` call in the next idle task.
       // This is needed to increase the chances that all event entries that
       // occurred between the user interaction and the next paint
       // have been dispatched. Note: there is currently an experiment
       // running in Chrome (EventTimingKeypressAndCompositionInteractionId)
       // 123+ that if rolled out fully may make this no longer necessary.
-      whenIdleOrHidden(() => {
-        // Only process entries, if at least some of them have interaction ids
-        // (otherwise run into lots of errors later for empty INP entries)
-        if (!entries.some((entry) => entry.interactionId)) return;
-        for (const entry of entries) {
-          if (entry.entryType === 'soft-navigation') {
-            handleSoftNavEntry(entry as PerformanceSoftNavigation);
-            continue;
-          }
-          interactionManager._processEntry(entry as PerformanceEventTiming);
-        }
-
-        updateINPMetric();
-      });
+      whenIdleOrHidden(() => processEntries(entries));
     };
 
     const types = ['event', 'first-input'] as (


### PR DESCRIPTION
This PR resolves two distinct issues in the INP measurement and attribution logic on the `soft-navs` branch:

1. Pending interactions prior to a soft navigation were incorrectly processed *after* metric reset, causing incorrect attribution across navigations.
2. Attribution threw a `TypeError` when handling dummy metrics (e.g., after bfcache restores or soft navigations with sub-16ms interactions) where `navigationStartTime` is `0`.

---

## Issue 1: Pending interaction flush was deferred past soft navigation metric reset

### Symptom
When a soft navigation occurs, interaction entries from the preceding navigation were being assigned to the *new* soft navigation metric instead of the old navigation metric. As a result, the old navigation's INP was under-reported, and the soft navigation's INP was artificially inflated.

### Root Cause
When a soft navigation entry was observed, `handleSoftNavEntry` attempted to flush pending entries buffered in the `PerformanceObserver` via `handleEntries(po?.takeRecords())`. However, `handleEntries` wrapped entry processing inside `whenIdleOrHidden()`, which defers execution until an idle period.

Immediately after calling `handleEntries()`, `handleSoftNavEntry` executed synchronously to:
1. Report the old navigation's metric (`report(true)`).
2. Invoke `initNewINPMetric()`, which calls `interactionManager._resetInteractions()` and re-initializes the metric object for the soft navigation.

When the deferred `whenIdleOrHidden` callback eventually executed, the flushed entries were processed into the newly reset `InteractionManager`, causing the old navigation's interactions to land in the soft navigation's metric.

### Fix
- Separated entry processing logic into a synchronous function, `processEntries(entries)`.
- Updated `handleSoftNavEntry` to invoke `processEntries(po?.takeRecords())` synchronously before calling `report(true)` and `initNewINPMetric()`.
- Refactored `handleEntries` to delegate to `whenIdleOrHidden(() => processEntries(entries))`.

> **Note on batch guard:** `processEntries` retains the check `if (!entries.some((entry) => entry.interactionId)) return;`. This is safe because both `first-input` and `soft-navigation` entries are required to carry an `interactionId` per the [Event Timing](https://w3c.github.io/event-timing/#sec-performance-event-timing) and [Soft Navigations](https://wicg.github.io/soft-navigations/#sec-pe-extension) specifications.

---

## Issue 2: Attribution crash (`TypeError`) on dummy INP metrics with zero `navigationStartTime`

### Symptom
A soft-navigation or bfcache-restore metric with sub-16ms interactions (which produces an empty `entries` array) could throw a `TypeError: Cannot read properties of undefined` during attribution computation.

### Root Cause
When a metric has no matching event timing entries (e.g., when all interactions are under 16ms), `InteractionManager._estimateP98LongestInteraction` generates a synthetic dummy metric (`{ _latency: 8, entries: [] }`).

In `src/attribution/onINP.ts`, the dummy metric handling checked:
```ts
if (metric.entries.length === 0 && (metric.navigationType === 'soft-navigation' || metric.navigationType === 'back-forward-cache')) {
  const navStartTime = metric.navigationStartTime;
  if (navStartTime) {
    // Return synthetic attribution...
  }
}
```
For initial hard navigations or bfcache restores, `navigationStartTime` is `0`. Because `0` is falsy, `if (navStartTime)` evaluated to `false`. Execution fell through the guard and attempted to access `metric.entries[0]`, resulting in `entryToEntriesGroupMap.get(undefined)!` and raising a `TypeError`.

### Fix
Removed the `if (navStartTime)` guard and defaulted `navStartTime` to `0`:
```ts
const navStartTime = metric.navigationStartTime || 0;
```
Synthetic attribution is now consistently constructed and returned for all empty-entries soft-navigation and bfcache-restore metrics, preventing out-of-bounds access on `metric.entries[0]`.
