### PR TITLE
Fix type exports

### DIFF
--- a/src/attribution/index.ts
+++ b/src/attribution/index.ts
@@ -26,4 +26,4 @@ export {INPThresholds} from '../onINP.js';
 export {LCPThresholds} from '../onLCP.js';
 export {TTFBThresholds} from '../onTTFB.js';
 
-export type * from '../types.js';
+export * from '../types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,4 @@ export {onINP, INPThresholds} from './onINP.js';
 export {onLCP, LCPThresholds} from './onLCP.js';
 export {onTTFB, TTFBThresholds} from './onTTFB.js';
 
-export type * from './types.js';
+export * from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-export type * from './types/base.js';
+export * from './types/base.js';
 
-export type * from './types/cls.js';
-export type * from './types/fcp.js';
-export type * from './types/inp.js';
-export type * from './types/lcp.js';
-export type * from './types/ttfb.js';
+export * from './types/cls.js';
+export * from './types/fcp.js';
+export * from './types/inp.js';
+export * from './types/lcp.js';
+export * from './types/ttfb.js';
 
 // --------------------------------------------------------------------------
 // Everything below is modifications to built-in modules.


### PR DESCRIPTION
Slight tweak to #741 to fix some internal build dependency failures.

This should functionally be the same and still enforce type import/exports since the underlying types are the same, but it fixes some build errors that struggle with the nested type imports.

FYI: @isker 