### PR TITLE
Clean up soft navigations implementation

### DIFF
--- a/src/attribution/onTTFB.ts
+++ b/src/attribution/onTTFB.ts
@@ -23,7 +23,7 @@ import {
 } from '../types.js';
 
 const attributeTTFB = (metric: TTFBMetric): TTFBMetricWithAttribution => {
-  const navigationEntry = metric?.entries?.[0];
+  const navigationEntry = metric.entries[0];
   // Use a default object if no other attribution has been set.
   let attribution: TTFBAttribution = {
     waitingDuration: 0,

--- a/src/lib/initMetric.ts
+++ b/src/lib/initMetric.ts
@@ -29,8 +29,8 @@ export const initMetric = <MetricName extends MetricType['name']>(
   navigationURL?: string,
   navigationStartTime?: number,
 ) => {
-  const hardNavId = getNavigationEntry()?.navigationId || 0;
   const hardNavEntry = getNavigationEntry();
+  const hardNavId = hardNavEntry?.navigationId || 0;
   let _navigationType: MetricType['navigationType'] = 'navigate';
 
   if (navigationType) {

--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -50,31 +50,29 @@ export const observe = <K extends keyof PerformanceEntryMap>(
         // callback is invoked immediately, rather than in a separate task.
         // See: https://github.com/GoogleChrome/web-vitals/issues/277
         queueMicrotask(() => {
-          // sort entries to ensure they're in the right order
           const entries = list.getEntries();
-          // Best to sort by end time (startTime + duration)
+          // When observing more than one entry type, entries from different
+          // types can be delivered out of order, so sort by end time
+          // (startTime + duration) to ensure they're in the right order.
           // See: https://github.com/w3c/performance-timeline/issues/224
-          entries.sort((a, b) => {
-            const scoreA = a.startTime + a.duration;
-            const scoreB = b.startTime + b.duration;
+          if (supportedTypes.length > 1) {
+            entries.sort((a, b) => {
+              const scoreA = a.startTime + a.duration;
+              const scoreB = b.startTime + b.duration;
 
-            return scoreA - scoreB;
-          });
+              return scoreA - scoreB;
+            });
+          }
           callback(entries as Array<PerformanceEntryMap[K][number]>);
         });
       });
 
       for (const t of supportedTypes) {
-        po.observe(
-          Object.assign(
-            {
-              type: t,
-              buffered: true,
-              ...opts,
-            },
-            opts || {},
-          ) as PerformanceObserverInit,
-        );
+        po.observe({
+          type: t,
+          buffered: true,
+          ...opts,
+        } as PerformanceObserverInit);
       }
       return po;
     }

--- a/src/lib/softNavs.ts
+++ b/src/lib/softNavs.ts
@@ -23,3 +23,21 @@ export const checkSoftNavsEnabled = (opts?: ReportOpts) => {
     opts.reportSoftNavs
   );
 };
+
+// Stores a soft navigation entry keyed by its navigationId, keeping only
+// the 2 most recent entries so the map cannot grow unbounded.
+export const storeSoftNavEntry = (
+  map: Map<number, PerformanceSoftNavigation>,
+  entry: PerformanceSoftNavigation,
+) => {
+  map.set(entry.navigationId!, entry);
+
+  // Clean up older entries to prevent memory leaks, keeping only
+  // the 2 most recent entries.
+  if (map.size > 2) {
+    const firstKey = map.keys().next().value;
+    if (firstKey !== undefined) {
+      map.delete(firstKey);
+    }
+  }
+};

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -15,7 +15,7 @@
  */
 
 import {bindReporter} from './lib/bindReporter.js';
-import {checkSoftNavsEnabled} from './lib/softNavs.js';
+import {checkSoftNavsEnabled, storeSoftNavEntry} from './lib/softNavs.js';
 import {doubleRAF} from './lib/doubleRAF.js';
 import {getActivationStart} from './lib/getActivationStart.js';
 import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
@@ -40,8 +40,6 @@ export const onFCP = (
   onReport: (metric: FCPMetric) => void,
   opts: ReportOpts = {},
 ) => {
-  // Set defaults
-  opts = opts || {};
   const softNavsEnabled = checkSoftNavsEnabled(opts);
 
   whenActivated(() => {
@@ -121,21 +119,7 @@ export const onFCP = (
           // is only used when attribution is enabled which sets the
           // _softNavigationEntryMap.
           if (fcpEntryManager._softNavigationEntryMap && entry.navigationId) {
-            fcpEntryManager._softNavigationEntryMap.set(
-              entry.navigationId,
-              entry,
-            );
-
-            // Clean up older entries to prevent memory leaks, keeping only
-            // the 2 most recent entries.
-            if (fcpEntryManager._softNavigationEntryMap.size > 2) {
-              const firstKey = fcpEntryManager._softNavigationEntryMap
-                .keys()
-                .next().value;
-              if (firstKey !== undefined) {
-                fcpEntryManager._softNavigationEntryMap.delete(firstKey);
-              }
-            }
+            storeSoftNavEntry(fcpEntryManager._softNavigationEntryMap, entry);
           }
 
           // Cap FCP at 0. It should never be less, but better safe than sorry.

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -172,9 +172,9 @@ export const onLCP = (
             continue;
           }
 
-          // The LCP entry is exposed either nested under
-          // `largestContentfulPaint` or directly via `renderTime`, depending
-          // on the implementation, so handle both.
+          // Older implementations expose the render time directly on the entry
+          // rather than nested under `largestContentfulPaint`.
+          // TODO: remove after the origin trial ends.
           const renderTime =
             ICPEntry.largestContentfulPaint?.renderTime ||
             ICPEntry.renderTime ||

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -19,7 +19,7 @@ import {onBFCacheRestore} from './lib/bfcache.js';
 import {bindReporter} from './lib/bindReporter.js';
 import {doubleRAF} from './lib/doubleRAF.js';
 import {getActivationStart} from './lib/getActivationStart.js';
-import {checkSoftNavsEnabled} from './lib/softNavs.js';
+import {checkSoftNavsEnabled, storeSoftNavEntry} from './lib/softNavs.js';
 import {getVisibilityWatcher} from './lib/getVisibilityWatcher.js';
 import {initMetric} from './lib/initMetric.js';
 import {initUnique} from './lib/initUnique.js';
@@ -95,18 +95,7 @@ export const onLCP = (
 
     const handleSoftNavEntry = (entry: PerformanceSoftNavigation) => {
       if (lcpEntryManager._softNavigationEntryMap && entry.navigationId) {
-        lcpEntryManager._softNavigationEntryMap.set(entry.navigationId, entry);
-
-        // Clean up older entries to prevent memory leaks, keeping only
-        // the 2 most recent entries.
-        if (lcpEntryManager._softNavigationEntryMap.size > 2) {
-          const firstKey = lcpEntryManager._softNavigationEntryMap
-            .keys()
-            .next().value;
-          if (firstKey !== undefined) {
-            lcpEntryManager._softNavigationEntryMap.delete(firstKey);
-          }
-        }
+        storeSoftNavEntry(lcpEntryManager._softNavigationEntryMap, entry);
       }
 
       if (!isFinalized) report(true);
@@ -123,8 +112,9 @@ export const onLCP = (
       // (see https://github.com/GoogleChrome/web-vitals/issues/725)
       const largestInteractionContentfulPaint =
         entry.getLargestInteractionContentfulPaint?.() ||
-        // TODO to remove this, after OT ends as this has been replaced
-        // with above function
+        // Older implementations expose the value as an attribute rather
+        // than the method above.
+        // TODO: remove this fallback after the origin trial ends.
         entry.largestInteractionContentfulPaint;
       if (largestInteractionContentfulPaint) {
         handleEntries([largestInteractionContentfulPaint]);
@@ -153,7 +143,7 @@ export const onLCP = (
         }
 
         let value = 0;
-        let entries: LargestContentfulPaint[] = [];
+        let metricEntries: LargestContentfulPaint[] = [];
         if (entry.entryType === 'largest-contentful-paint') {
           // The startTime attribute returns the value of the renderTime if it is
           // not 0, and the value of the loadTime otherwise. The activationStart
@@ -164,7 +154,7 @@ export const onLCP = (
           value = Math.max(entry.startTime - getActivationStart(), 0);
 
           lcpEntryManager._processEntry(entry as LargestContentfulPaint);
-          entries = [entry as LargestContentfulPaint];
+          metricEntries = [entry as LargestContentfulPaint];
         } else if (entry.entryType === 'interaction-contentful-paint') {
           const ICPEntry = entry as InteractionContentfulPaint;
           // InteractionContentfulPaints should only happen after a
@@ -182,8 +172,9 @@ export const onLCP = (
             continue;
           }
 
-          // We're changing the shape to nest LCP entries within
-          // interaction-contentful-paint so handle both for now
+          // The LCP entry is exposed either nested under
+          // `largestContentfulPaint` or directly via `renderTime`, depending
+          // on the implementation, so handle both.
           const renderTime =
             ICPEntry.largestContentfulPaint?.renderTime ||
             ICPEntry.renderTime ||
@@ -194,7 +185,7 @@ export const onLCP = (
 
           if (ICPEntry.largestContentfulPaint) {
             lcpEntryManager._processEntry(ICPEntry.largestContentfulPaint);
-            entries = [ICPEntry.largestContentfulPaint];
+            metricEntries = [ICPEntry.largestContentfulPaint];
           }
         }
 
@@ -207,7 +198,7 @@ export const onLCP = (
           // where `activationStart` occurs after the LCP, this time should be
           // clamped at 0.
           metric.value = value;
-          metric.entries = entries;
+          metric.entries = metricEntries;
           report();
         }
       }

--- a/src/onTTFB.ts
+++ b/src/onTTFB.ts
@@ -61,8 +61,6 @@ export const onTTFB = (
   onReport: (metric: TTFBMetric) => void,
   opts: ReportOpts = {},
 ) => {
-  // Set defaults
-  opts = opts || {};
   const softNavsEnabled = checkSoftNavsEnabled(opts);
 
   let metric = initMetric('TTFB');

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,14 +101,19 @@ declare global {
   interface InteractionContentfulPaint extends PerformanceEntry {
     readonly interactionId: number;
     readonly largestContentfulPaint?: LargestContentfulPaint;
-    readonly renderTime?: DOMHighResTimeStamp; // TODO: remove
+    // Older implementations expose the render time directly on this entry
+    // rather than nested under `largestContentfulPaint`.
+    // TODO: remove after the origin trial ends.
+    readonly renderTime?: DOMHighResTimeStamp;
   }
   interface PerformanceSoftNavigation extends PerformanceEntry {
     readonly interactionId: number;
     readonly navigationType?: NavigationType;
     readonly paintTime?: number;
     readonly presentationTime?: number;
-    // TODO Remove the largestInteractionContentfulPaint when OT ends as moved to function
+    // Older implementations expose this as an attribute rather than via
+    // `getLargestInteractionContentfulPaint()`.
+    // TODO: remove after the origin trial ends.
     readonly largestInteractionContentfulPaint: InteractionContentfulPaint;
     readonly getLargestInteractionContentfulPaint?: () => InteractionContentfulPaint | null;
   }

--- a/test/views/layout.njk
+++ b/test/views/layout.njk
@@ -264,7 +264,7 @@
         }
 
         function doSoftNav() {
-          document.nav = ++document.nav;
+          document.nav++;
           loadPage(document.nav);
         }
 


### PR DESCRIPTION
This PR performs a behavior-preserving cleanup pass across the soft navigations implementation added on the `soft-navs` feature branch, based on code review feedback. It eliminates dead code, extracts redundant map-management logic, resolves variable shadowing, and updates outdated comments.

All changes preserve existing functionality, with one intentional micro-optimization in `src/lib/observe.ts` to skip sorting entries for single-type observers.

## Key Changes

- **`src/lib/observe.ts`**:
  - Replaced redundant `Object.assign({...opts}, opts || {})` in `po.observe()` with a clean object literal `{ type: t, buffered: true, ...opts }`. `opts` already defaults to `{}` in the signature.
  - Gated `entries.sort()` to run only when `supportedTypes.length > 1`. Single-type performance observers already receive entries in chronological order, so skipping sort for single-type observers avoids unnecessary overhead.

- **`src/lib/softNavs.ts`**:
  - Extracted `storeSoftNavEntry(map, entry)` helper to handle inserting soft navigation entries into `_softNavigationEntryMap` and pruning the map size to the 2 most recent entries.

- **`src/onFCP.ts` & `src/onLCP.ts`**:
  - Replaced inline map insertion and pruning blocks with calls to `storeSoftNavEntry()`.
  - Removed dead `opts = opts || {}` reassignments in `src/onFCP.ts` and `src/onTTFB.ts`.

- **`src/attribution/onTTFB.ts` & `src/onTTFB.ts`**:
  - Simplified `metric?.entries?.[0]` to `metric.entries[0]`, as `metric` is guaranteed to be a newly initialized metric object with an `entries` array on this code path.
  - Removed redundant `opts = opts || {}` default check in `src/onTTFB.ts`.

- **`src/onLCP.ts`**:
  - Renamed inner variable `entries` to `metricEntries` inside `handleEntries()` to eliminate shadowing of the outer function parameter `entries`.

- **`src/lib/initMetric.ts`**:
  - Reduced back-to-back duplicate calls of `getNavigationEntry()` down to a single call, storing and reusing `hardNavEntry`.

- **Comments & Test Fixtures (`src/types.ts`, `src/onLCP.ts`, `test/views/layout.njk`)**:
  - Rewrote comments that referenced outdated origin-trial transition state to clearly explain current fallback mechanisms and cleanup prerequisites.
  - Simplified `document.nav = ++document.nav` to `document.nav++` in test template.
