### PR TITLE
Prevent JavaScript error if PerformanceObserver not available

### DIFF
--- a/src/lib/softNavs.ts
+++ b/src/lib/softNavs.ts
@@ -18,6 +18,7 @@ import type {ReportOpts} from '../types.js';
 
 export const checkSoftNavsEnabled = (opts?: ReportOpts) => {
   return (
+    'PerformanceObserver' in window &&
     PerformanceObserver.supportedEntryTypes.includes('soft-navigation') &&
     // Older implementations expose the value as an attribute rather than the
     // method. We only support the newer method as that was what was launched

--- a/src/lib/softNavs.ts
+++ b/src/lib/softNavs.ts
@@ -19,7 +19,9 @@ import type {ReportOpts} from '../types.js';
 export const checkSoftNavsEnabled = (opts?: ReportOpts) => {
   return (
     // Firefox has a preference to disable this, which some people use so add a guard
-    globalThis.PerformanceObserver?.supportedEntryTypes.includes('soft-navigation') &&
+    globalThis.PerformanceObserver?.supportedEntryTypes.includes(
+      'soft-navigation',
+    ) &&
     // Older implementations expose the value as an attribute rather than the
     // method. We only support the newer method as that was what was launched
     // to stable unflagged.

--- a/src/lib/softNavs.ts
+++ b/src/lib/softNavs.ts
@@ -18,8 +18,8 @@ import type {ReportOpts} from '../types.js';
 
 export const checkSoftNavsEnabled = (opts?: ReportOpts) => {
   return (
-    'PerformanceObserver' in window &&
-    PerformanceObserver.supportedEntryTypes.includes('soft-navigation') &&
+    // Firefox has a preference to disable this, which some people use so add a guard
+    globalThis.PerformanceObserver?.supportedEntryTypes.includes('soft-navigation') &&
     // Older implementations expose the value as an attribute rather than the
     // method. We only support the newer method as that was what was launched
     // to stable unflagged.


### PR DESCRIPTION
Some Firefox users seem to disable the PerformanceObserver API which causes JavaScript errors: "ReferenceError: PerformanceObserver is not defined"