### PR TITLE
Flip default for `includeProcessedEventEntries` to `false` for v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@ In the [attribution build](#attribution-build) each of the metric functions has 
    onLCP(sendToAnalytics, {generateTarget: customGenerateTarget});
    ```
 
-3. The `onINP` `AttributionReportOpts` supports an additional, optional, `includeProcessedEventEntries` configuration option. When set to `false`, the `event` performance entries will not be included in the `attribution` object to conserve memory if these entries are not needed. The default value is `true`.
+3. The `onINP` `AttributionReportOpts` supports an additional, optional, `includeProcessedEventEntries` configuration option. When set to `true`, _all_ the `event` performance entries processed during the INP duration will be included in the `attribution.processedEventEntries` object. This can include a lot of events and increased memory on very interactive or event-heavy pages. The default value is `false`. Regardless of this setting, the `entries` object will include the entries with an `interactionId` (which are the entries relevant for INP), but use this setting to include all entries (whether they have an `interactionId` or not) in `attribution.processedEventEntries` if you need more attribution information to identify delays to INP events.
 
 ```ts
 interface INPAttributionReportOpts extends AttributionReportOpts {
@@ -937,8 +937,8 @@ interface INPAttribution {
   /**
    * An array of Event Timing entries that were processed within the same
    * animation frame as the INP candidate interaction.
-   * This array can be quite large so it will be empty if the
-   * `includeProcessedEventEntries` configuration option is set to `false` to
+   * This array can be quite large so it will be empty unless the
+   * `includeProcessedEventEntries` configuration option is set to `true` to
    * conserve memory if these entries are not required.
    */
   processedEventEntries: PerformanceEventTiming[];

--- a/src/attribution/onINP.ts
+++ b/src/attribution/onINP.ts
@@ -66,7 +66,7 @@ const MAX_PENDING_FRAMES = 10;
  *
  * A custom `includeProcessedEventEntries` configuration option can optionally
  * be passed to control whether the `processedEventEntries` array in the
- * attribution object is populated. The default value is `true`.
+ * attribution object is populated. The default value is `false`.
  *
  * If the `reportAllChanges` configuration option is set to `true`, the
  * `callback` function will be called as soon as the value is initially
@@ -186,7 +186,7 @@ export const onINP = (
         );
         // processedEventEntries can be quite large, so only include them if
         // the user explicitly requests them (default is to include).
-        if (opts.includeProcessedEventEntries !== false) {
+        if (opts.includeProcessedEventEntries) {
           group.entries.push(entry);
         }
 
@@ -203,7 +203,7 @@ export const onINP = (
         renderTime,
         // processedEventEntries can be quite large, so only include them if
         // the user explicitly requests them (default is to include).
-        entries: opts.includeProcessedEventEntries !== false ? [entry] : [],
+        entries: opts.includeProcessedEventEntries ? [entry] : [],
       };
 
       pendingEntriesGroups.push(group);

--- a/src/types/inp.ts
+++ b/src/types/inp.ts
@@ -95,8 +95,8 @@ export interface INPAttribution {
   /**
    * An array of Event Timing entries that were processed within the same
    * animation frame as the INP candidate interaction.
-   * This array can be quite large so it will be empty if the
-   * `includeProcessedEventEntries` configuration option is set to `false` to
+   * This array can be quite large so it will be empty unless the
+   * `includeProcessedEventEntries` configuration option is set to `true` to
    * conserve memory if these entries are not required.
    */
   processedEventEntries: PerformanceEventTiming[];

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -750,6 +750,128 @@ describe('onINP()', async function () {
       assert.equal(inp1.attribution.interactionType, 'pointer');
       assert.equal(inp1.attribution.interactionTime, inp1.entries[0].startTime);
       assert.equal(inp1.attribution.loadState, 'complete');
+
+      // Assert that the reported `nextPaintTime` estimate is not more than 8ms
+      // different from `startTime+duration` in the Event Timing API.
+      assert(
+        inp1.attribution.nextPaintTime -
+          (inp1.entries[0].startTime + inp1.entries[0].duration) <=
+          8,
+      );
+      // Assert that `nextPaintTime` is after processing ends.
+      assert(
+        inp1.attribution.nextPaintTime >=
+          inp1.attribution.interactionTime +
+            (inp1.attribution.inputDelay + inp1.attribution.processingDuration),
+      );
+      // Assert that the INP subpart durations adds up to the total duration
+      // with a tolerance of 1 for rounding error issues
+      assertIsCloseTo(
+        inp1.attribution.nextPaintTime - inp1.attribution.interactionTime,
+        inp1.attribution.inputDelay +
+          inp1.attribution.processingDuration +
+          inp1.attribution.presentationDelay,
+        1,
+      );
+
+      await clearBeacons();
+
+      await stubVisibilityChange('visible');
+      await setBlockingTime('keydown', 300);
+
+      const textarea = await $('#textarea');
+      await textarea.click();
+      await browser.keys(['x']);
+
+      // Ensure the interaction completes.
+      await nextFrame();
+      // Give INP a chance to report
+      await waitUntilIdle();
+
+      await stubVisibilityChange('hidden');
+      await beaconCountIs(1);
+
+      const [inp2] = await getBeacons();
+
+      assert(inp2.value >= 300 - ROUNDING_ERROR);
+      assert(inp2.id.match(/^v5-\d+-\d+$/));
+      assert.strictEqual(inp2.name, 'INP');
+      assert.strictEqual(inp2.value, inp1.value + inp2.delta);
+      assert.strictEqual(inp2.rating, 'needs-improvement');
+      assert(allEntriesPresentTogether(inp2.entries));
+      assert.match(inp2.navigationType, /navigate|reload/);
+
+      assert.equal(inp2.attribution.interactionTarget, '#textarea');
+      assert.equal(inp2.attribution.interactionType, 'keyboard');
+      assert.equal(inp2.attribution.interactionTime, inp2.entries[0].startTime);
+      assert.equal(inp2.attribution.loadState, 'complete');
+
+      // Assert that the reported `nextPaintTime` estimate is not more than 8ms
+      // different from `startTime+duration` in the Event Timing API.
+      assert(
+        inp2.attribution.nextPaintTime -
+          (inp2.entries[0].startTime + inp2.entries[0].duration) <=
+          8,
+      );
+      // Assert that `nextPaintTime` is after processing ends.
+      assert(
+        inp2.attribution.nextPaintTime >=
+          inp2.attribution.interactionTime +
+            (inp2.attribution.inputDelay + inp2.attribution.processingDuration),
+      );
+      // Assert that the INP subpart durations adds up to the total duration.
+      assert.equal(
+        inp2.attribution.nextPaintTime - inp2.attribution.interactionTime,
+        inp2.attribution.inputDelay +
+          inp2.attribution.processingDuration +
+          inp2.attribution.presentationDelay,
+      );
+    });
+
+    it('attribution data matches processedEventEntries', async function () {
+      if (!browserSupportsINP) this.skip();
+
+      await navigateTo(
+        '/test/inp?click=100&attribution=1&includeProcessedEventEntries=true',
+        {
+          readyState: 'complete',
+        },
+      );
+
+      // Wait until the library is loaded and the first paint occurs to ensure
+      // The 40ms event duration is set
+      await webVitalsLoaded();
+      await firstContentfulPaint();
+
+      const h1 = await $('h1');
+      await simulateUserLikeClick(h1);
+
+      // Ensure the interaction completes.
+      await nextFrame();
+      // Give INP a chance to report
+      await waitUntilIdle();
+
+      await stubVisibilityChange('hidden');
+
+      await beaconCountIs(1);
+
+      const [inp1] = await getBeacons();
+
+      assert(inp1.value >= 100 - ROUNDING_ERROR);
+      assert(inp1.id.match(/^v5-\d+-\d+$/));
+      assert.strictEqual(inp1.name, 'INP');
+      assert.strictEqual(inp1.value, inp1.delta);
+      assert.strictEqual(inp1.rating, 'good');
+      assert(
+        containsEntry(inp1.entries, 'click', '[object HTMLHeadingElement]'),
+      );
+      assert(allEntriesPresentTogether(inp1.entries));
+      assert.match(inp1.navigationType, /navigate|reload/);
+
+      assert.equal(inp1.attribution.interactionTarget, 'html>body>main>h1');
+      assert.equal(inp1.attribution.interactionType, 'pointer');
+      assert.equal(inp1.attribution.interactionTime, inp1.entries[0].startTime);
+      assert.equal(inp1.attribution.loadState, 'complete');
       assert(allEntriesPresentTogether(inp1.attribution.processedEventEntries));
 
       // Assert that the reported `nextPaintTime` estimate is not more than 8ms
@@ -899,6 +1021,35 @@ describe('onINP()', async function () {
           readyState: 'complete',
         },
       );
+
+      const h1 = await $('h1');
+      await simulateUserLikeClick(h1);
+
+      // Ensure the interaction completes.
+      await nextFrame();
+      // Give INP a chance to report
+      await waitUntilIdle();
+
+      await stubVisibilityChange('hidden');
+
+      await beaconCountIs(1);
+
+      const [inp] = await getBeacons();
+
+      assert(inp.value >= 0);
+      assert(inp.id.match(/^v5-\d+-\d+$/));
+      assert.strictEqual(inp.name, 'INP');
+      assert.strictEqual(inp.value, inp.delta);
+      assert(allEntriesPresentTogether(inp.entries));
+      assert.equal(inp.attribution.processedEventEntries.length, 0);
+    });
+
+    it('processedEventEntries is disabled by default', async function () {
+      if (!browserSupportsINP) this.skip();
+
+      await navigateTo('/test/inp?click=100&attribution=1', {
+        readyState: 'complete',
+      });
 
       const h1 = await $('h1');
       await simulateUserLikeClick(h1);


### PR DESCRIPTION
In #714 we added a `includeProcessedEventEntries` (defaulting to `true`) to allow switching off of this potentially large object.

We do not think this is used by many (we only use this for debugging ourselves!) but didn't want to default this to `false` in v5 as that was a breaking change.

Now we're planning on launching a major version (v6) to include the soft navs support, we can flip the default as a breaking change. This will reduce the library's memory and the INP attribution object's size for all users not using this?