### PR TITLE
refactor: remove unnecessary non-null assertions

### DIFF
--- a/src/onCLS.ts
+++ b/src/onCLS.ts
@@ -91,7 +91,7 @@ export const onCLS = (
           onReport,
           metric,
           CLSThresholds,
-          opts!.reportAllChanges,
+          opts.reportAllChanges,
         );
       };
 
@@ -136,7 +136,7 @@ export const onCLS = (
           onReport,
           metric,
           CLSThresholds,
-          opts!.reportAllChanges,
+          opts.reportAllChanges,
         );
 
         visibilityWatcher.onHidden(() => {

--- a/src/onFCP.ts
+++ b/src/onFCP.ts
@@ -79,7 +79,7 @@ export const onFCP = (
         onReport,
         metric,
         FCPThresholds,
-        opts!.reportAllChanges,
+        opts.reportAllChanges,
       );
 
       // Only report after a bfcache restore if the `PerformanceObserver`
@@ -98,7 +98,7 @@ export const onFCP = (
           onReport,
           metric,
           FCPThresholds,
-          opts!.reportAllChanges,
+          opts.reportAllChanges,
         );
 
         doubleRAF(() => {
@@ -140,7 +140,7 @@ export const onFCP = (
             onReport,
             metric,
             FCPThresholds,
-            opts!.reportAllChanges,
+            opts.reportAllChanges,
           );
           report(true);
         });

--- a/src/onINP.ts
+++ b/src/onINP.ts
@@ -119,7 +119,7 @@ export const onINP = (
         onReport,
         metric,
         INPThresholds,
-        opts!.reportAllChanges,
+        opts.reportAllChanges,
       );
     };
 

--- a/src/onLCP.ts
+++ b/src/onLCP.ts
@@ -83,7 +83,7 @@ export const onLCP = (
         onReport,
         metric,
         LCPThresholds,
-        opts!.reportAllChanges,
+        opts.reportAllChanges,
       );
       // Reset the finalized flag
       isFinalized = false;
@@ -130,7 +130,7 @@ export const onLCP = (
     ) => {
       // If reportAllChanges is set or soft navs is enabled then call this
       // function for each entry, otherwise only consider the last one.
-      if (!opts!.reportAllChanges && !softNavsEnabled) {
+      if (!opts.reportAllChanges && !softNavsEnabled) {
         entries = entries.slice(-1);
       }
 
@@ -214,7 +214,7 @@ export const onLCP = (
         onReport,
         metric,
         LCPThresholds,
-        opts!.reportAllChanges,
+        opts.reportAllChanges,
       );
 
       const finalizeEventTypes = ['keydown', 'click', 'visibilitychange'];
@@ -272,7 +272,7 @@ export const onLCP = (
           onReport,
           metric,
           LCPThresholds,
-          opts!.reportAllChanges,
+          opts.reportAllChanges,
         );
 
         doubleRAF(() => {

--- a/src/onTTFB.ts
+++ b/src/onTTFB.ts
@@ -100,7 +100,7 @@ export const onTTFB = (
           onReport,
           metric,
           TTFBThresholds,
-          opts!.reportAllChanges,
+          opts.reportAllChanges,
         );
 
         report(true);
@@ -125,7 +125,7 @@ export const onTTFB = (
                 onReport,
                 metric,
                 TTFBThresholds,
-                opts!.reportAllChanges,
+                opts.reportAllChanges,
               );
               report(true);
             }


### PR DESCRIPTION
This PR removes unnecessary non-null assertions for readabiliy and type clarity

Since each function defaults `opts` to `{}`, `opts` is always defined inside the function body. using `opts!.reportAllChanges` suggests there may be nullable value that needs to be asserted (which is not)