### PR TITLE
Fix attribution and navigationId issues in soft-navigation support

### DIFF
--- a/src/attribution/onFCP.ts
+++ b/src/attribution/onFCP.ts
@@ -43,7 +43,6 @@ export const onFCP = (
   }
 
   const attributeFCP = (metric: FCPMetric): FCPMetricWithAttribution => {
-    const hardNavId = getNavigationEntry()?.navigationId || 0;
     // Use a default object if no other attribution has been set.
     let attribution: FCPAttribution = {
       timeToFirstByte: 0,
@@ -51,7 +50,7 @@ export const onFCP = (
       loadState: getLoadState(getBFCacheRestoreTime()),
     };
 
-    if (!metric.navigationId || metric.navigationId === hardNavId) {
+    if (metric.navigationType !== 'soft-navigation') {
       if (metric.entries.length) {
         const navigationEntry = getNavigationEntry();
         const fcpEntry = metric.entries.at(-1);

--- a/src/attribution/onLCP.ts
+++ b/src/attribution/onLCP.ts
@@ -70,7 +70,6 @@ export const onLCP = (
   };
 
   const attributeLCP = (metric: LCPMetric): LCPMetricWithAttribution => {
-    const hardNavId = getNavigationEntry()?.navigationId || 0;
     // Use a default object if no other attribution has been set.
     let attribution: LCPAttribution = {
       timeToFirstByte: 0,
@@ -104,16 +103,10 @@ export const onLCP = (
       let activationStart = 0;
       let responseStart = 0;
 
-      if (!metric.navigationId || metric.navigationId === hardNavId) {
+      if (metric.navigationType !== 'soft-navigation') {
         navigationEntry = getNavigationEntry();
-        activationStart =
-          navigationEntry && navigationEntry.activationStart
-            ? navigationEntry.activationStart
-            : 0;
-        responseStart =
-          navigationEntry && navigationEntry.responseStart
-            ? navigationEntry.responseStart
-            : 0;
+        activationStart = navigationEntry?.activationStart ?? 0;
+        responseStart = navigationEntry?.responseStart ?? 0;
       } else {
         // Set activationStart to the navigation start time
         activationStart = metric.navigationStartTime || 0;
@@ -140,7 +133,7 @@ export const onLCP = (
           // Cap at LCP time (videos continue downloading after LCP for example)
           metric.value,
           Math.max(
-            lcpRequestStart - activationStart,
+            lcpRequestStart,
             lcpResourceEntry
               ? lcpResourceEntry.responseEnd - activationStart
               : 0,

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -66,7 +66,7 @@ export const onFCP = (
             // after the FCP, this time should be clamped at 0.
             metric.value = Math.max(entry.startTime - getActivationStart(), 0);
             metric.entries.push(entry);
-            metric.navigationId = entry.navigationId || 0;
+            metric.navigationId = entry.navigationId || metric.navigationId;
             // FCP should only be reported once so can report right away
             report(true);
           }


### PR DESCRIPTION
This PR addresses three distinct issues in the soft-navigation and attribution logic: correcting a double-subtraction of `activationStart` in LCP attribution, preventing stale soft-navigation attribution after back-forward cache (bfcache) restores in FCP and LCP, and preserving the initial `navigationId` for FCP when paint entries omit `navigationId`.

---

## 1. Fix double-subtraction of `activationStart` in LCP attribution

### Problem
In `src/attribution/onLCP.ts`, `lcpRequestStart` is calculated as an activation-relative time:

```ts
const lcpRequestStart = Math.max(
  ttfb,
  lcpResourceEntry
    ? (lcpResourceEntry.requestStart || lcpResourceEntry.startTime) - activationStart
    : 0,
);
```

Since `ttfb` is `Math.max(0, responseStart - activationStart)`, `lcpRequestStart` is already relative to `activationStart`. However, `lcpResponseEnd` subtracted `activationStart` from `lcpRequestStart` a second time:

```ts
const lcpResponseEnd = Math.min(
  metric.value,
  Math.max(
    lcpRequestStart - activationStart, // bug: activationStart subtracted twice
    lcpResourceEntry ? lcpResourceEntry.responseEnd - activationStart : 0,
    0,
  ),
);
```

On prerendered pages (where `activationStart > 0`) with element-only LCPs (or resource entries starting early), `lcpRequestStart - activationStart` yielded a negative number, pulling `lcpResponseEnd` down to `0`. This resulted in negative `resourceLoadDuration` (`lcpResponseEnd - lcpRequestStart`) and artificially inflated `elementRenderDelay`.

### Fix
Use `lcpRequestStart` directly in the `lcpResponseEnd` calculation without subtracting `activationStart` again:

```ts
const lcpResponseEnd = Math.min(
  metric.value,
  Math.max(
    lcpRequestStart,
    lcpResourceEntry ? lcpResourceEntry.responseEnd - activationStart : 0,
    0,
  ),
);
```

Additionally, simplified `activationStart` and `responseStart` extractions using optional chaining and nullish coalescing (`navigationEntry?.activationStart ?? 0` and `navigationEntry?.responseStart ?? 0`).

---

## 2. Prevent stale soft-navigation attribution for FCP and LCP after bfcache restores

### Problem
In `src/attribution/onFCP.ts` and `src/attribution/onLCP.ts`, the decision to take the hard-navigation branch vs. the soft-navigation branch was made by checking whether `metric.navigationId` matched the initial navigation ID (`hardNavId`):

```ts
const hardNavId = getNavigationEntry()?.navigationId || 0;
if (!metric.navigationId || metric.navigationId === hardNavId) {
  // hard-nav branch
} else {
  // soft-nav lookup
}
```

When a bfcache restore occurs following a soft navigation, `onBFCacheRestore` generates a metric with `navigationType = 'back-forward-cache'` while retaining the `navigationId` of the prior soft navigation. Because `metric.navigationId` differed from `hardNavId`, the metric incorrectly took the soft-navigation branch and was attributed against a stale soft-navigation entry.

### Fix
Branch directly on `metric.navigationType` rather than comparing navigation IDs:

```ts
if (metric.navigationType !== 'soft-navigation') {
  // hard-nav / default attribution branch
} else {
  // soft-navigation map lookup
}
```

This change is applied to both `src/attribution/onFCP.ts` and `src/attribution/onLCP.ts`. Metrics resulting from bfcache restores (`navigationType === 'back-forward-cache'`) now enter the hard-navigation branch, returning default attribution objects as intended. The unused `hardNavId` variables have been removed.

---

## 3. Preserve FCP `navigationId` when paint entries omit it

### Problem
In `src/onFCP.ts`, `handleEntries` previously executed:

```ts
metric.navigationId = entry.navigationId || 0;
```

In browsers without soft-navigations support (or for standard `first-contentful-paint` entries that do not carry a `navigationId`), `entry.navigationId` is `undefined`. This unconditionally reset `metric.navigationId` to `0`, clobbering the valid ID assigned during `initMetric('FCP')`.

### Fix
Preserve the existing `metric.navigationId` if `entry.navigationId` is falsy:

```ts
metric.navigationId = entry.navigationId || metric.navigationId;
```

---

## Summary of Changes

- **`src/attribution/onLCP.ts`**:
  - Removed double-subtraction of `activationStart` in `lcpResponseEnd` calculation.
  - Replaced `!metric.navigationId || metric.navigationId === hardNavId` check with `metric.navigationType !== 'soft-navigation'`.
  - Cleaned up navigation entry property lookups using optional chaining.

- **`src/attribution/onFCP.ts`**:
  - Replaced `!metric.navigationId || metric.navigationId === hardNavId` check with `metric.navigationType !== 'soft-navigation'`.

- **`src/onFCP.ts`**:
  - Updated `metric.navigationId` assignment to fall back to `metric.navigationId` instead of `0`.
