### PR TITLE
Update tests to remove unneeded overrides and resolve flakiness

### DIFF
--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -96,10 +96,7 @@ describe('onINP()', async function () {
     assert(inp.id.match(/^v5-\d+-\d+$/));
     assert.strictEqual(inp.name, 'INP');
     assert.strictEqual(inp.value, inp.delta);
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    if (browser.capabilities.browserName !== 'Safari') {
-      assert.strictEqual(inp.rating, 'good');
-    }
+    assert.strictEqual(inp.rating, 'good');
     assert(containsEntry(inp.entries, 'click', '[object HTMLHeadingElement]'));
     assert(allEntriesPresentTogether(inp.entries));
     assert.match(inp.navigationType, /navigate|reload/);
@@ -125,12 +122,7 @@ describe('onINP()', async function () {
     // Give INP a chance to report
     await waitUntilIdle();
 
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
-    }
+    await browser.pause(1000);
 
     await stubVisibilityChange('hidden');
 
@@ -141,10 +133,7 @@ describe('onINP()', async function () {
     assert(inp.id.match(/^v5-\d+-\d+$/));
     assert.strictEqual(inp.name, 'INP');
     assert.strictEqual(inp.value, inp.delta);
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    if (browser.capabilities.browserName !== 'Safari') {
-      assert.strictEqual(inp.rating, 'good');
-    }
+    assert.strictEqual(inp.rating, 'good');
     assert(containsEntry(inp.entries, 'click', '[object HTMLHeadingElement]'));
     assert(allEntriesPresentTogether(inp.entries));
     assert.match(inp.navigationType, /navigate|reload/);
@@ -167,10 +156,7 @@ describe('onINP()', async function () {
     assert(inp.id.match(/^v5-\d+-\d+$/));
     assert.strictEqual(inp.name, 'INP');
     assert.strictEqual(inp.value, inp.delta);
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    if (browser.capabilities.browserName !== 'Safari') {
-      assert.strictEqual(inp.rating, 'good');
-    }
+    assert.strictEqual(inp.rating, 'good');
     assert(containsEntry(inp.entries, 'click', '[object HTMLHeadingElement]'));
     assert(allEntriesPresentTogether(inp.entries));
     assert.match(inp.navigationType, /navigate|reload/);
@@ -184,13 +170,6 @@ describe('onINP()', async function () {
     const h1 = await $('h1');
     await simulateUserLikeClick(h1);
 
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
-    }
-
     await navigateTo('about:blank', {readyState: 'interactive'});
 
     await beaconCountIs(1);
@@ -200,10 +179,7 @@ describe('onINP()', async function () {
     assert(inp.id.match(/^v5-\d+-\d+$/));
     assert.strictEqual(inp.name, 'INP');
     assert.strictEqual(inp.value, inp.delta);
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    if (browser.capabilities.browserName !== 'Safari') {
-      assert.strictEqual(inp.rating, 'good');
-    }
+    assert.strictEqual(inp.rating, 'good');
     assert(containsEntry(inp.entries, 'click', '[object HTMLHeadingElement]'));
     assert(allEntriesPresentTogether(inp.entries));
     assert.match(inp.navigationType, /navigate|reload/);
@@ -219,13 +195,6 @@ describe('onINP()', async function () {
     const h1 = await $('h1');
     await simulateUserLikeClick(h1);
 
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
-    }
-
     await navigateTo('about:blank');
 
     await beaconCountIs(1);
@@ -235,10 +204,7 @@ describe('onINP()', async function () {
     assert(inp.id.match(/^v5-\d+-\d+$/));
     assert.strictEqual(inp.name, 'INP');
     assert.strictEqual(inp.value, inp.delta);
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    if (browser.capabilities.browserName !== 'Safari') {
-      assert.strictEqual(inp.rating, 'good');
-    }
+    assert.strictEqual(inp.rating, 'good');
     assert(containsEntry(inp.entries, 'click', '[object HTMLHeadingElement]'));
     assert(allEntriesPresentTogether(inp.entries));
     assert.match(inp.navigationType, /navigate|reload/);
@@ -267,13 +233,6 @@ describe('onINP()', async function () {
     // Give INP a chance to report
     await waitUntilIdle();
 
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
-    }
-
     await stubVisibilityChange('hidden');
     await beaconCountIs(1);
 
@@ -296,13 +255,6 @@ describe('onINP()', async function () {
     // Give INP a chance to report
     await waitUntilIdle();
 
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
-    }
-
     await stubVisibilityChange('hidden');
     await beaconCountIs(1);
 
@@ -324,13 +276,6 @@ describe('onINP()', async function () {
 
     // Give INP a chance to report
     await waitUntilIdle();
-
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
-    }
 
     await stubVisibilityChange('hidden');
     await beaconCountIs(1);
@@ -366,13 +311,6 @@ describe('onINP()', async function () {
       count++;
       // Ensure the interaction completes.
       await nextFrame();
-    }
-
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
     }
 
     await beaconCountIs(3);
@@ -436,13 +374,6 @@ describe('onINP()', async function () {
     // Give INP a chance to report
     await waitUntilIdle();
 
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
-    }
-
     await stubForwardBack();
     await beaconCountIs(1);
 
@@ -454,12 +385,9 @@ describe('onINP()', async function () {
     assert.strictEqual(inp2.name, 'INP');
     assert.strictEqual(inp2.value, inp2.delta);
     assert.strictEqual(inp2.rating, 'good');
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    if (browser.capabilities.browserName === 'Safari') {
-      assert(
-        containsEntry(inp2.entries, 'keydown', '[object HTMLTextAreaElement]'),
-      );
-    }
+    assert(
+      containsEntry(inp2.entries, 'keydown', '[object HTMLTextAreaElement]'),
+    );
     assert(allEntriesPresentTogether(inp1.entries));
     assert(inp2.entries[0].startTime > inp1.entries[0].startTime);
     assert.strictEqual(inp2.navigationType, 'back-forward-cache');
@@ -477,13 +405,6 @@ describe('onINP()', async function () {
     // Give INP a chance to report
     await waitUntilIdle();
 
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
-    }
-
     await stubVisibilityChange('hidden');
     await beaconCountIs(1);
 
@@ -493,19 +414,12 @@ describe('onINP()', async function () {
     assert(inp1.id !== inp3.id);
     assert.strictEqual(inp3.name, 'INP');
     assert.strictEqual(inp3.value, inp3.delta);
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    if (browser.capabilities.browserName !== 'Safari') {
-      assert.strictEqual(inp3.rating, 'needs-improvement');
-      assert(
-        containsEntry(
-          inp3.entries,
-          'pointerdown',
-          '[object HTMLButtonElement]',
-        ),
-      );
-      assert(allEntriesPresentTogether(inp3.entries));
-      assert(inp3.entries[0].startTime > inp2.entries[0].startTime);
-    }
+    assert.strictEqual(inp3.rating, 'needs-improvement');
+    assert(
+      containsEntry(inp3.entries, 'pointerdown', '[object HTMLButtonElement]'),
+    );
+    assert(allEntriesPresentTogether(inp3.entries));
+    assert(inp3.entries[0].startTime > inp2.entries[0].startTime);
     assert.strictEqual(inp3.navigationType, 'back-forward-cache');
   });
 
@@ -583,13 +497,6 @@ describe('onINP()', async function () {
     // Give INP a chance to report
     await waitUntilIdle();
 
-    // Safari doesn't emit an entry immediately when no paint
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    // So need to give it a moment to make sure the entry was emitted.
-    if (browser.capabilities.browserName === 'Safari') {
-      await browser.pause(1000);
-    }
-
     await stubVisibilityChange('hidden');
 
     await beaconCountIs(1);
@@ -644,17 +551,10 @@ describe('onINP()', async function () {
     assert.strictEqual(inp2_2.name, 'INP');
     assert.strictEqual(inp2_2.value, inp2_2.delta + inp2_1.delta);
     assert.strictEqual(inp2_2.delta, inp2_2.value - inp2_1.delta);
-    // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-    if (browser.capabilities.browserName !== 'Safari') {
-      assert.strictEqual(inp2_2.rating, 'needs-improvement');
-      assert(
-        containsEntry(
-          inp2_2.entries,
-          'keydown',
-          '[object HTMLTextAreaElement]',
-        ),
-      );
-    }
+    assert.strictEqual(inp2_2.rating, 'needs-improvement');
+    assert(
+      containsEntry(inp2_2.entries, 'keydown', '[object HTMLTextAreaElement]'),
+    );
     assert(allEntriesValid(inp2_2.entries));
     assert.match(inp2_2.navigationType, /navigate|reload/);
 
@@ -1038,10 +938,7 @@ describe('onINP()', async function () {
       assert(inp1.id.match(/^v5-\d+-\d+$/));
       assert.strictEqual(inp1.name, 'INP');
       assert.strictEqual(inp1.value, inp1.delta);
-      // See Safari bug - https://bugs.webkit.org/show_bug.cgi?id=305251
-      if (browser.capabilities.browserName !== 'Safari') {
-        assert.strictEqual(inp1.rating, 'good');
-      }
+      assert.strictEqual(inp1.rating, 'good');
       assert(
         containsEntry(inp1.entries, 'click', '[object HTMLHeadingElement]'),
       );
@@ -1102,8 +999,6 @@ describe('onINP()', async function () {
       assert.equal(inp2.attribution.loadState, 'loading');
     });
 
-    // TODO: remove this test once the following bug is fixed:
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=1367329
     it('reports the interaction target from any entry where target is defined', async function () {
       if (!browserSupportsINP) this.skip();
 

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -30,7 +30,7 @@ const ROUNDING_ERROR = 8;
 
 describe('onINP()', async function () {
   // Retry all tests in this suite up to 2 times.
-  this.retries(2);
+  this.retries(0);
 
   let browserSupportsINP;
   let browserSupportsLoAF;
@@ -383,6 +383,7 @@ describe('onINP()', async function () {
     assert.strictEqual(inp2.name, 'INP');
     assert.strictEqual(inp2.value, inp2.delta);
     assert.strictEqual(inp2.rating, 'good');
+    console.log(inp2.entries);
     assert(
       containsEntry(inp2.entries, 'keydown', '[object HTMLTextAreaElement]'),
     );

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -30,7 +30,7 @@ const ROUNDING_ERROR = 8;
 
 describe('onINP()', async function () {
   // Retry all tests in this suite up to 2 times.
-  this.retries(0);
+  this.retries(2);
 
   let browserSupportsINP;
   let browserSupportsLoAF;
@@ -365,6 +365,11 @@ describe('onINP()', async function () {
     const textarea = await $('#textarea');
     await textarea.click();
 
+    // Ensure the button click is not in same frame
+    // as the next key presses.
+    await nextFrame();
+    await waitUntilIdle();
+
     await browser.keys(['a', 'b', 'c']);
 
     // Ensure the interaction completes.
@@ -383,15 +388,16 @@ describe('onINP()', async function () {
     assert.strictEqual(inp2.name, 'INP');
     assert.strictEqual(inp2.value, inp2.delta);
     assert.strictEqual(inp2.rating, 'good');
-    console.log(inp2.entries);
-    assert(
-      containsEntry(inp2.entries, 'keydown', '[object HTMLTextAreaElement]'),
-    );
+    // Entry name can be keydown or keyup or keypress depending which frame
+    // is processed to just use key (the containsEntry does an `includes` so
+    // supports this).
+    assert(containsEntry(inp2.entries, 'key', '[object HTMLTextAreaElement]'));
     assert(allEntriesPresentTogether(inp1.entries));
     assert(inp2.entries[0].startTime > inp1.entries[0].startTime);
     assert.strictEqual(inp2.navigationType, 'back-forward-cache');
 
     await stubForwardBack();
+    await clearBeacons();
 
     await setBlockingTime('keydown', 0);
     await setBlockingTime('pointerdown', 300);
@@ -551,8 +557,11 @@ describe('onINP()', async function () {
     assert.strictEqual(inp2_2.value, inp2_2.delta + inp2_1.delta);
     assert.strictEqual(inp2_2.delta, inp2_2.value - inp2_1.delta);
     assert.strictEqual(inp2_2.rating, 'needs-improvement');
+    // Entry name can be keydown or keyup or keypress depending which frame
+    // is processed to just use key (the containsEntry does an `includes` so
+    // supports this).
     assert(
-      containsEntry(inp2_2.entries, 'keydown', '[object HTMLTextAreaElement]'),
+      containsEntry(inp2_2.entries, 'key', '[object HTMLTextAreaElement]'),
     );
     assert(allEntriesValid(inp2_2.entries));
     assert.match(inp2_2.navigationType, /navigate|reload/);
@@ -709,6 +718,12 @@ describe('onINP()', async function () {
 
       const textarea = await $('#textarea');
       await textarea.click();
+
+      // Ensure the button click is not in same frame
+      // as the next key presses.
+      await nextFrame();
+      await waitUntilIdle();
+
       await browser.keys(['x']);
 
       // Ensure the interaction completes.
@@ -734,10 +749,13 @@ describe('onINP()', async function () {
       assert.equal(inp2.attribution.interactionTime, inp2.entries[0].startTime);
       assert.equal(inp2.attribution.loadState, 'complete');
       assert(allEntriesPresentTogether(inp2.attribution.processedEventEntries));
+      // Entry name can be keydown or keyup or keypress depending which frame
+      // is processed to just use key (the containsEntry does an `includes` so
+      // supports this).
       assert(
         containsEntry(
           inp2.attribution.processedEventEntries,
-          'keydown',
+          'key',
           '[object HTMLTextAreaElement]',
         ),
       );
@@ -1107,7 +1125,9 @@ describe('onINP()', async function () {
 });
 
 const containsEntry = (entries, name, target) => {
-  return entries.findIndex((e) => e.name === name && e.target === target) > -1;
+  return (
+    entries.findIndex((e) => e.name.includes(name) && e.target === target) > -1
+  );
 };
 
 const allEntriesValid = (entries) => {

--- a/test/e2e/onINP-test.js
+++ b/test/e2e/onINP-test.js
@@ -122,8 +122,6 @@ describe('onINP()', async function () {
     // Give INP a chance to report
     await waitUntilIdle();
 
-    await browser.pause(1000);
-
     await stubVisibilityChange('hidden');
 
     await beaconCountIs(1);

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -128,48 +128,32 @@ describe('onLCP()', async function () {
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
 
-    // Safari has an LCP buffer bug - https://bugs.webkit.org/show_bug.cgi?id=305256
-    if (browser.capabilities.browserName !== 'Safari') {
-      await beaconCountIs(2);
-      const beacons = await getBeacons();
-      // Firefox sometimes sends <p>, then <h1>
-      // so grab last two
-      await browser.pause(500);
+    await beaconCountIs(2);
+    const beacons = await getBeacons();
+    // Firefox sometimes sends <p>, then <h1>
+    // so grab last two
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1977827
+    await browser.pause(500);
 
-      assert(beacons.length >= 2);
-      const lcp1 = beacons.at(-2);
-      const lcp2 = beacons.at(-1);
+    assert(beacons.length >= 2);
+    const lcp1 = beacons.at(-2);
+    const lcp2 = beacons.at(-1);
 
-      assert(lcp1.value > 0);
-      assert(lcp1.id.match(/^v5-\d+-\d+$/));
-      assert.strictEqual(lcp1.name, 'LCP');
-      assert.strictEqual(lcp1.value, lcp1.delta);
-      assert.strictEqual(lcp1.rating, 'good');
-      assert.strictEqual(lcp1.entries.length, 1);
-      assert.strictEqual(lcp1.navigationType, 'navigate');
+    assert(lcp1.value > 0);
+    assert(lcp1.id.match(/^v5-\d+-\d+$/));
+    assert.strictEqual(lcp1.name, 'LCP');
+    assert.strictEqual(lcp1.value, lcp1.delta);
+    assert.strictEqual(lcp1.rating, 'good');
+    assert.strictEqual(lcp1.entries.length, 1);
+    assert.strictEqual(lcp1.navigationType, 'navigate');
 
-      assert(lcp2.value > 500); // Greater than the image load delay.
-      assert(lcp2.id.match(/^v5-\d+-\d+$/));
-      assert.strictEqual(lcp2.name, 'LCP');
-      assert(lcp2.value > lcp2.delta);
-      assert.strictEqual(lcp2.rating, 'good');
-      assert.strictEqual(lcp2.entries.length, 1);
-      assert.strictEqual(lcp2.navigationType, 'navigate');
-    } else {
-      await beaconCountIs(1);
-      const beacons = await getBeacons();
-
-      assert(beacons.length >= 1);
-      const lcp2 = beacons.at(-1);
-
-      assert(lcp2.value > 500); // Greater than the image load delay.
-      assert(lcp2.id.match(/^v5-\d+-\d+$/));
-      assert.strictEqual(lcp2.name, 'LCP');
-      // assert(lcp2.value > lcp2.delta);
-      assert.strictEqual(lcp2.rating, 'good');
-      assert.strictEqual(lcp2.entries.length, 1);
-      assert.strictEqual(lcp2.navigationType, 'navigate');
-    }
+    assert(lcp2.value > 500); // Greater than the image load delay.
+    assert(lcp2.id.match(/^v5-\d+-\d+$/));
+    assert.strictEqual(lcp2.name, 'LCP');
+    assert(lcp2.value > lcp2.delta);
+    assert.strictEqual(lcp2.rating, 'good');
+    assert.strictEqual(lcp2.entries.length, 1);
+    assert.strictEqual(lcp2.navigationType, 'navigate');
   });
 
   it('accounts for time prerendering the page', async function () {
@@ -434,6 +418,7 @@ describe('onLCP()', async function () {
 
     await beaconCountIs(1);
     // Firefox sometimes sends a <p> and then <h1> beacon, so grab last one
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1977827
     await browser.pause(1000);
     let beacons = await getBeacons();
     const lcp = beacons.at(-1);
@@ -725,9 +710,6 @@ describe('onLCP()', async function () {
     it('handles image resources with incomplete timing data', async function () {
       if (!browserSupportsLCP) this.skip();
 
-      // TODO - this whole test is flakey in Safari. Need to find out why.
-      if (browser.capabilities.browserName === 'Safari') this.skip();
-
       await navigateTo('/test/lcp?attribution=1');
 
       // Wait until all images are loaded and fully rendered.
@@ -995,6 +977,7 @@ const assertStandardReportsAreCorrect = (beacons) => {
 const assertFullReportsAreCorrect = (beacons) => {
   // Firefox sometimes sends <p>, then <h1>
   // so grab last two
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1977827
   assert(beacons.length >= 2);
   const lcp1 = beacons.at(-2);
   const lcp2 = beacons.at(-1);

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -128,32 +128,47 @@ describe('onLCP()', async function () {
     // Wait until all images are loaded and fully rendered.
     await imagesPainted();
 
-    await beaconCountIs(2);
-    const beacons = await getBeacons();
-    // Firefox sometimes sends <p>, then <h1>
-    // so grab last two
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1977827
-    await browser.pause(500);
+    // Safari has an LCP buffer bug - https://bugs.webkit.org/show_bug.cgi?id=305256
+    if (browser.capabilities.browserName !== 'Safari') {
+      await beaconCountIs(2);
+      const beacons = await getBeacons();
+      // Firefox sometimes sends <p>, then <h1>
+      // so grab last two
+      await browser.pause(500);
 
-    assert(beacons.length >= 2);
-    const lcp1 = beacons.at(-2);
-    const lcp2 = beacons.at(-1);
+      assert(beacons.length >= 2);
+      const lcp1 = beacons.at(-2);
+      const lcp2 = beacons.at(-1);
 
-    assert(lcp1.value > 0);
-    assert(lcp1.id.match(/^v5-\d+-\d+$/));
-    assert.strictEqual(lcp1.name, 'LCP');
-    assert.strictEqual(lcp1.value, lcp1.delta);
-    assert.strictEqual(lcp1.rating, 'good');
-    assert.strictEqual(lcp1.entries.length, 1);
-    assert.strictEqual(lcp1.navigationType, 'navigate');
+      assert(lcp1.value > 0);
+      assert(lcp1.id.match(/^v5-\d+-\d+$/));
+      assert.strictEqual(lcp1.name, 'LCP');
+      assert.strictEqual(lcp1.value, lcp1.delta);
+      assert.strictEqual(lcp1.rating, 'good');
+      assert.strictEqual(lcp1.entries.length, 1);
+      assert.strictEqual(lcp1.navigationType, 'navigate');
 
-    assert(lcp2.value > 500); // Greater than the image load delay.
-    assert(lcp2.id.match(/^v5-\d+-\d+$/));
-    assert.strictEqual(lcp2.name, 'LCP');
-    assert(lcp2.value > lcp2.delta);
-    assert.strictEqual(lcp2.rating, 'good');
-    assert.strictEqual(lcp2.entries.length, 1);
-    assert.strictEqual(lcp2.navigationType, 'navigate');
+      assert(lcp2.value > 500); // Greater than the image load delay.
+      assert(lcp2.id.match(/^v5-\d+-\d+$/));
+      assert.strictEqual(lcp2.name, 'LCP');
+      assert(lcp2.value > lcp2.delta);
+      assert.strictEqual(lcp2.rating, 'good');
+      assert.strictEqual(lcp2.entries.length, 1);
+      assert.strictEqual(lcp2.navigationType, 'navigate');
+    } else {
+      await beaconCountIs(1);
+      const beacons = await getBeacons();
+
+      assert(beacons.length >= 1);
+      const lcp2 = beacons.at(-1);
+      assert(lcp2.value > 500); // Greater than the image load delay.
+      assert(lcp2.id.match(/^v5-\d+-\d+$/));
+      assert.strictEqual(lcp2.name, 'LCP');
+      // assert(lcp2.value > lcp2.delta);
+      assert.strictEqual(lcp2.rating, 'good');
+      assert.strictEqual(lcp2.entries.length, 1);
+      assert.strictEqual(lcp2.navigationType, 'navigate');
+    }
   });
 
   it('accounts for time prerendering the page', async function () {

--- a/test/e2e/onLCP-test.js
+++ b/test/e2e/onLCP-test.js
@@ -161,6 +161,7 @@ describe('onLCP()', async function () {
 
       assert(beacons.length >= 1);
       const lcp2 = beacons.at(-1);
+
       assert(lcp2.value > 500); // Greater than the image load delay.
       assert(lcp2.id.match(/^v5-\d+-\d+$/));
       assert.strictEqual(lcp2.name, 'LCP');

--- a/test/e2e/onTTFB-test.js
+++ b/test/e2e/onTTFB-test.js
@@ -65,7 +65,6 @@ describe('onTTFB()', async function () {
     });
   });
   beforeEach(async function () {
-    await navigateTo('about:blank');
     await clearBeacons();
   });
 

--- a/test/e2e/onTTFB-test.js
+++ b/test/e2e/onTTFB-test.js
@@ -65,11 +65,7 @@ describe('onTTFB()', async function () {
     });
   });
   beforeEach(async function () {
-    // In Safari when navigating to 'about:blank' between tests the
-    // Navigation Timing data is consistently negative, so the tests fail.
-    if (browser.capabilities.browserName !== 'Safari') {
-      await navigateTo('about:blank');
-    }
+    await navigateTo('about:blank');
     await clearBeacons();
   });
 


### PR DESCRIPTION
Some of the overrides aren't needed anymore.

Also resolves some flakiness where different events can be merged into the same frame depending on browser heurisitics.
- `keydown` can be reported as `keyup` or `keypress` if `keydown` and `keyup` are in same frame. Be happy with any of these.
- Button clicks and immediate keypresses can result in button press in same frame. Add an explicit frame await.