### PR TITLE
Fix LCP finalization races and event listener leaks

### DIFF
--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -51,15 +51,18 @@ export const onLCP = (
   onReport: (metric: LCPMetric) => void,
   opts: ReportOpts = {},
 ) => {
-  // As InteractionContentfulPaint entries used by soft navs can emit after
-  // LCP is finalized, we need a flag to know to ignore them.
-  let isFinalized = false;
   const softNavsEnabled = checkSoftNavsEnabled(opts);
 
   whenActivated(() => {
     let visibilityWatcher = getVisibilityWatcher();
     let metric = initMetric('LCP');
     let report: ReturnType<typeof bindReporter>;
+
+    const finalizedMetrics = new WeakSet<Metric>();
+    const isFinalized = (m: Metric) => finalizedMetrics.has(m);
+    const markFinalized = (m: Metric) => {
+      finalizedMetrics.add(m);
+    };
 
     const lcpEntryManager = initUnique(opts, LCPEntryManager);
 
@@ -72,7 +75,7 @@ export const onLCP = (
     ) => {
       metric = initMetric(
         'LCP',
-        0,
+        -1,
         interactionId,
         navigation,
         navigationId,
@@ -85,8 +88,6 @@ export const onLCP = (
         LCPThresholds,
         opts!.reportAllChanges,
       );
-      // Reset the finalized flag
-      isFinalized = false;
       // If it's a soft nav, then need to reset the visibilityWatcher
       if (navigation === 'soft-navigation') {
         visibilityWatcher = getVisibilityWatcher(true);
@@ -109,7 +110,10 @@ export const onLCP = (
         }
       }
 
-      if (!isFinalized) report(true);
+      if (!isFinalized(metric)) {
+        report(true);
+        markFinalized(metric);
+      }
       initNewLCPMetric(
         'soft-navigation',
         entry.interactionId,
@@ -151,6 +155,7 @@ export const onLCP = (
           handleSoftNavEntry(entry as PerformanceSoftNavigation);
           continue;
         }
+        if (isFinalized(metric)) continue;
 
         let value = 0;
         let entries: LargestContentfulPaint[] = [];
@@ -231,30 +236,39 @@ export const onLCP = (
         opts!.reportAllChanges,
       );
 
+      // Stop listening after input or visibilitychange.
+      // Note: while scrolling is an input that stops LCP observation, it's
+      // unreliable since it can be programmatically generated.
+      // See: https://github.com/GoogleChrome/web-vitals/issues/75
+      const finalizeEventTypes = ['keydown', 'click', 'visibilitychange'];
+
       const finalizeLCP = (event: Event) => {
-        if (event.isTrusted && !isFinalized) {
+        if (event.isTrusted && !isFinalized(metric)) {
+          const metricToFinalize = metric;
+          const reportToFinalize = report;
           // Wrap the listener in an idle callback so it's run in a separate
           // task to reduce potential INP impact.
           // https://github.com/GoogleChrome/web-vitals/issues/383
           whenIdleOrHidden(() => {
-            if (!isFinalized) {
+            if (!isFinalized(metricToFinalize)) {
               handleEntries(po!.takeRecords() as LCPMetric['entries']);
               if (!softNavsEnabled) {
                 po!.disconnect();
-                removeEventListener(event.type, finalizeLCP);
+                for (const type of finalizeEventTypes) {
+                  removeEventListener(type, finalizeLCP, {capture: true});
+                }
               }
-              isFinalized = true;
-              report(true);
+              markFinalized(metricToFinalize);
+              // If a soft navigation in the taken records already reported and
+              // finalized this metric, this forced report is a no-op: the value
+              // is unchanged, so the reporter's delta check skips the callback.
+              reportToFinalize(true);
             }
           });
         }
       };
 
-      // Stop listening after input or visibilitychange.
-      // Note: while scrolling is an input that stops LCP observation, it's
-      // unreliable since it can be programmatically generated.
-      // See: https://github.com/GoogleChrome/web-vitals/issues/75
-      for (const type of ['keydown', 'click', 'visibilitychange']) {
+      for (const type of finalizeEventTypes) {
         addEventListener(type, finalizeLCP, {
           capture: true,
         });
@@ -279,7 +293,7 @@ export const onLCP = (
 
         doubleRAF(() => {
           metric.value = performance.now() - event.timeStamp;
-          isFinalized = true;
+          markFinalized(metric);
           report(true);
         });
       });


### PR DESCRIPTION
This PR addresses three interrelated finalization bugs in `onLCP` when soft navigation support is enabled. Soft navigations require `onLCP` to continue observing performance entries across navigations instead of finalizing once for the lifetime of the page. The previous finalization tracking relied on shared state and incomplete cleanup, causing race conditions and spurious LCP reports.

---

## Detailed Bug Breakdown & Fixes

### 1. Premature Finalization of Soft-Navigation Metrics via Shared State

* **Issue:** An interaction (e.g., user click) triggering a soft navigation could cause the newly initialized soft-navigation metric to be force-reported immediately with value `0` (or an incomplete paint value), preventing subsequent paints for that soft navigation from being finalized.
* **Root Cause:** Finalization was tracked using a single scoped variable (`let isFinalized = false`) shared across all metric instances created during the page lifecycle. When an interaction occurred:
  1. `finalizeLCP` checked `!isFinalized` and scheduled its work asynchronously via `whenIdleOrHidden()`.
  2. Before `whenIdleOrHidden()` executed, a `soft-navigation` entry arrived (either from microtasks or `po.takeRecords()`), invoking `initNewLCPMetric()`.
  3. `initNewLCPMetric()` replaced `metric` and `report` with new objects and reset `isFinalized = false`.
  4. The deferred `whenIdleOrHidden()` callback executed, saw `isFinalized === false`, marked the *new* metric as finalized, and force-reported it before paint entries arrived.
* **Fix:**
  * Replaced the shared boolean with per-metric tracking using a `WeakSet<Metric>` (`finalizedMetrics`) and helper functions `isFinalized(m)` / `markFinalized(m)`.
  * `finalizeLCP` captures the exact `metric` and `report` references (`metricToFinalize` / `reportToFinalize`) active at the moment the interaction event fired.
  * In `handleEntries`, entry processing for already-finalized metric instances is skipped so late-arriving paint entries cannot mutate or re-report finalized metrics.

---

### 2. Failure to Remove Finalize Event Listeners (`removeEventListener` Bug)

* **Issue:** Keydown, click, and visibilitychange event listeners attached for LCP finalization remained registered for the lifetime of the page even after LCP was finalized and the `PerformanceObserver` was disconnected.
* **Root Cause:**
  1. Listeners were registered with `{capture: true}` via `addEventListener(type, finalizeLCP, {capture: true})`.
  2. When removing listeners, `removeEventListener(event.type, finalizeLCP)` was called without the `{capture: true}` option. Per the DOM specification, `removeEventListener` requires matching capture options to remove a listener.
  3. Only `event.type` (the specific event type that fired) was targeted for removal, leaving the other event types registered.
* **Fix:**
  * Defined a shared `finalizeEventTypes` array (`['keydown', 'click', 'visibilitychange']`).
  * When `softNavsEnabled` is `false`, all three event types are unbound specifying `{capture: true}`.

---

### 3. Reporting Spurious `LCP = 0` for Unpainted Metrics

* **Issue:** Soft-navigation or bfcache-restore metrics that received no paint entries could be force-reported with a value of `0` and an empty `entries` array.
* **Root Cause:** `initNewLCPMetric` initialized new metric objects with a default value of `0` (`initMetric('LCP', 0, ...)`). In `bindReporter`, forced reports are guarded by `metric.value >= 0`. Consequently, an unpainted metric initialized to `0` passed the guard and emitted a zero-value LCP report.
* **Fix:** `initNewLCPMetric` now initializes the metric value to `-1` (matching `initMetric`'s default sentinel value), ensuring `bindReporter` suppresses reports for metrics that have not observed a paint.
